### PR TITLE
Add queue details page

### DIFF
--- a/src/templates/queue_detail.html
+++ b/src/templates/queue_detail.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% set active_page = 'queues' %}
+{% block content %}
+<div class="general-info center">
+    <table>
+        <tr>
+            <th>Queue Name:</th>
+            <td>{{ queue.name }}</td>
+        </tr>
+        <tr>
+            <th>Description:</th>
+            <td>{{ queue.description }}</td>
+        </tr>
+    </table>
+</div>
+<br>
+<br>
+<div class="filter-table center">
+    <table width="100%">
+        <tr>
+            <th>Job ID</th>
+            <th>State</th>
+            <th>Created At</th>
+        </tr>
+        {% for job in jobs %}
+        <tr class="tr-highlight">
+            <td><a href="/jobs/{{ job.job_id}}">{{ job.job_id }}</a></td>
+            <td>{{ job.result_data.job_state }}</td>
+            <td>{{ job.created_at }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</div>
+{% endblock %}

--- a/src/views.py
+++ b/src/views.py
@@ -96,3 +96,24 @@ def queues():
         ]
     )
     return render_template("queues.html", queues=queue_data)
+
+
+@views.route("/queues/<queue_id>")
+def queue_detail(queue_id):
+    """Queue detailed view"""
+    queue_data = mongo.db.queues.find_one({"name": queue_id})
+    if not queue_data:
+        # If it's not an advertised queue, create some dummy data
+        queue_data = {"name": queue_id, "description": "No description"}
+
+    # Find all the jobs active jobs in this queue
+    job_data = mongo.db.jobs.find(
+        {
+            "job_data.job_queue": queue_id,
+            "result_data.job_state": {"$nin": ["complete", "cancelled"]},
+        }
+    )
+
+    return render_template(
+        "queue_detail.html", queue=queue_data, jobs=job_data
+    )


### PR DESCRIPTION
queue details view - including a list of jobs in the queue. Interesting thing to note from this screenshot is that this is NOT an advertised queue, but you can still at least see the name and list of jobs in the queue
![image](https://user-images.githubusercontent.com/1255513/224091384-833c9169-0cb8-46e5-a7cc-13b89cc2190d.png)
