### PR TITLE
Allow for passing MONGODB_URI environment variable to docker image

### DIFF
--- a/testflinger.env
+++ b/testflinger.env
@@ -7,4 +7,4 @@
 #MONGODB_DATABASE=testflinger_db
 #MONGODB_ROOT_PASSWORD=testflinger
 # If you specify this variable the others are unneeded/ignored.
-#MONOGDB_URI=mongodb://mongo:27017/testflinger_db
+#MONGODB_URI=mongodb://mongo:27017/testflinger_db

--- a/testflinger.env
+++ b/testflinger.env
@@ -6,3 +6,5 @@
 #MONGODB_PASSWORD=testflinger
 #MONGODB_DATABASE=testflinger_db
 #MONGODB_ROOT_PASSWORD=testflinger
+# If you specify this variable the others are unneeded/ignored.
+#MONOGDB_URI=mongodb://mongo:27017/testflinger_db

--- a/testflinger/__init__.py
+++ b/testflinger/__init__.py
@@ -157,17 +157,21 @@ def setup_mongodb(application):
     mongo_pass = os.environ.get("MONGODB_PASSWORD")
     mongo_db = os.environ.get("MONGODB_DATABASE")
     mongo_host = os.environ.get("MONGODB_HOST", "mongo")
+    mongo_uri = os.environ.get("MONGODB_URI")
     if not application.config.get("MONGO_URI") and not (
-        mongo_user and mongo_pass and mongo_db
+        mongo_user and mongo_pass and mongo_db and mongo_uri
     ):
         # We are probably running unit tests
         return
 
     if not application.config.get("MONGO_URI"):
-        application.config["MONGO_URI"] = (
-            f"mongodb://{mongo_user}:{mongo_pass}@"
-            f"{mongo_host}:27017/{mongo_db}"
-        )
+        if mongo_uri:
+            application_config["MONGO_URI"] = mongo_uri
+        else:
+            application.config["MONGO_URI"] = (
+                f"mongodb://{mongo_user}:{mongo_pass}@"
+                f"{mongo_host}:27017/{mongo_db}"
+            )
 
     mongo_client = PyMongo(
         application,

--- a/testflinger/__init__.py
+++ b/testflinger/__init__.py
@@ -166,7 +166,7 @@ def setup_mongodb(application):
 
     if not application.config.get("MONGO_URI"):
         if mongo_uri:
-            application_config["MONGO_URI"] = mongo_uri
+            application.config["MONGO_URI"] = mongo_uri
         else:
             application.config["MONGO_URI"] = (
                 f"mongodb://{mongo_user}:{mongo_pass}@"


### PR DESCRIPTION
Allow for passing MONGODB_URI environment variable to the docker image.

This will override over variables, and can be used to deploy this application using https://charmhub.io/gunicorn-k8s (in the edge channel) which now supports a relation to mongodb-k8s.