### PR TITLE
Add support for nginx-ingress-integrator to the juju charm

### DIFF
--- a/charm/README.md
+++ b/charm/README.md
@@ -1,0 +1,68 @@
+# Deploying with Juju
+
+To deploy Testflinger server using Juju, there are 3 main charms you'll need:
+ - mongodb-k8s
+ - nginx-ingress-integrator
+ - testflinger-k8s
+
+All of these can currently be pulled from charmhub, but there are a few extra
+steps needed for configuration and integration listed below. You'll also need
+a juju and k8s environment set up ahead of time. There are good instructions
+for doing this with microk8s here: https://juju.is/docs/olm/microk8s
+
+Additionally, you'll need to enable the following add-ons in microk8s:
+ - dns
+ - hostpath-storage
+ - ingress
+
+## Deploy mongodb-k8s
+
+For a simple test deployment, it is sufficient to just run:
+```
+    $ juju deploy mongodb-k8s --channel=5/edge
+```
+If you need to add additional storage for the database, you can also add
+the option `--storage db=100G`, for example, to allocate 100G from your
+storage pool for use by the database.
+
+## Deploy nginx-ingress-integrator
+
+First, deploy nginx-ingress-integrator using:
+```
+    $ juju deploy nginx-ingress-integrator
+```
+
+(OPTIONAL) If you want to use https, you'll need to add the TLS secret to a
+k8s secret.  The process for doing that is described at
+https://github.com/canonical/nginx-ingress-integrator-operator/blob/main/docs/how-to/secure-an-ingress-with-tls.md
+
+Once you've created that secret in k8s, you can update the config for the nginx
+charm to use it by running:
+```
+    $ juju config nginx-ingress-integrator tls-secret-name="my-tls-secret"
+```
+
+## Deploy testflinger-k8s
+
+To deploy testflinger itself from charmhub, you can use:
+```
+    $ juju deploy testflinger-k8s --channel=edge
+    $ juju config testflinger-k8s external-hostname=testflinger.local
+```
+You can replace testflinger.local with any other hostname you wish to use
+for the ingress. Just make sure to either configure your DNS or /etc/hosts
+to use that name for the ip address of the system where you are running
+microk8s.
+
+## Integrate (relate) the Charms
+
+To make the charms talk together, you'll need to run:
+```
+    $ juju integrate testflinger-k8s nginx-ingress-integrator
+    $ juju integrate testflinger-k8s mongodb-k8s
+```
+
+After this, watch `juju status` and/or `juju debug-log` for progress.
+Once everything is settled, you should be able to point your web browser
+at the hostname you specified above and see the default testflinger
+homepage.

--- a/charm/config.yaml
+++ b/charm/config.yaml
@@ -1,0 +1,5 @@
+options:
+  external_hostname:
+    default: testflinger.local
+    description: external hostname for accessing testflinger server
+    type: string

--- a/charm/metadata.yaml
+++ b/charm/metadata.yaml
@@ -19,3 +19,5 @@ requires:
   mongodb_client:
     interface: mongodb_client
     limit: 1
+  nginx-route:
+    interface: nginx-route

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -9,6 +9,7 @@ import sys
 from ops.pebble import Layer
 from charms.data_platform_libs.v0.data_interfaces import DatabaseCreatedEvent
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
+from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,8 @@ class TestflingerCharm(ops.CharmBase):
         self._stored.set_default(
             reldata={},
         )
+
+        self._require_nginx_route()
 
         self.mongodb = DatabaseRequires(
             self,
@@ -55,6 +58,14 @@ class TestflingerCharm(ops.CharmBase):
         """Report the current version of the app"""
         # TODO: get the version somehow and return it
         return "Version ?"
+
+    def _require_nginx_route(self):
+        require_nginx_route(
+            charm=self,
+            service_hostname=self.config["external_hostname"],
+            service_name=self.app.name,
+            service_port=5000,
+        )
 
     def _on_testflinger_pebble_ready(
         self, event: ops.PebbleReadyEvent


### PR DESCRIPTION
I've tested this locally with microk8s, which requires the "ingress" plugin enabled to work with it. Once deployed, I was able to easily connect to it though.