### PR TITLE
Only consider "waiting" jobs in the queue when getting position

### DIFF
--- a/src/api/v1.py
+++ b/src/api/v1.py
@@ -394,7 +394,10 @@ def job_position_get(job_id):
     except (AttributeError, TypeError):
         return "Invalid json returned for id: {}\n".format(job_id), 400
     # Get all jobs with job_queue=queue and return only the _id
-    jobs = mongo.db.jobs.find({"job_data.job_queue": queue}, {"job_id": 1})
+    jobs = mongo.db.jobs.find(
+        {"job_data.job_queue": queue, "result_data.job_state": "waiting"},
+        {"job_id": 1},
+    )
     # Create a dict mapping job_id (as a string) to the position in the queue
     jobs_id_position = {job.get("job_id"): pos for pos, job in enumerate(jobs)}
     if job_id in jobs_id_position:

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -289,7 +289,7 @@ def test_job_position(mongo_app):
     """Ensure initial job state is set to 'waiting'"""
     app, _ = mongo_app
     job_data = {"job_queue": "test"}
-    # Place a 3 jobs on the queue
+    # Place 3 jobs on the queue
     job_id = []
     for pos in range(3):
         output = app.post(


### PR DESCRIPTION
When querying for queue position, we are asking "how many jobs are waiting in the queue to run that came before my job". So we should restrict the query to only consider jobs in the "waiting" state.