### PR TITLE
Fixes needed for tox 23.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [tool.black]
 line-length = 79
-exclude = [
-  "charm/lib"
-]
+exclude = "charm/lib"
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands_pre =
 
 [testenv:format]
 commands =
-    {envbindir}/python -m black --check setup.py testflinger.py src tests charm/src charm/tests
+    {envbindir}/python -m black --check setup.py testflinger.py src tests charm
 
 [testenv:lint]
 set_env =


### PR DESCRIPTION
It looks like exclude key in pyproject.toml handling by black changed a bit. This works better now, which is good, but needed a string instead of a list. This was causing tests to fail in tox but not because of anything we broke. We'll need to merge this before we can merge anything else though.