### PR TITLE
Only include the test_data in the job details page if it exists

### DIFF
--- a/src/templates/job_detail.html
+++ b/src/templates/job_detail.html
@@ -30,6 +30,7 @@
         {{ job.job_data.provision_data }}
     </div>
 
+    {% if job.job_data.test_data %}
     <hr>
     test_cmds:
     <div class="center scrollable">
@@ -37,6 +38,7 @@
             {{ job.job_data.test_data.test_cmds }}
         </span>
     </div>
+    {% endif %}
 
     <hr>
     provision_status: {{ job.result_data.provision_status }}<br>


### PR DESCRIPTION
if the user chose to skip the test_data section, then there's no reason to try to output it here. If we try to get it when it doesn't exist, we could get an error:
Unhandled Exception: 'dict object' has no attribute 'test_data' 