### PR TITLE
Add a job detail view

### DIFF
--- a/src/static/assets/css/testflinger.css
+++ b/src/static/assets/css/testflinger.css
@@ -11,6 +11,14 @@ main {
     width: 95%;
 }
 
+table {
+    text-align: left;
+}
+
+table td {
+    padding: 2px 2px 2px 30px;
+}
+
 .center {
     margin: auto;
     padding: 10px;
@@ -72,8 +80,8 @@ main {
 }
 
 .scrollable {
-    background-color: lightgrey;
+    background-color: rgb(230, 230, 230);
     max-height: 500px;
     max-width: 80%;
-    overflow: scroll;
+    overflow: auto;
 }

--- a/src/static/assets/css/testflinger.css
+++ b/src/static/assets/css/testflinger.css
@@ -11,11 +11,11 @@ main {
     width: 95%;
 }
 
-table {
+.general-info table {
     text-align: left;
 }
 
-table td {
+.general-info table td {
     padding: 2px 2px 2px 30px;
 }
 
@@ -77,6 +77,10 @@ table td {
     color: white;
     text-align: left;
     text-decoration: underline;
+}
+
+.filter-table table td {
+    text-align: left;
 }
 
 .scrollable {

--- a/src/templates/job_detail.html
+++ b/src/templates/job_detail.html
@@ -1,0 +1,58 @@
+{% extends 'base.html' %}
+{% set active_page = 'jobs' %}
+{% block content %}
+<div class="center">
+    <table>
+        <tr>
+            <th>Job ID:</th>
+            <td>{{ job.job_id }}</td>
+        </tr>
+        <tr>
+            <th>Queue:</th>
+            <td>{{ job.job_data.job_queue }}</td>
+        </tr>
+        <tr>
+            <th>State:</th>
+            <td>{{ job.result_data.job_state }}</td>
+        </tr>
+        <tr>
+            <th>Created At:</th>
+            <td>{{ job.created_at }}</td>
+        </tr>
+    </table>
+    <br>
+
+    <hr>
+    provision_data:
+    <div>
+        {{ job.job_data.provision_data }}
+    </div>
+
+    <hr>
+    test_cmds:
+    <div class="center scrollable">
+        <span style="white-space: pre-line">
+            {{ job.job_data.test_data.test_cmds }}
+        </span>
+    </div>
+
+    <hr>
+    provision_status: {{ job.result_data.provision_status }}<br>
+    provision_output:
+    <div class="center scrollable">
+        <span style="white-space: pre-line">
+            {{ job.result_data.provision_output }}
+        </span>
+    </div>
+
+    <hr>
+    test_status: {{ job.result_data.test_status }}<br>
+    test_output:
+    <div class="center scrollable">
+        <span style="white-space: pre-line">
+            {{ job.result_data.test_output }}
+        </span>
+    </div>
+</div>
+<script type="text/javascript" src="/static/assets/js/filter.js"></script>
+{% endblock %}

--- a/src/templates/job_detail.html
+++ b/src/templates/job_detail.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% set active_page = 'jobs' %}
 {% block content %}
-<div class="center">
+<div class="general-info center">
     <table>
         <tr>
             <th>Job ID:</th>
@@ -21,7 +21,9 @@
         </tr>
     </table>
     <br>
+</div>
 
+<div class="center">
     <hr>
     provision_data:
     <div>

--- a/src/views.py
+++ b/src/views.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Canonical
+# Copyright (C) 2023 Canonical
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,6 +42,13 @@ def jobs():
     """Jobs view"""
     jobs_data = mongo.db.jobs.find()
     return render_template("jobs.html", jobs=jobs_data)
+
+
+@views.route("/jobs/<job_id>")
+def job_detail(job_id):
+    """Job detail view"""
+    job_data = mongo.db.jobs.find_one({"job_id": job_id})
+    return render_template("job_detail.html", job=job_data)
 
 
 @views.route("/queues")


### PR DESCRIPTION
First pass at a job details page. Here's a sample of what it might look like. I added some extra lines (which really aren't useful) in the test_cmds section so you can see the added scrollbar. Since this isn't on a server where anything is actually running the job and adding provision/test output, you don't see anything in those fields, but they would be populated if it were actually running

![image](https://user-images.githubusercontent.com/1255513/223195574-67116b17-2101-48ef-9346-c988496396c2.png)
