### PR TITLE
Remove /api from the oci image name

### DIFF
--- a/.github/workflows/publish_oci_image.yml
+++ b/.github/workflows/publish_oci_image.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
 
     env:
-      IMAGE_NAME: ${{ github.repository }}/api
+      IMAGE_NAME: ${{ github.repository }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
very minor thing, but while the oci image build worked fine and pushed to ghcr.io, it has the name testflinger/api:main instead of simply testflinger:main. I don't think we should need to have more than one image, so it's not worth making the distinction. If we ever do need a second oci image or something, then this would still be the main api server and calling it simply "testflinger" would be fine I think.