### PR TITLE
Improve handling of configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,11 +56,10 @@ allow external connections, use the ''--bind'' option:
 Configuration
 -------------
 
-Configuration values can be loaded from a file. By default, testflinger will
-look for testflinger.conf in the testflinger source directory. If you want
-to change the location for the configuration file, set the environment variable
-*TESTFLINGER_CONFIG* to the path of your configuration file.  If no config file
-is found, defaults will be used.
+Configuration values are read from environment variables.  If you prefer to
+store the configuration in a config file, the config file should be sourced
+prior to running the server so that the values may still be read from the
+environment.
 
 Currently supported configuration values are:
 
@@ -72,7 +71,7 @@ Currently supported configuration values are:
 
 - **MONGODB_HOST**: host or ip of the MongoDB server
 
-  - Default: ''mongo''
+- **MONGODB_PORT**: MongoDB port to connect to (Default: 27017)
 
 - **MONGODB_URI**: URI for connecting to MongoDB (used instead of the above config options)
 

--- a/testflinger.conf.example
+++ b/testflinger.conf.example
@@ -5,4 +5,4 @@
 # MONGODB_PASSWORD="testflinger"
 # MONGODB_DATABASE="testflinger_db"
 # MONGODB_HOST="mongo"
-# MONGODB_URI = "mongodb://mongo:27017/testflinger_db"
+# MONGODB_URI="mongodb://mongo:27017/testflinger_db"

--- a/testflinger.conf.example
+++ b/testflinger.conf.example
@@ -1,8 +1,8 @@
 # These values can be used in place of environment variables to configure
 # Testflinger. If MONGO_URI is not specified, then it will be built using the
 # other values specified
-# MONGODB_USERNAME=testflinger
-# MONGODB_PASSWORD=testflinger
-# MONGODB_DATABASE=testflinger_db
-# MONGODB_HOST=mongo
-# MONGO_URI = "mongodb://mongo:27017/testflinger_db"
+# MONGODB_USERNAME="testflinger"
+# MONGODB_PASSWORD="testflinger"
+# MONGODB_DATABASE="testflinger_db"
+# MONGODB_HOST="mongo"
+# MONGODB_URI = "mongodb://mongo:27017/testflinger_db"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2022 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Fixtures for testing
+"""
+
+from dataclasses import dataclass
+import pytest
+import mongomock
+from mongomock.gridfs import enable_gridfs_integration
+import src
+from src.api import v1
+
+
+@dataclass
+class TestingConfig:
+    """Config for Testing"""
+
+    TESTING = True
+
+
+class MongoClientMock(mongomock.MongoClient):
+    """Mock MongoClient and allow GridFS"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        enable_gridfs_integration()
+
+    def start_session(self, *args, **kwargs):
+        # Reimplemented to avoid pylint issues
+        return super().start_session(*args, **kwargs)
+
+
+@pytest.fixture
+def mongo_app():
+    """Create a pytest fixture for the app"""
+    mock_mongo = MongoClientMock()
+
+    app = src.create_flask_app(TestingConfig)
+    old_src_mongo = src.mongo
+    old_v1_mongo = v1.mongo
+    src.mongo = mock_mongo
+    v1.mongo = mock_mongo
+    yield app.test_client(), mock_mongo.db
+    src.mongo = old_src_mongo
+    v1.mongo = old_v1_mongo
+
+
+@pytest.fixture
+def testing_app():
+    """Create an app for testing without using test_client"""
+    app = src.create_flask_app(TestingConfig)
+    yield app

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,22 +17,18 @@
 Unit tests for Testflinger flask app
 """
 
-import os
-import tempfile
+import pytest
 import src
 
 
-def test_default_config():
+def test_default_config(testing_app):
     """Test default config settings"""
-    app = src.create_flask_app()
+    app = testing_app
     assert app.config.get("PROPAGATE_EXCEPTIONS") is True
 
 
-def test_load_config():
-    """Test loading a config file"""
-    with tempfile.NamedTemporaryFile() as testconfig:
-        testconfig.write('TEST_FOO="YES"\n'.encode())
-        testconfig.flush()
-        os.environ["TESTFLINGER_CONFIG"] = testconfig.name
-        app = src.create_flask_app()
-        assert app.config.get("TEST_FOO") == "YES"
+def test_setup_mongo_fails_without_config():
+    """Ensure setup_mongo fails without config"""
+    with pytest.raises(SystemExit) as exc:
+        src.create_flask_app()
+    assert exc.value.code == "No MongoDB URI configured!"

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -20,34 +20,8 @@ Unit tests for Testflinger v1 API
 import json
 
 from io import BytesIO
-import mongomock
-from mongomock.gridfs import enable_gridfs_integration
-import pytest
 import src
 from src.api import v1
-
-
-class MongoClientMock(mongomock.MongoClient):
-    """Mock MongoClient and allow GridFS"""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        enable_gridfs_integration()
-
-    def start_session(self, *args, **kwargs):
-        # Reimplemented to avoid pylint issues
-        return super().start_session(*args, **kwargs)
-
-
-@pytest.fixture(name="mongo_app")
-def fixture_app():
-    """Create a pytest fixture for the app"""
-    mock_mongo = MongoClientMock()
-
-    app = src.create_flask_app()
-    src.mongo = mock_mongo
-    v1.mongo = mock_mongo
-    yield app.test_client(), mock_mongo.db
 
 
 def test_home(mongo_app):

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,4 @@ commands =
     {envbindir}/python -m black --check setup.py testflinger.py src tests
     {envbindir}/python -m flake8 setup.py testflinger.py src tests
     {envbindir}/python -m pylint testflinger.py src tests
-    {envbindir}/python -m pytest --doctest-modules --cov=.
+    {envbindir}/python -m pytest --doctest-modules --ignore testflinger.py --cov=.


### PR DESCRIPTION
With the recent config var changes, we moved away from using the flask app.config values. Which is fine, because we didn't really need it to be stored in the flask app config, but it also means that loading values from a python .conf file wouldn't work now.

I don't think using the flask config.from_pyfile is all that useful anyway since:
1. we can load the values we need from the environment
2. even if you want to use that config file, you can easily source it before running the flask app

This documents that recommendation in the README.rst, and makes some test changes to allow testing the error path so that the user gets an obvious error if the server isn't configured.