### PR TITLE
Detect if we have empty relation data and exit

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -210,6 +210,11 @@ class TestflingerCharm(ops.CharmBase):
             username = val.get("username")
             password = val.get("password")
             database = val.get("database")
+            break
+        else:
+            logger.error("No database relation data found yet")
+            sys.exit()
+
         db_data = {
             "db_host": host,
             "db_port": port,


### PR DESCRIPTION
There's a chance that the relation can exist but not yet have data in it. This can result in an error if we try to use that data later, and the charm will get stuck in an error state rather than retrying. Exiting here if there's no data for the relation forces it to retry getting the data later.