### PR TITLE
Add OpenAPI specs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -292,6 +292,7 @@ server will only return one job.
   - HTTP 200 (OK)
   - HTTP 400 (Bad Request) - the job is already completed or cancelled
   - HTTP 404 (Not Found) - the job isn't found
+  - HTTP 422 (Unprocessable) - The action or the argument to it could not be processed
 
 - Supported Actions:
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ INSTALL_REQUIRES = [
     "prometheus-client",
     "pyyaml",
     "sentry-sdk[flask]",
+    "apiflask",
 ]
 
 setup(

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -21,10 +21,11 @@ import logging
 import os
 import urllib
 
-from flask import Flask, request
+from flask import request
 from flask.logging import create_logger
 from werkzeug.exceptions import NotFound
 from pymongo.errors import ConnectionFailure
+from apiflask import APIFlask
 
 from src.database import mongo
 from src.api.v1 import v1
@@ -43,7 +44,7 @@ except ImportError:
 
 def create_flask_app(config=None):
     """Create the flask app"""
-    tf_app = Flask(__name__)
+    tf_app = APIFlask(__name__)
     if config:
         tf_app.config.from_object(config)
     tf_log = create_logger(tf_app)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -82,3 +82,55 @@ class Result(Schema):
     cleanup_serial = fields.String(required=False)
     device_info = fields.Dict(required=False)
     job_state = fields.String(required=False)
+
+
+job_empty = {
+    204: {
+        "description": "No job found",
+        "content": {
+            "application/json": {
+                "schema": {"type": "object", "properties": {}}
+            }
+        },
+    }
+}
+
+queues_out = {
+    200: {
+        "description": "Mapping of queue names and descriptions",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string",
+                    },
+                    "example": {
+                        "device001": "Queue for device001",
+                        "some-queue": "some other queue",
+                    },
+                },
+            },
+        },
+    },
+}
+
+images_out = {
+    200: {
+        "description": "Mapping of image names and provision data",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string",
+                    },
+                    "example": {
+                        "core22": "url: http://.../core22.img.xz",
+                        "server-22.04": "url: http://.../ubuntu-22.04.img.xz",
+                    },
+                },
+            },
+        },
+    },
+}

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2022 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Testflinger v1 OpenAPI schemas
+"""
+
+import uuid
+from apiflask import Schema, fields
+from apiflask.validators import OneOf
+
+
+class AgentIn(Schema):
+    """Agent data schema"""
+
+    state = fields.String(required=False)
+    queues = fields.List(fields.String(), required=False)
+    location = fields.String(required=False)
+    job_id = fields.String(required=False)
+    log = fields.List(fields.String(), required=False)
+
+
+class ActionIn(Schema):
+    """Action data schema"""
+
+    action = fields.String(required=True, validate=OneOf(["cancel"]))
+
+
+class JobIn(Schema):
+    job_id = fields.String(required=False)
+    job_queue = fields.String(required=True)
+    global_timeout = fields.Integer(required=False)
+    output_timeout = fields.Integer(required=False)
+    provision_data = fields.Dict(required=False)
+    test_data = fields.Dict(required=False)
+    allocate_data = fields.Dict(required=False)
+    recover_data = fields.Dict(required=False)
+
+
+class JobOut(Schema):
+    job_id = fields.String(required=True)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -17,13 +17,12 @@
 Testflinger v1 OpenAPI schemas
 """
 
-import uuid
 from apiflask import Schema, fields
 from apiflask.validators import OneOf
 
 
 class AgentIn(Schema):
-    """Agent data schema"""
+    """Agent data input schema"""
 
     state = fields.String(required=False)
     queues = fields.List(fields.String(), required=False)
@@ -33,21 +32,53 @@ class AgentIn(Schema):
 
 
 class ActionIn(Schema):
-    """Action data schema"""
+    """Action data input schema"""
 
     action = fields.String(required=True, validate=OneOf(["cancel"]))
 
 
-class JobIn(Schema):
+class Job(Schema):
+    """Job schema"""
+
     job_id = fields.String(required=False)
+    parent_job_id = fields.String(required=False)
+    name = fields.String(required=False)
     job_queue = fields.String(required=True)
     global_timeout = fields.Integer(required=False)
     output_timeout = fields.Integer(required=False)
+    allocation_timeout = fields.Integer(required=False)
     provision_data = fields.Dict(required=False)
     test_data = fields.Dict(required=False)
     allocate_data = fields.Dict(required=False)
     recover_data = fields.Dict(required=False)
 
 
-class JobOut(Schema):
+class JobId(Schema):
+    """Job ID schema"""
+
     job_id = fields.String(required=True)
+
+
+class Result(Schema):
+    """Result schema"""
+
+    setup_status = fields.Integer(required=False)
+    setup_output = fields.String(required=False)
+    setup_serial = fields.String(required=False)
+    provision_status = fields.Integer(required=False)
+    provision_output = fields.String(required=False)
+    provision_serial = fields.String(required=False)
+    test_status = fields.Integer(required=False)
+    test_output = fields.String(required=False)
+    test_serial = fields.String(required=False)
+    recover_status = fields.Integer(required=False)
+    recover_output = fields.String(required=False)
+    recover_serial = fields.String(required=False)
+    allocate_status = fields.Integer(required=False)
+    allocate_output = fields.String(required=False)
+    allocate_serial = fields.String(required=False)
+    cleanup_status = fields.Integer(required=False)
+    cleanup_output = fields.String(required=False)
+    cleanup_serial = fields.String(required=False)
+    device_info = fields.Dict(required=False)
+    job_state = fields.String(required=False)

--- a/src/api/v1.py
+++ b/src/api/v1.py
@@ -22,7 +22,8 @@ import uuid
 from datetime import datetime
 
 import pkg_resources
-from flask import Blueprint, jsonify, request, send_file
+from apiflask import APIBlueprint
+from flask import jsonify, request, send_file
 from gridfs import GridFS
 from gridfs.errors import NoFile
 from prometheus_client import Counter
@@ -36,7 +37,7 @@ reservations_metric = Counter(
 )
 
 
-v1 = Blueprint("v1", __name__)
+v1 = APIBlueprint("v1", __name__)
 
 
 @v1.get("/")

--- a/src/api/v1.py
+++ b/src/api/v1.py
@@ -67,7 +67,7 @@ def job_post(json_data: dict):
         # Set job_queue to None so we take the failure path below
         job_queue = ""
     if not job_queue:
-        return "Invalid data or no job_queue specified\n", 400
+        abort(422, message="Invalid data or no job_queue specified")
 
     try:
         job = job_builder(json_data)

--- a/src/api/v1.py
+++ b/src/api/v1.py
@@ -110,6 +110,7 @@ def job_builder(data):
 
 @v1.get("/job")
 @v1.output(schemas.Job)
+@v1.doc(responses=schemas.job_empty)
 def job_get():
     """Request a job to run from supported queues"""
     queue_list = request.args.getlist("queue")
@@ -290,6 +291,7 @@ def action_post(job_id, json_data):
 
 
 @v1.get("/agents/queues")
+@v1.doc(responses=schemas.queues_out)
 def queues_get():
     """Get all advertised queues from this server
 
@@ -327,6 +329,7 @@ def queues_post():
 
 
 @v1.get("/agents/images/<queue>")
+@v1.doc(responses=schemas.images_out)
 def images_get(queue):
     """Get a dict of known images for a given queue"""
     queue_data = mongo.db.queues.find_one(

--- a/src/api/v1.py
+++ b/src/api/v1.py
@@ -57,13 +57,12 @@ def get_version():
 
 
 @v1.post("/job")
-@v1.input(schemas.JobIn, location="json")
-@v1.output(schemas.JobOut)
+@v1.input(schemas.Job, location="json")
+@v1.output(schemas.JobId)
 def job_post(json_data: dict):
     """Add a job to the queue"""
     try:
-        data = request.get_json()
-        job_queue = data.get("job_queue")
+        job_queue = json_data.get("job_queue")
     except (AttributeError, BadRequest):
         # Set job_queue to None so we take the failure path below
         job_queue = ""
@@ -71,12 +70,12 @@ def job_post(json_data: dict):
         return "Invalid data or no job_queue specified\n", 400
 
     try:
-        job = job_builder(data)
+        job = job_builder(json_data)
     except ValueError:
         abort(400, message="Invalid job_id specified")
 
     jobs_metric.labels(queue=job_queue).inc()
-    if "reserve_data" in data:
+    if "reserve_data" in json_data:
         reservations_metric.labels(queue=job_queue).inc()
 
     # CAUTION! If you ever move this line, you may need to pass data as a copy
@@ -110,6 +109,7 @@ def job_builder(data):
 
 
 @v1.get("/job")
+@v1.output(schemas.Job)
 def job_get():
     """Request a job to run from supported queues"""
     queue_list = request.args.getlist("queue")
@@ -118,10 +118,11 @@ def job_get():
     job = get_job(queue_list)
     if job:
         return jsonify(job)
-    return "", 204
+    return {}, 204
 
 
 @v1.get("/job/<job_id>")
+@v1.output(schemas.Job)
 def job_get_id(job_id):
     """Request the json job definition for a specified job, even if it has
        already run
@@ -130,46 +131,41 @@ def job_get_id(job_id):
         UUID as a string for the job
     :return:
         JSON data for the job or error string and http error
-
-    >>> job_get_id('foo')
-    ('Invalid job id\\n', 400)
     """
 
     if not check_valid_uuid(job_id):
-        return "Invalid job id\n", 400
+        abort(400, message="Invalid job_id specified")
     response = mongo.db.jobs.find_one(
         {"job_id": job_id}, projection={"job_data": True, "_id": False}
     )
     if not response:
-        return "", 204
+        return {}, 204
     job_data = response.get("job_data")
     job_data["job_id"] = job_id
-    return jsonify(job_data), 200
+    return job_data
 
 
 @v1.post("/result/<job_id>")
-def result_post(job_id):
+@v1.input(schemas.Result, location="json")
+def result_post(job_id, json_data):
     """Post a result for a specified job_id
 
     :param job_id:
         UUID as a string for the job
     """
     if not check_valid_uuid(job_id):
-        return "Invalid job id\n", 400
-    try:
-        result_data = request.get_json()
-    except BadRequest:
-        return "Invalid result data\n", 400
+        abort(400, message="Invalid job_id specified")
 
     # First, we need to prepend "result_data" to each key in the result_data
-    for key in list(result_data):
-        result_data[f"result_data.{key}"] = result_data.pop(key)
+    for key in list(json_data):
+        json_data[f"result_data.{key}"] = json_data.pop(key)
 
-    mongo.db.jobs.update_one({"job_id": job_id}, {"$set": result_data})
+    mongo.db.jobs.update_one({"job_id": job_id}, {"$set": json_data})
     return "OK"
 
 
 @v1.get("/result/<job_id>")
+@v1.output(schemas.Result)
 def result_get(job_id):
     """Return results for a specified job_id
 
@@ -177,7 +173,7 @@ def result_get(job_id):
         UUID as a string for the job
     """
     if not check_valid_uuid(job_id):
-        return "Invalid job id\n", 400
+        abort(400, message="Invalid job_id specified")
     response = mongo.db.jobs.find_one(
         {"job_id": job_id}, {"result_data": True, "_id": False}
     )
@@ -185,7 +181,7 @@ def result_get(job_id):
     if not response or not (results := response.get("result_data")):
         return "", 204
     results = response.get("result_data")
-    return jsonify(results)
+    return results
 
 
 @v1.post("/result/<job_id>/artifact")
@@ -261,13 +257,10 @@ def output_post(job_id):
     :param job_id:
         UUID as a string for the job
     :param data:
-        A list containing the lines of output to post
-
-    >>> output_post('foo')
-    ('Invalid job id\\n', 400)
+        A string containing the latest lines of output to post
     """
     if not check_valid_uuid(job_id):
-        return "Invalid job id\n", 400
+        abort(400, message="Invalid job_id specified")
     data = request.get_data().decode("utf-8")
     timestamp = datetime.utcnow()
     mongo.db.output.update_one(
@@ -298,7 +291,14 @@ def action_post(job_id, json_data):
 
 @v1.get("/agents/queues")
 def queues_get():
-    """Get a current list of all advertised queues from this server"""
+    """Get all advertised queues from this server
+
+    Returns a dict of queue names and descriptions, ex:
+    {
+        "some_queue": "A queue for testing",
+        "other_queue": "A queue for something else"
+    }
+    """
     all_queues = mongo.db.queues.find(
         {}, projection={"_id": False, "name": True, "description": True}
     )
@@ -328,7 +328,7 @@ def queues_post():
 
 @v1.get("/agents/images/<queue>")
 def images_get(queue):
-    """Get a list of known images for a given queue"""
+    """Get a dict of known images for a given queue"""
     queue_data = mongo.db.queues.find_one(
         {"name": queue}, {"_id": False, "images": True}
     )
@@ -339,19 +339,17 @@ def images_get(queue):
 @v1.post("/agents/images")
 def images_post():
     """Tell testflinger about known images for a specified queue
-    images will be stored in a list of key/value pairs as part of the queues
-    collection. That list will contain image_name:provision_data mappings, ex:
-    [
-        "name":"some_queue",
-        ...
-        "images": [
-            {"core22": "http://cdimage.ubuntu.com/.../core-22.tar.gz"},
-            {"jammy": "http://cdimage.ubuntu.com/.../ubuntu-22.04.tar.gz"}
-        ],
-        "other_queue": [
+    images will be stored in a dict of key/value pairs as part of the queues
+    collection. That dict will contain image_name:provision_data mappings, ex:
+    {
+        "some_queue": {
+            "core22": "http://cdimage.ubuntu.com/.../core-22.tar.gz",
+            "jammy": "http://cdimage.ubuntu.com/.../ubuntu-22.04.tar.gz"
+        },
+        "other_queue": {
             ...
-        ]
-    ]
+        }
+    }
     """
     image_dict = request.get_json()
     # We need to delete and recreate the images in case some were removed
@@ -433,14 +431,13 @@ def get_job(queue_list):
 @v1.get("/job/<job_id>/position")
 def job_position_get(job_id):
     """Return the position of the specified jobid in the queue"""
-    response, http_code = job_get_id(job_id)
-    if http_code != 200:
-        return response, http_code
-    job_data = response.json
-    if not job_data:
+    job_data, status = job_get_id(job_id)
+    if status == 204:
         return "Job not found or already started\n", 410
+    if status != 200:
+        return job_data
     try:
-        queue = job_data.get("job_queue")
+        queue = job_data.json.get("job_queue")
     except (AttributeError, TypeError):
         return "Invalid json returned for id: {}\n".format(job_id), 400
     # Get all jobs with job_queue=queue and return only the _id

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -122,6 +122,14 @@ def test_add_job_bad_job_queue(mongo_app):
     assert 422 == output.status_code
 
 
+def test_add_job_empty_queue(mongo_app):
+    """Test for error when adding a job with an empty queue"""
+    app, _ = mongo_app
+    output = app.post("/v1/job", json={"job_queue": ""})
+    assert "Invalid data or no job_queue specified" in output.text
+    assert 422 == output.status_code
+
+
 def test_result_get_result_not_exists(mongo_app):
     """Test for 204 when getting a nonexistent result"""
     app, _ = mongo_app


### PR DESCRIPTION
This uses schemas and apiflask to generate OpenAPI docs via a /docs link that you can browse to.  It covers most of the APIs along with the fields that they can accept and return. There are a few things that couldn't be fully specified because of the way the v1 api works.  For example, some things return string data, or return json but there are no predefined keys (queue/image mappings for example, use the queue name as the key). This should be considered in future revisions of the API to allow everything to be specified more easily.

I've handled all the changes needed for the unit tests to account for some data validation that happens automatically by using these schemas (such as 422 errors when we give it bad data). I've also tested this locally using a stress run that hits most of the api. However, we should definitely do a full integration test by deploying this to staging and put full runs through it before pushing to production.