### PR TITLE
Reverse sort jobs view on timestamp when it was created

### DIFF
--- a/src/views.py
+++ b/src/views.py
@@ -53,7 +53,7 @@ def agent_detail(agent_id):
 @views.route("/jobs")
 def jobs():
     """Jobs view"""
-    jobs_data = mongo.db.jobs.find()
+    jobs_data = mongo.db.jobs.find(sort=[("created_at", -1)])
     return render_template("jobs.html", jobs=jobs_data)
 
 


### PR DESCRIPTION
I noticed after accumulating a lot of jobs in testing that the most recent jobs were at the bottom of the view. I think most people would much rather see the most recent jobs at the top.