### PR TITLE
Don't try to load the favicon and generate more 404s

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -6,6 +6,8 @@
     <title>{% block title %} {% endblock %} - Testflinger</title>
     <!-- Site CSS Files -->
     <link href="/static/assets/css/testflinger.css" rel="stylesheet" />
+    <!-- Don't request favicon -->
+    <link rel="icon" href="data:,">
     <!-- Page specific CSS Files -->
     {% block stylesheets %}{% endblock stylesheets %}
 </head>


### PR DESCRIPTION
I see a lot of 404s in our logs when anyone accesses the web ui because the browser automatically tries to load the favicon. This disables it from the browser side, so that the request isn't made.