### PR TITLE
Add settings for the auth source db to use for mongodb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,8 @@ Currently supported configuration values are:
 
 - **MONGODB_DATABASE**: Name of the MongoDB database to use
 
+- **MONGODB_AUTH_SOURCE**: Name of the database to use for authentication (Default: admin)
+
 - **MONGODB_HOST**: host or ip of the MongoDB server
 
 - **MONGODB_PORT**: MongoDB port to connect to (Default: 27017)

--- a/devel/docker-compose.override.yml
+++ b/devel/docker-compose.override.yml
@@ -13,6 +13,7 @@ services:
       - MONGODB_PASSWORD=testflinger
       - MONGODB_DATABASE=testflinger_db
       - MONGODB_HOST=mongo
+      - MONGODB_AUTH_SOURCE=testflinger_db
     volumes:
       - .:/srv/testflinger
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -170,6 +170,7 @@ def setup_mongodb(application):
     mongo_host = os.environ.get("MONGODB_HOST")
     mongo_port = os.environ.get("MONGODB_PORT", "27017")
     mongo_uri = os.environ.get("MONGODB_URI")
+    mongo_auth = os.environ.get("MONGODB_AUTH_SOURCE", "admin")
 
     if not mongo_uri:
         if not (mongo_host and mongo_db):
@@ -179,6 +180,7 @@ def setup_mongodb(application):
         )
         mongo_uri = (
             f"mongodb://{mongo_creds}{mongo_host}:{mongo_port}/{mongo_db}"
+            f"?authSource={mongo_auth}"
         )
 
     mongo.init_app(


### PR DESCRIPTION
So I *think* this is what we need for getting things working with the mongodb version used by mongodb-k8s charm. I've tried testing this by building the container and deploying it in juju, but so far I haven't had any luck getting juju to re-pull the oci image. So for now, I'm testing it by connecting to the container, making the changes, and manually starting testflinger.

Without this, it will try to authenticate against the testflinger_db rather than the admin db. If you use the default of admin db, you don't have to specify the authentication source database, but I added the env var in case you use something like the bitnami mongodb image, so that it will be more flexible.

I also added documentation in the README about the new option