### PR TITLE
Standard db env vars

### DIFF
--- a/testflinger.conf.example
+++ b/testflinger.conf.example
@@ -1,9 +1,7 @@
-# Normally, defaults will be sufficient and a config file is not
-# necessary. However, if you wish to use a different server for
-# redis, or store the data at an alternate location, these values
-# should be changed
-
-# DATA_PATH = '/path/to/my/data/location'
-# REDIS_HOST = 'localhost'
-# REDIS_PORT = '6379'
-# SENTRY_DSN = 'optional sentry server dsn'
+# These values can be used in place of environment variables to configure
+# Testflinger. If MONGO_URI is not specified, then it will be built using the
+# other values specified
+# MONGODB_USERNAME=testflinger
+# MONGODB_PASSWORD=testflinger
+# MONGODB_DATABASE=testflinger_db
+# MONGO_URI = "mongodb://mongo:27017/testflinger_db"

--- a/testflinger/__init__.py
+++ b/testflinger/__init__.py
@@ -56,7 +56,7 @@ def create_flask_app():
     tf_app.config.from_pyfile(config_file, silent=True)
 
     # Finally, override config data with env vars
-    tf_app.config.from_prefixed_env("MONGO_")
+    tf_app.config.from_prefixed_env("MONGO")
 
     setup_mongodb(tf_app)
 
@@ -153,9 +153,9 @@ def setup_mongodb(application):
     Setup mongodb connection if we have valid config data
     Otherwise leave it empty, which means we are probably running unit tests
     """
-    mongo_user = os.environ.get("MONGO_USER")
-    mongo_pass = os.environ.get("MONGO_PASSWORD")
-    mongo_db = os.environ.get("MONGO_DATABASE")
+    mongo_user = os.environ.get("MONGODB_USERNAME")
+    mongo_pass = os.environ.get("MONGODB_PASSWORD")
+    mongo_db = os.environ.get("MONGODB_DATABASE")
     if not application.config.get("MONGO_URI") and not (
         mongo_user and mongo_pass and mongo_db
     ):


### PR DESCRIPTION
The mongodb container I've been using for testing uses slightly different env vars from what we use. That's ok, but using the same ones means we can load a .env file with values that work for both rather than having to duplicate them. This also updates the testflinger.conf.example which can also be used, to reflect more current config items.