### PR TITLE
quick fix to make agents collection name in views match what we store

### DIFF
--- a/src/views.py
+++ b/src/views.py
@@ -33,7 +33,7 @@ def metrics():
 @views.route("/agents")
 def agents():
     """Agents view"""
-    agent_info = mongo.db.agent_info.find()
+    agent_info = mongo.db.agents.find()
     return render_template("agents.html", agents=agent_info)
 
 


### PR DESCRIPTION
simple one-liner to make the name of this collection in the views match what we store in the api