### PR TITLE
Redirect / to /agents for now

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -64,7 +64,6 @@ def create_flask_app(config=None):
             dsn=sentry_dsn, integrations=[FlaskIntegration()]
         )
 
-    tf_app.add_url_rule("/", "home", v1.home)
     tf_app.add_url_rule("/v1/job", "job_post", v1.job_post, methods=["POST"])
     tf_app.add_url_rule("/v1/job", "job_get", v1.job_get, methods=["GET"])
     tf_app.add_url_rule(

--- a/src/views.py
+++ b/src/views.py
@@ -17,11 +17,17 @@
 Additional views not associated with the API
 """
 
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, redirect, url_for
 from prometheus_client import generate_latest
 from src.database import mongo
 
 views = Blueprint("testflinger", __name__)
+
+
+@views.route("/")
+def home():
+    """Home view"""
+    return redirect(url_for("testflinger.agents"))
 
 
 @views.route("/metrics")

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -23,6 +23,14 @@ from io import BytesIO
 from src.api import v1
 
 
+def test_home(mongo_app):
+    """Test that queries to / are redirected to /agents"""
+    app, _ = mongo_app
+    response = app.get("/")
+    assert 302 == response.status_code
+    assert "/agents" == response.headers.get("Location")
+
+
 def test_add_job_good(mongo_app):
     """Test that adding a new job works"""
     job_data = json.dumps({"job_queue": "test"})

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -20,15 +20,7 @@ Unit tests for Testflinger v1 API
 import json
 
 from io import BytesIO
-import src
 from src.api import v1
-
-
-def test_home(mongo_app):
-    """Test root URL returns the version"""
-    app, _ = mongo_app
-    output = app.get("/")
-    assert src.api.v1.get_version() == output.text
 
 
 def test_add_job_good(mongo_app):


### PR DESCRIPTION
Once this gets deployed, it's not useful to have people just get a version string when they go to the index page. Let's redirect it to /agents unless we later decide on a better landing page for the index.