### PR TITLE
Add fw upgrade test

### DIFF
--- a/extras/.gitignore
+++ b/extras/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.coverage
+*.pyc
+*.ini

--- a/extras/.gitignore
+++ b/extras/.gitignore
@@ -1,4 +1,0 @@
-__pycache__/
-.coverage
-*.pyc
-*.ini

--- a/extras/README
+++ b/extras/README
@@ -1,5 +1,8 @@
 # Device Firmware Upgrade Tool
 
+This is the prototype for firmware upgrade test. It will be temporarily placed in `/extras` folder until we figure out a proper way to merge it into device agent codes. 
+Currently, it only supports `fwupd/LVFS` update method on selected device types (DMI chassis type = All In One, Desktop) with selected OEM (HP, Dell, and Lenovo). Note that it hasn't be widely tested on all supported devices.
+
 ## How to use this tool directly
 ### Upgrade all firmware on the DUT to the latest version.
 `$ upgrade_fw.py upgrade $DEVICE_IP`

--- a/extras/README
+++ b/extras/README
@@ -1,0 +1,39 @@
+# Device Firmware Upgrade Tool
+
+## How to use this tool directly
+### Upgrade all firmware on the DUT to the latest version.
+`$ upgrade_fw.py upgrade $DEVICE_IP`
+
+### Downgrade all firmware on the DUT to the 2nd new version.
+`$ upgrade_fw.py upgrade $DEVICE_IP`
+
+### Detect DUT type and all updatable firmware, no upgrade/downgrade will be performed.
+`$ upgrade_fw.py detect $DEVICE_IP`
+
+### All usages:
+`$ upgrade_fw.py --help`
+
+## Log and output
+All logs (including commands output) can be found at `/tmp/upgrade_fw.log`
+
+## Use this tool with Testflinger
+Testflinger job yaml file example.
+```
+job_queue: <TF job queue name>
+provision_data:
+test_data:
+        test_cmds: |
+          sudo apt update && sudo apt install -y git
+          git clone -b main https://github.com/canonical/testflinger.git
+          cd testflinger/extras
+          ./upgrade_fw.py upgrade $DEVICE_IP
+          sudo cat /tmp/upgrade_fw.log
+reserve_data:
+```
+
+### Unit test and code coverage
+```
+$ python -m pip install coverage pytest pytest-cov
+# cd to testflinger/extras
+$ python -m coverage run -m pytest .
+```

--- a/extras/devices/LVFS/LVFS.py
+++ b/extras/devices/LVFS/LVFS.py
@@ -1,0 +1,332 @@
+import subprocess
+import json
+import time
+from devices.base import AbstractDevice, logger
+
+SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+
+class LVFSDevice(AbstractDevice):
+    fw_update_type = "LVFS"
+    vendor = ["HP", "Dell Inc.", "LENOVO"]
+    reboot_timeout = 600
+
+    def __init__(self, ipaddr, user, password):
+        super().__init__(ipaddr, user, password)
+        # self.run_cmd("sudo apt update && sudo apt install fwupd")
+
+    def run_cmd(self, cmd, raise_stderr=True, timeout=30):
+        """
+        Execute command on DUT via SSH
+
+        :returns: return code, stdout, stderr
+        :rtype: int, string, string
+        """
+        if self.password == "":
+            ssh_cmd = 'ssh -t %s %s@%s "%s"' % (
+                SSH_OPTS,
+                self.user,
+                self.ipaddr,
+                cmd,
+            )
+        else:
+            ssh_cmd = (
+                'sshpass -p %s  ssh -t %s %s@%s "%s"'
+                % (self.password, SSH_OPTS, self.user, self.ipaddr, cmd),
+            )
+        r = subprocess.run(
+            ssh_cmd,
+            shell=True,
+            capture_output=True,
+            timeout=timeout,
+        )
+        rc, stdout, stderr = (
+            r.returncode,
+            r.stdout.decode().strip(),
+            r.stderr.decode().strip(),
+        )
+        logger.debug("Run command: %s" % ssh_cmd)
+        if raise_stderr and rc != 0:
+            err_msg = "Failed to execute %s:\n [%d] %s %s" % (
+                cmd,
+                rc,
+                stdout,
+                stderr,
+            )
+            logger.debug(err_msg)
+            raise RuntimeError(err_msg)
+        else:
+            return rc, stdout, stderr
+
+    def get_fw_info(self):
+        """
+        Get current firmware version of all updatable devices on DUT
+        And print out devices with upgradable/downgradable versions
+        """
+        logger.info("collect firmware info")
+        self.run_cmd("sudo fwupdmgr refresh --force")
+        rc, stdout, stderr = self.run_cmd("sudo fwupdmgr get-devices --json")
+        logger.debug("$fwupdmgr get-devices = \n%s" % stdout)
+        for dev in json.loads(stdout)["Devices"]:
+            if "Flags" in dev:
+                if "updatable" in dev["Flags"]:
+                    self.fw_info.append(dev)
+
+        for dev in self.fw_info:
+            if "Version" in dev:
+                dev_name = dev["Name"] if "Name" in dev else dev["DeviceId"]
+                msg = "[%s] current version: %s" % (dev_name, dev["Version"])
+            else:
+                msg = ""
+            if "Releases" in dev:
+                higher_ver, lower_ver, same_ver = [], [], []
+                vers = ""
+                for rel in dev["Releases"]:
+                    if "Flags" not in rel:
+                        continue
+                    elif "is-upgrade" in rel["Flags"]:
+                        higher_ver.append(rel["Version"])
+                    elif (
+                        "is-downgrade"
+                        in rel["Flags"]
+                        # and "blocked-version" not in rel["Flags"]
+                    ):
+                        lower_ver.append(rel["Version"])
+                    else:
+                        same_ver.append(rel["Version"])
+                if higher_ver != []:
+                    vers = " - LVFS upgradable version(s): %s" % ", ".join(
+                        higher_ver
+                    )
+                if lower_ver != []:
+                    vers = (
+                        vers
+                        + " - LVFS downgradable version(s): %s"
+                        % ", ".join(lower_ver)
+                    )
+                if vers:
+                    msg = msg + vers
+                    print(msg)
+            else:
+                msg = msg + " - no available firmware on LVFS"
+            if msg:
+                logger.info(msg)
+
+    def upgrade(self):
+        """
+        Upgrade all devices firmware to latest version if available on LVFS
+
+        :returns: if reboot is required
+        :rtype: boolean
+        """
+        logger.info("start upgrading")
+        reboot = False
+        for dev in self.fw_info:
+            dev_name = dev["Name"] if "Name" in dev else dev["DeviceId"]
+            try:
+                latest_ver = dev["Releases"][0]
+            except KeyError:
+                continue
+            if dev["Version"] != latest_ver["Version"]:
+                if "is-upgrade" in latest_ver["Flags"]:
+                    logger.info(
+                        "[%s] try upgrading to %s"
+                        % (dev_name, latest_ver["Version"])
+                    )
+                    dev["targetVersion"] = latest_ver["Version"]
+                    rc, stdout, stderr = self.run_cmd(
+                        "sudo fwupdmgr upgrade %s -y --no-reboot-check"
+                        % dev["DeviceId"],
+                        raise_stderr=False,
+                    )
+                    if rc == 0:
+                        logger.debug(stdout)
+                        reboot = True
+                    else:
+                        logger.info(
+                            "[%s] Failed to upgrade %s"
+                            % (dev_name, latest_ver["Version"])
+                        )
+                        logger.debug(stdout)
+                        logger.debug(stderr)
+                else:
+                    logger.info(
+                        "[%s] unsupported Flags: %s"
+                        % (dev_name, str(latest_ver["Flags"]))
+                    )
+            else:
+                logger.info(
+                    "[%s] already the latest available firmware version"
+                    % dev_name
+                )
+        return reboot
+
+    def downgrade(self):
+        """
+        Downgrade all devices firmware to 2nd new version if available on LVFS
+
+        :returns: if reboot is required
+        :rtype: boolean
+        """
+        logger.info("start downgrading")
+        reboot = False
+        for dev in self.fw_info:
+            dev_name = dev["Name"] if "Name" in dev else dev["DeviceId"]
+            try:
+                prev_ver = dev["Releases"][1]
+            except KeyError:
+                continue
+            except IndexError:
+                continue
+            if dev["Version"] != prev_ver["Version"]:
+                if (
+                    "is-downgrade"
+                    in prev_ver["Flags"]
+                    # and "blocked-version" not in prev_ver["Flags"]
+                ):
+                    dev["targetVersion"] = prev_ver["Version"]
+                    logger.info(
+                        "[%s] try downgrading to %s"
+                        % (dev_name, prev_ver["Version"])
+                    )
+                    rc, stdout, stderr = self.run_cmd(
+                        "sudo fwupdmgr download %s" % prev_ver["Uri"],
+                        raise_stderr=False,
+                    )
+                    if rc == 0:
+                        pass
+                    elif rc == 1 and "already exists" in stderr:
+                        pass
+                    else:
+                        raise RuntimeError(
+                            "[%s] fail to download firmware file from LVFS\ntarget: %s\nerror: %s"
+                            % (dev_name, prev_ver["Uri"], stdout)
+                        )
+                    rc, stdout, stderr = self.run_cmd(
+                        "sudo fwupdmgr install %s -y --no-reboot-check --allow-older"
+                        % prev_ver["Uri"].split("/")[-1],
+                        raise_stderr=False,
+                    )
+                    if rc == 0:
+                        logger.debug(stdout)
+                        reboot = True
+                    else:
+                        logger.info(
+                            "[%s] fail to force install (downgrade) firmware %s"
+                            % (dev_name, prev_ver["Uri"].split("/")[-1])
+                        )
+                        logger.debug(stdout)
+                        logger.debug(stderr)
+                else:
+                    logger.info(
+                        "[%s] unsupported Flags: %s"
+                        % (dev_name, str(prev_ver["Flags"]))
+                    )
+            else:
+                logger.info(
+                    "[%s] already the previous version of latest release"
+                    % dev_name
+                )
+        return reboot
+
+    def check_results(self):
+        """
+        Get upgrade/downgrade result and validate if it succeeds
+
+        :returns: overall upgrade status
+        :rtype: boolean
+        """
+        fwupd_result = True
+        for dev in self.fw_info:
+            try:
+                dev_name = dev["Name"]
+            except KeyError:
+                dev_name = dev["DeviceId"]
+            try:
+                expected_ver = dev["targetVersion"]
+            except KeyError:
+                continue
+            rc, stdout, stderr = self.run_cmd(
+                "sudo fwupdmgr get-results %s --json" % dev["DeviceId"]
+            )
+            get_results = json.loads(stdout)
+            logger.debug("$fwupdmgr get-result = \n%s" % stdout)
+            try:
+                new_fw = get_results["Releases"][0]
+                update_state = get_results["UpdateState"]
+            except KeyError:
+                msg = "[%s] unable to determine if new firmware is landed due to missing results"
+                logger.info(msg)
+                print(msg)
+                fwupd_result = False
+                continue
+
+            if new_fw["Version"] == expected_ver and update_state == 2:
+                msg = "[%s] firmware flashed %s → %s" % (
+                    dev_name,
+                    dev["Version"],
+                    expected_ver,
+                )
+            else:
+                FwupdUpdateState = [
+                    "FWUPD_UPDATE_STATE_UNKNOWN",
+                    "FWUPD_UPDATE_STATE_PENDING",
+                    "FWUPD_UPDATE_STATE_SUCCESS",
+                    "FWUPD_UPDATE_STATE_FAILED",
+                    "FWUPD_UPDATE_STATE_NEEDS_REBOOT",
+                    "FWUPD_UPDATE_STATE_FAILED_TRANSIENT",
+                    "FWUPD_UPDATE_STATE_LAST",
+                ]
+                msg = "[%s] firmware upgrade failed. %s" % (
+                    dev_name,
+                    FwupdUpdateState[update_state],
+                )
+                fwupd_result = False
+            print(msg)
+            logger.info(msg)
+
+        return fwupd_result
+
+    def check_connectable(self, timeout):
+        """
+        After DUT reboot, check if SSH to DUT works within a given timeout period
+
+        :param timeout: wait time for regaining DUT access
+        :type timeout: int
+        """
+        logger.info(
+            "check and wait for %ss until SSH is connectable" % timeout
+        )
+        status = "1"
+        timeout_start = time.time()
+
+        while status != "0" and time.time() < timeout_start + timeout:
+            status = subprocess.check_output(
+                "timeout 10 ssh %s %s@%s /bin/true 2>/dev/null; echo $?"
+                % (SSH_OPTS, self.user, self.ipaddr),
+                shell=True,
+                universal_newlines=True,
+            ).strip()
+        if status != "0":
+            logger.error(f"Failed to SSH to {self.ipaddr} after {timeout}s")
+            raise RuntimeError(
+                f"Failed to SSH to {self.ipaddr} after {timeout}s"
+            )
+        else:
+            delta = time.time() - timeout_start
+            logger.info(f"{self.ipaddr} is SSHable after {int(delta)}s")
+
+    def reboot(self):
+        logger.info("reboot DUT")
+        self.run_cmd("sudo reboot", raise_stderr=False)
+        time.sleep(10)
+        self.check_connectable(self.reboot_timeout)
+
+
+class LenovoNB(LVFSDevice):
+    fw_update_type = "LVFS-ext"
+    vendor = "LENOVO"
+
+
+# class HPNB(LVFSDevice):
+# class DellNB(LVFSDevice)

--- a/extras/devices/LVFS/LVFS.py
+++ b/extras/devices/LVFS/LVFS.py
@@ -13,7 +13,6 @@ class LVFSDevice(AbstractDevice):
 
     def __init__(self, ipaddr, user, password):
         super().__init__(ipaddr, user, password)
-        # self.run_cmd("sudo apt update && sudo apt install fwupd")
 
     def run_cmd(self, cmd, raise_stderr=True, timeout=30):
         """
@@ -23,17 +22,10 @@ class LVFSDevice(AbstractDevice):
         :rtype: int, string, string
         """
         if self.password == "":
-            ssh_cmd = 'ssh -t %s %s@%s "%s"' % (
-                SSH_OPTS,
-                self.user,
-                self.ipaddr,
-                cmd,
-            )
+            ssh_cmd = f'ssh -t {SSH_OPTS} {self.user}@{self.ipaddr} "{cmd}"'
         else:
-            ssh_cmd = (
-                'sshpass -p %s  ssh -t %s %s@%s "%s"'
-                % (self.password, SSH_OPTS, self.user, self.ipaddr, cmd),
-            )
+            ssh_cmd = f'sshpass -p {self.password}  ssh -t {SSH_OPTS} {self.user}@{self.ipaddr} "{cmd}"'
+        logger.debug(f"Run command: {ssh_cmd}")
         r = subprocess.run(
             ssh_cmd,
             shell=True,
@@ -45,37 +37,43 @@ class LVFSDevice(AbstractDevice):
             r.stdout.decode().strip(),
             r.stderr.decode().strip(),
         )
-        logger.debug("Run command: %s" % ssh_cmd)
         if raise_stderr and rc != 0:
-            err_msg = "Failed to execute %s:\n [%d] %s %s" % (
-                cmd,
-                rc,
-                stdout,
-                stderr,
-            )
+            err_msg = f"Failed to execute {cmd}:\n [{rc}] {stdout} {stderr}"
             logger.debug(err_msg)
             raise RuntimeError(err_msg)
-        else:
-            return rc, stdout, stderr
+        return rc, stdout, stderr
 
     def get_fw_info(self):
         """
-        Get current firmware version of all updatable devices on DUT
-        And print out devices with upgradable/downgradable versions
+        Get current firmware version of all updatable devices on DUT, and print
+        out devices with upgradable/downgradable versions
         """
+        self._install_fwupd()
         logger.info("collect firmware info")
         self.run_cmd("sudo fwupdmgr refresh --force")
         rc, stdout, stderr = self.run_cmd("sudo fwupdmgr get-devices --json")
-        logger.debug("$fwupdmgr get-devices = \n%s" % stdout)
-        for dev in json.loads(stdout)["Devices"]:
-            if "Flags" in dev:
-                if "updatable" in dev["Flags"]:
-                    self.fw_info.append(dev)
+        logger.debug(f"$fwupdmgr get-devices = \n{stdout}")
+        self._parse_fwupd_raw(stdout)
+
+    def _install_fwupd(self):
+        self.run_cmd("sudo apt update", timeout=120)
+        self.run_cmd("sudo apt install -y fwupd")
+        rc, stdout, stderr = self.run_cmd("sudo fwupdmgr --version")
+        logger.debug(stdout)
+
+    def _parse_fwupd_raw(self, fwupd_raw: str):
+        """
+        Parse the output of $fwupdmgr get-devices
+
+        """
+        for dev in json.loads(fwupd_raw)["Devices"]:
+            if "Flags" in dev and "updatable" in dev["Flags"]:
+                self.fw_info.append(dev)
 
         for dev in self.fw_info:
             if "Version" in dev:
                 dev_name = dev["Name"] if "Name" in dev else dev["DeviceId"]
-                msg = "[%s] current version: %s" % (dev_name, dev["Version"])
+                msg = f"[{dev_name}] current version: {dev['Version']}"
             else:
                 msg = ""
             if "Releases" in dev:
@@ -95,20 +93,14 @@ class LVFSDevice(AbstractDevice):
                     else:
                         same_ver.append(rel["Version"])
                 if higher_ver != []:
-                    vers = " - LVFS upgradable version(s): %s" % ", ".join(
-                        higher_ver
-                    )
+                    vers = f" - LVFS upgradable version(s): {', '.join(higher_ver)}"
                 if lower_ver != []:
-                    vers = (
-                        vers
-                        + " - LVFS downgradable version(s): %s"
-                        % ", ".join(lower_ver)
-                    )
+                    vers += f" - LVFS downgradable version(s): {', '.join(lower_ver)}"
                 if vers:
-                    msg = msg + vers
+                    msg += vers
                     print(msg)
             else:
-                msg = msg + " - no available firmware on LVFS"
+                msg = f"{msg} - no available firmware on LVFS"
             if msg:
                 logger.info(msg)
 
@@ -130,13 +122,11 @@ class LVFSDevice(AbstractDevice):
             if dev["Version"] != latest_ver["Version"]:
                 if "is-upgrade" in latest_ver["Flags"]:
                     logger.info(
-                        "[%s] try upgrading to %s"
-                        % (dev_name, latest_ver["Version"])
+                        f"[{dev_name}] try upgrading to {latest_ver['Version']}"
                     )
                     dev["targetVersion"] = latest_ver["Version"]
                     rc, stdout, stderr = self.run_cmd(
-                        "sudo fwupdmgr upgrade %s -y --no-reboot-check"
-                        % dev["DeviceId"],
+                        f"sudo fwupdmgr upgrade {dev['DeviceId']} -y --no-reboot-check",
                         raise_stderr=False,
                     )
                     if rc == 0:
@@ -144,20 +134,17 @@ class LVFSDevice(AbstractDevice):
                         reboot = True
                     else:
                         logger.info(
-                            "[%s] Failed to upgrade %s"
-                            % (dev_name, latest_ver["Version"])
+                            f"[{dev_name}] Failed to upgrade {latest_ver['Version']}"
                         )
                         logger.debug(stdout)
                         logger.debug(stderr)
                 else:
                     logger.info(
-                        "[%s] unsupported Flags: %s"
-                        % (dev_name, str(latest_ver["Flags"]))
+                        f"[{dev_name}] unsupported Flags: {str(latest_ver['Flags'])}"
                     )
             else:
                 logger.info(
-                    "[%s] already the latest available firmware version"
-                    % dev_name
+                    f"[{dev_name}] already the latest available firmware version"
                 )
         return reboot
 
@@ -174,9 +161,7 @@ class LVFSDevice(AbstractDevice):
             dev_name = dev["Name"] if "Name" in dev else dev["DeviceId"]
             try:
                 prev_ver = dev["Releases"][1]
-            except KeyError:
-                continue
-            except IndexError:
+            except (KeyError, IndexError):
                 continue
             if dev["Version"] != prev_ver["Version"]:
                 if (
@@ -185,12 +170,12 @@ class LVFSDevice(AbstractDevice):
                     # and "blocked-version" not in prev_ver["Flags"]
                 ):
                     dev["targetVersion"] = prev_ver["Version"]
+                    fw_file = prev_ver["Uri"].split("/")[-1]
                     logger.info(
-                        "[%s] try downgrading to %s"
-                        % (dev_name, prev_ver["Version"])
+                        f"[{dev_name}] try downgrading to {prev_ver['Version']}"
                     )
                     rc, stdout, stderr = self.run_cmd(
-                        "sudo fwupdmgr download %s" % prev_ver["Uri"],
+                        f"sudo fwupdmgr download {prev_ver['Uri']}",
                         raise_stderr=False,
                     )
                     if rc == 0:
@@ -199,12 +184,10 @@ class LVFSDevice(AbstractDevice):
                         pass
                     else:
                         raise RuntimeError(
-                            "[%s] fail to download firmware file from LVFS\ntarget: %s\nerror: %s"
-                            % (dev_name, prev_ver["Uri"], stdout)
+                            f"[{dev_name}] fail to download firmware file from LVFS\ntarget: {prev_ver['Uri']}\nerror: {stdout}"
                         )
                     rc, stdout, stderr = self.run_cmd(
-                        "sudo fwupdmgr install %s -y --no-reboot-check --allow-older"
-                        % prev_ver["Uri"].split("/")[-1],
+                        f"sudo fwupdmgr install {fw_file} -y --no-reboot-check --allow-older",
                         raise_stderr=False,
                     )
                     if rc == 0:
@@ -212,20 +195,17 @@ class LVFSDevice(AbstractDevice):
                         reboot = True
                     else:
                         logger.info(
-                            "[%s] fail to force install (downgrade) firmware %s"
-                            % (dev_name, prev_ver["Uri"].split("/")[-1])
+                            f"[{dev_name}] fail to force install (downgrade) firmware {fw_file}"
                         )
                         logger.debug(stdout)
                         logger.debug(stderr)
                 else:
                     logger.info(
-                        "[%s] unsupported Flags: %s"
-                        % (dev_name, str(prev_ver["Flags"]))
+                        f"[{dev_name}] unsupported Flags: {prev_ver['Flags']}"
                     )
             else:
                 logger.info(
-                    "[%s] already the previous version of latest release"
-                    % dev_name
+                    f"[{dev_name}] already the previous version of latest release"
                 )
         return reboot
 
@@ -247,26 +227,22 @@ class LVFSDevice(AbstractDevice):
             except KeyError:
                 continue
             rc, stdout, stderr = self.run_cmd(
-                "sudo fwupdmgr get-results %s --json" % dev["DeviceId"]
+                f"sudo fwupdmgr get-results {dev['DeviceId']} --json"
             )
             get_results = json.loads(stdout)
-            logger.debug("$fwupdmgr get-result = \n%s" % stdout)
+            logger.debug(f"$fwupdmgr get-result = \n{stdout}")
             try:
                 new_fw = get_results["Releases"][0]
                 update_state = get_results["UpdateState"]
             except KeyError:
-                msg = "[%s] unable to determine if new firmware is landed due to missing results"
+                msg = f"[{dev_name}] unable to determine if new firmware is landed due to missing results"
                 logger.info(msg)
                 print(msg)
                 fwupd_result = False
                 continue
 
             if new_fw["Version"] == expected_ver and update_state == 2:
-                msg = "[%s] firmware flashed %s → %s" % (
-                    dev_name,
-                    dev["Version"],
-                    expected_ver,
-                )
+                msg = f"[{dev_name}] firmware flashed {dev['Version']} → {expected_ver}"
             else:
                 FwupdUpdateState = [
                     "FWUPD_UPDATE_STATE_UNKNOWN",
@@ -277,10 +253,7 @@ class LVFSDevice(AbstractDevice):
                     "FWUPD_UPDATE_STATE_FAILED_TRANSIENT",
                     "FWUPD_UPDATE_STATE_LAST",
                 ]
-                msg = "[%s] firmware upgrade failed. %s" % (
-                    dev_name,
-                    FwupdUpdateState[update_state],
-                )
+                msg = f"[{dev_name}] firmware upgrade failed. {FwupdUpdateState[update_state]}"
                 fwupd_result = False
             print(msg)
             logger.info(msg)
@@ -294,16 +267,13 @@ class LVFSDevice(AbstractDevice):
         :param timeout: wait time for regaining DUT access
         :type timeout: int
         """
-        logger.info(
-            "check and wait for %ss until SSH is connectable" % timeout
-        )
+        logger.info(f"check and wait for {timeout}s until SSH is connectable")
         status = "1"
         timeout_start = time.time()
 
         while status != "0" and time.time() < timeout_start + timeout:
             status = subprocess.check_output(
-                "timeout 10 ssh %s %s@%s /bin/true 2>/dev/null; echo $?"
-                % (SSH_OPTS, self.user, self.ipaddr),
+                f"timeout 10 ssh {SSH_OPTS} {self.user}@{self.ipaddr} /bin/true 2>/dev/null; echo $?",
                 shell=True,
                 universal_newlines=True,
             ).strip()
@@ -312,9 +282,8 @@ class LVFSDevice(AbstractDevice):
             raise RuntimeError(
                 f"Failed to SSH to {self.ipaddr} after {timeout}s"
             )
-        else:
-            delta = time.time() - timeout_start
-            logger.info(f"{self.ipaddr} is SSHable after {int(delta)}s")
+        delta = time.time() - timeout_start
+        logger.info(f"{self.ipaddr} is SSHable after {int(delta)}s")
 
     def reboot(self):
         logger.info("reboot DUT")

--- a/extras/devices/LVFS/LVFS.py
+++ b/extras/devices/LVFS/LVFS.py
@@ -5,6 +5,7 @@ import subprocess
 import json
 import time
 from devices.base import AbstractDevice, logger
+from typing import Tuple
 
 SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
@@ -21,7 +22,7 @@ class LVFSDevice(AbstractDevice):
 
     def run_cmd(
         self, cmd: str, raise_stderr: bool = True, timeout: int = 30
-    ) -> tuple[int, str, str]:
+    ) -> Tuple[int, str, str]:
         """
         Execute command on the DUT via SSH
 
@@ -35,7 +36,7 @@ class LVFSDevice(AbstractDevice):
             ssh_cmd = f'ssh -t {SSH_OPTS} {self.user}@{self.ipaddr} "{cmd}"'
         else:
             ssh_cmd = f'sshpass -p {self.password}  ssh -t {SSH_OPTS} {self.user}@{self.ipaddr} "{cmd}"'
-        logger.debug("Run command: %s" % ssh_cmd)
+        logger.debug("Run command: %s", ssh_cmd)
         r = subprocess.run(
             ssh_cmd,
             shell=True,
@@ -62,7 +63,7 @@ class LVFSDevice(AbstractDevice):
         logger.info("collect firmware info")
         self.run_cmd("sudo fwupdmgr refresh --force")
         rc, stdout, stderr = self.run_cmd("sudo fwupdmgr get-devices --json")
-        logger.debug("$fwupdmgr get-devices = \n%s" % stdout)
+        logger.debug("$fwupdmgr get-devices = \n%s", stdout)
         self._parse_fwupd_raw(stdout)
 
     def _install_fwupd(self):
@@ -129,8 +130,9 @@ class LVFSDevice(AbstractDevice):
             if dev["Version"] != latest_ver["Version"]:
                 if "is-upgrade" in latest_ver["Flags"]:
                     logger.info(
-                        "[%s] try upgrading to %s"
-                        % (dev_name, latest_ver["Version"])
+                        "[%s] try upgrading to %s",
+                        dev_name,
+                        latest_ver["Version"],
                     )
                     dev["targetVersion"] = latest_ver["Version"]
                     rc, stdout, stderr = self.run_cmd(
@@ -142,20 +144,22 @@ class LVFSDevice(AbstractDevice):
                         reboot = True
                     else:
                         logger.error(
-                            "[%s] Failed to upgrade %s"
-                            % (dev_name, latest_ver["Version"])
+                            "[%s] Failed to upgrade %s",
+                            dev_name,
+                            latest_ver["Version"],
                         )
                         logger.debug(stdout)
                         logger.debug(stderr)
                 else:
                     logger.debug(
-                        "[%s] unsupported Flags: %s"
-                        % (dev_name, str(latest_ver["Flags"]))
+                        "[%s] unsupported Flags: %s",
+                        dev_name,
+                        str(latest_ver["Flags"]),
                     )
             else:
                 logger.info(
-                    "[%s] already the latest available firmware version"
-                    % dev_name
+                    "[%s] already the latest available firmware version",
+                    dev_name,
                 )
         return reboot
 
@@ -179,8 +183,8 @@ class LVFSDevice(AbstractDevice):
                     dev["targetVersion"] = prev_ver["Version"]
                     fw_file = prev_ver["Uri"].split("/")[-1]
                     logger.info(
-                        "[%s] try downgrading to {prev_ver['Version']}"
-                        % dev_name
+                        "[%s] try downgrading to {prev_ver['Version']}",
+                        dev_name,
                     )
                     rc, stdout, stderr = self.run_cmd(
                         f"sudo fwupdmgr download {prev_ver['Uri']}",
@@ -201,20 +205,22 @@ class LVFSDevice(AbstractDevice):
                         reboot = True
                     else:
                         logger.error(
-                            "[%s] fail to force install (downgrade) firmware %s"
-                            % (dev_name, fw_file)
+                            "[%s] fail to force install (downgrade) firmware %s",
+                            dev_name,
+                            fw_file,
                         )
                         logger.debug(stdout)
                         logger.debug(stderr)
                 else:
                     logger.debug(
-                        "[%s] unsupported Flags: %s"
-                        % (dev_name, prev_ver["Flags"])
+                        "[%s] unsupported Flags: %s",
+                        dev_name,
+                        prev_ver["Flags"],
                     )
             else:
                 logger.info(
-                    "[%s] already the previous version of latest release"
-                    % dev_name
+                    "[%s] already the previous version of latest release",
+                    dev_name,
                 )
         return reboot
 
@@ -238,7 +244,7 @@ class LVFSDevice(AbstractDevice):
                 f"sudo fwupdmgr get-results {dev['DeviceId']} --json"
             )
             get_results = json.loads(stdout)
-            logger.debug("$fwupdmgr get-result = \n%s" % stdout)
+            logger.debug("$fwupdmgr get-result = \n%s", stdout)
             try:
                 new_fw = get_results["Releases"][0]
                 update_state = get_results["UpdateState"]
@@ -274,9 +280,7 @@ class LVFSDevice(AbstractDevice):
 
         :param timeout: wait time for regaining DUT access
         """
-        logger.info(
-            "check and wait for %ss until SSH is connectable" % timeout
-        )
+        logger.info("check and wait for %ss until SSH is connectable", timeout)
         status = "1"
         timeout_start = time.time()
 
@@ -291,7 +295,7 @@ class LVFSDevice(AbstractDevice):
             logger.error(err_msg)
             raise RuntimeError(err_msg)
         delta = time.time() - timeout_start
-        logger.info("%s is SSHable after %ss" % (self.ipaddr, int(delta)))
+        logger.info("%s is SSHable after %ss", self.ipaddr, int(delta))
 
     def reboot(self):
         """Reboot the DUT from OS"""

--- a/extras/devices/LVFS/tests/fwupd_data.py
+++ b/extras/devices/LVFS/tests/fwupd_data.py
@@ -1,7 +1,7 @@
 """ fwupdmgr json outputs """
 
 
-get_results = """{
+GET_RESULTS_RESPONSE_DATA = """{
   "Name" : "System Firmware",
   "DeviceId" : "a45df35ac0e948ee180fe216a5f703f32dda163f",
   "Guid" : [
@@ -68,7 +68,7 @@ get_results = """{
 }
 """
 
-get_results_err = """
+GET_RESULTS_ERROR_RESPONSE_DATA = """
 {
   "Error" : {
     "Domain" : "FwupdError",
@@ -78,7 +78,7 @@ get_results_err = """
 }
 """
 
-get_device = """{
+GET_DEVICES_RESPONSE_DATA = """{
   "Devices" : [
     {
       "Name" : "Core™ i7-9800X CPU @ 3.80GHz",

--- a/extras/devices/LVFS/tests/fwupd_data.py
+++ b/extras/devices/LVFS/tests/fwupd_data.py
@@ -1,0 +1,387 @@
+""" fwupdmgr json outputs """
+
+
+get_results = """{
+  "Name" : "System Firmware",
+  "DeviceId" : "a45df35ac0e948ee180fe216a5f703f32dda163f",
+  "Guid" : [
+    "37c94477-30f8-42df-96f9-5e417cc49274"
+  ],
+  "Plugin" : "uefi_capsule",
+  "Flags" : [
+    "internal",
+    "updatable",
+    "require-ac",
+    "needs-reboot",
+    "historical",
+    "can-verify",
+    "usable-during-update"
+  ],
+  "Checksums" : [
+    "d655d59f250f7e15a90afb08f348ae428b9a37c1"
+  ],
+  "Version" : "2.91",
+  "Created" : 1694166016,
+  "Modified" : 1694166169,
+  "UpdateState" : 2,
+  "Releases" : [
+    {
+      "Version" : "2.90",
+      "Checksum" : [
+        "6232b2a43b22966b179f9b5a8f459731c37d7b8f"
+      ],
+      "LastAttemptVersion" : "0x2005a",
+      "TpmFamily" : "2.0",
+      "LastAttemptStatus" : "0x0",
+      "RuntimeVersion(org.kernel)" : "5.10.0-1023-oem",
+      "DistroVersion" : "20.04",
+      "RuntimeVersion(org.freedesktop.fwupd)" : "1.7.9",
+      "Pcr0_SHA1" : "d655d59f250f7e15a90afb08f348ae428b9a37c1",
+      "UEFIUXCapsule" : "Enabled",
+      "CpuArchitecture" : "x86_64",
+      "SecureBoot" : "Disabled",
+      "HostFamily" : "103C_53335X HP Workstation",
+      "HostVendor" : "HP",
+      "RuntimeVersion(org.freedesktop.gusb)" : "0.3.4",
+      "FwupdTainted" : "False",
+      "RuntimeVersion(com.dell.libsmbios)" : "2.4",
+      "MissingCapsuleHeader" : "False",
+      "CompileVersion(org.freedesktop.gusb)" : "0.3.4",
+      "FwupdSupported" : "True",
+      "KernelVersion" : "5.10.0-1023-oem",
+      "TpmEventLog" : "0x00000008 88f88963e20ba2063edbf78215e9f90f37c551cd",
+      "EspPath" : "/boot/efi",
+      "HostProduct" : "HP Z4 G4 Workstation",
+      "BootTime" : "1694165999",
+      "KernelName" : "Linux",
+      "CapsuleApplyMethod" : "nvram",
+      "LinuxLockdown" : "none",
+      "CompileVersion(com.hughsie.libjcat)" : "0.1.4",
+      "Pcr0_SHA256" : "580aaf47328accd895515cc0143903c7e88579769d319a511ca9567575bd547f",
+      "EfivarNvramUsed" : "100530",
+      "KernelCmdline" : "automatic-oem-config",
+      "DistroId" : "ubuntu",
+      "CompileVersion(org.freedesktop.fwupd)" : "1.7.9",
+      "HostSku" : "8DZ51UT#ABA"
+    }
+  ]
+}
+"""
+
+get_results_err = """
+{
+  "Error" : {
+    "Domain" : "FwupdError",
+    "Code" : 9,
+    "Message" : "Failed to find 4bde70ba4e39b28f9eab1628f9dd6e6244c03027 in history database: No devices found"
+  }
+}
+"""
+
+get_device = """{
+  "Devices" : [
+    {
+      "Name" : "Core™ i7-9800X CPU @ 3.80GHz",
+      "DeviceId" : "4bde70ba4e39b28f9eab1628f9dd6e6244c03027",
+      "Guid" : [
+        "b9a2dd81-159e-5537-a7db-e7101d164d3f",
+        "30249f37-d140-5d3e-9319-186b1bd5cac3",
+        "aeac0d3d-a127-52d8-9745-891104b2ec28",
+        "1c7713d4-3bd2-5032-b9cc-291671aba257"
+      ],
+      "Plugin" : "cpu",
+      "Flags" : [
+        "internal",
+        "registered"
+      ],
+      "Vendor" : "Intel",
+      "VersionFormat" : "hex",
+      "Icons" : [
+        "computer"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "DVDRW GUD1N",
+      "DeviceId" : "612faa85309fec62ddfdce9f4635cdfef838d74e",
+      "Guid" : [
+        "bcb713aa-ecde-5359-a2e5-49fe84787374",
+        "57ac0a58-5421-53ce-ac80-4566d4e1e6e3"
+      ],
+      "Summary" : "SCSI device",
+      "Plugin" : "scsi",
+      "Flags" : [
+        "registered"
+      ],
+      "Vendor" : "hp HLDS",
+      "VendorId" : "SCSI:hp-HLDS",
+      "Version" : "LD06",
+      "VersionFormat" : "plain",
+      "Icons" : [
+        "drive-harddisk"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "GP104GL [Quadro P5000]",
+      "DeviceId" : "3c07caee1bce434f1160c260ba0a471f60d66961",
+      "Guid" : [
+        "643cf998-eaee-5c6f-b403-8370b5f04f10",
+        "0e71595a-45dd-58cc-aed4-a29cd1e0176d",
+        "38458a57-3a97-53fa-824a-ba3809471a07",
+        "0ed83a18-0bb5-590e-aae1-7d07ca60a280"
+      ],
+      "Plugin" : "optionrom",
+      "Flags" : [
+        "internal",
+        "registered",
+        "can-verify",
+        "can-verify-image"
+      ],
+      "Vendor" : "NVIDIA Corporation",
+      "VendorId" : "PCI:0x10DE",
+      "Version" : "a1",
+      "VersionFormat" : "plain",
+      "Icons" : [
+        "audio-card"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "MZVLB256HBHQ-000H1",
+      "DeviceId" : "599ead362818be284e800cbc30d4c29f934086c3",
+      "Guid" : [
+        "0b4d773a-7ac3-58c1-a541-e22ef1cdfe02",
+        "c9d531ea-ee7d-5562-8def-c64d0d144813",
+        "6e54c992-d302-59ab-b454-2d26ddd63e6d",
+        "47335265-a509-51f7-841e-1c94911af66b",
+        "e803e58a-cbd1-5b1c-b60b-dc4cd6e985d7"
+      ],
+      "Serial" : "S4GNNX0NC13964",
+      "Summary" : "NVM Express solid state drive",
+      "Plugin" : "nvme",
+      "Protocol" : "org.nvmexpress",
+      "Flags" : [
+        "internal",
+        "updatable",
+        "require-ac",
+        "registered",
+        "needs-reboot",
+        "usable-during-update",
+        "signed-payload"
+      ],
+      "Vendor" : "Samsung",
+      "VendorId" : "NVME:0x144D",
+      "Version" : "HPS0NEXH",
+      "VersionFormat" : "plain",
+      "Icons" : [
+        "drive-harddisk"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "SanDisk 3.2Gen1",
+      "DeviceId" : "136108aa898cf18c2d6c51fb0d3942fcab13055b",
+      "Guid" : [
+        "9d4068a9-9553-59a2-ad7f-b19922d584b1",
+        "b861e037-c38d-56ea-adaf-b2325ee6b96b"
+      ],
+      "Summary" : "SCSI device",
+      "Plugin" : "scsi",
+      "Flags" : [
+        "registered"
+      ],
+      "Vendor" : "USB",
+      "VendorId" : "SCSI:USB",
+      "Version" : "1.00",
+      "VersionFormat" : "plain",
+      "Icons" : [
+        "drive-harddisk"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "System Firmware",
+      "DeviceId" : "a45df35ac0e948ee180fe216a5f703f32dda163f",
+      "Guid" : [
+        "37c94477-30f8-42df-96f9-5e417cc49274",
+        "230c8b18-8d9b-53ec-838b-6cfc0383493a"
+      ],
+      "Summary" : "UEFI ESRT device",
+      "Plugin" : "uefi_capsule",
+      "Protocol" : "org.uefi.capsule",
+      "Flags" : [
+        "internal",
+        "updatable",
+        "require-ac",
+        "supported",
+        "registered",
+        "needs-reboot",
+        "can-verify",
+        "usable-during-update"
+      ],
+      "Checksums" : [
+        "88168c9e2b47f7560125cd6f811a9b4390f8bc70",
+        "3bc12536624150ef382938f92ca0d3d80aed712552ae89cc8957d884d9372315"
+      ],
+      "Vendor" : "HP",
+      "VendorId" : "DMI:HP",
+      "Version" : "2.90",
+      "VersionLowest" : "0.1",
+      "VersionFormat" : "pair",
+      "VersionRaw" : 131162,
+      "VersionLowestRaw" : 1,
+      "Icons" : [
+        "computer"
+      ],
+      "Created" : 1693535931,
+      "UpdateState" : 2,
+      "Releases" : [
+        {
+          "AppstreamId" : "com.hp.workstation.P62.firmware",
+          "ReleaseId" : "28623",
+          "RemoteId" : "lvfs",
+          "Name" : "Z4 G4 Core-X Workstation",
+          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations (Core X-series processors), family P62",
+          "Description" : "<p>Fixes and enhancements in P62 2.91:</p><ul><li>Includes enhancements to mitigate security vulnerabilities.</li><li>Added support for a new DIMM manufacturer.</li><li>Added support for HP Anyware Remote System Controller features.</li></ul>",
+          "Version" : "2.91",
+          "Filename" : "9af72a66c38ab97ed17f1388582eb6baa0929295",
+          "Protocol" : "org.uefi.capsule",
+          "Categories" : [
+            "X-System"
+          ],
+          "Checksum" : [
+            "5ffa48e85b1bbb98a4a911643cd4a690194fee97",
+            "2571fa9e4ca038aa41c86ded57d355a70d1da3a02bcd12aa02b9c5ab84d8a2ee"
+          ],
+          "License" : "LicenseRef-proprietary",
+          "Size" : 16781312,
+          "Created" : 1679514694,
+          "Locations" : [
+            "https://fwupd.org/downloads/2571fa9e4ca038aa41c86ded57d355a70d1da3a02bcd12aa02b9c5ab84d8a2ee-P62_0291.cab"
+          ],
+          "Uri" : "https://fwupd.org/downloads/2571fa9e4ca038aa41c86ded57d355a70d1da3a02bcd12aa02b9c5ab84d8a2ee-P62_0291.cab",
+          "Homepage" : "http://www.hp.com/go/workstations",
+          "Vendor" : "HP",
+          "Flags" : [
+            "is-upgrade"
+          ]
+        },
+        {
+          "AppstreamId" : "com.hp.workstation.P62.firmware",
+          "ReleaseId" : "22717",
+          "RemoteId" : "lvfs",
+          "Name" : "Z4 G4 Core-X Workstation",
+          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations (Core X-series processors), family P62",
+          "Description" : "<p>Fixes and enhancements in P62 2.90:</p><ul><li>Added SATA hot plug support.</li><li>Includes enhancements to mitigate security vulnerabilities.</li><li>HP strongly recommends promptly transitioning to this updated BIOS version.</li><li>Updates UEFI-based Hardware Diagnostics to version 2.3.2.0&gt;</li><li>Addressed changes introduced in previous BIOS which prevented a custom logo from being set.</li></ul>",
+          "Version" : "2.90",
+          "Filename" : "ba3142d342afce4c5bde21ee469871156cb8add3",
+          "Protocol" : "org.uefi.capsule",
+          "Categories" : [
+            "X-System"
+          ],
+          "Checksum" : [
+            "6232b2a43b22966b179f9b5a8f459731c37d7b8f",
+            "90c505fd9b6f56311a4202d8fb95e711ab240dfcd50b0ff82a9ebe5f4750eed6"
+          ],
+          "License" : "LicenseRef-proprietary",
+          "Size" : 16781312,
+          "Created" : 1675389026,
+          "Locations" : [
+            "https://fwupd.org/downloads/90c505fd9b6f56311a4202d8fb95e711ab240dfcd50b0ff82a9ebe5f4750eed6-P62_0290.cab"
+          ],
+          "Uri" : "https://fwupd.org/downloads/90c505fd9b6f56311a4202d8fb95e711ab240dfcd50b0ff82a9ebe5f4750eed6-P62_0290.cab",
+          "Homepage" : "http://www.hp.com/go/workstations",
+          "Vendor" : "HP"
+        },
+        {
+          "AppstreamId" : "com.hp.workstation.P62.firmware",
+          "ReleaseId" : "14966",
+          "RemoteId" : "lvfs",
+          "Name" : "Z4 G4 Core-X Workstation",
+          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations (Core X-series processors), family P62",
+          "Description" : "<p>Fixes and enhancements in P62 2.85:</p><ul><li>Includes enhancements to mitigate security vulnerabilities.</li><li>HP strongly recommends promptly transitioning to this updated BIOS version.</li><li>Adds SMBIOS System Enclosure or Chassis (Type 3) entry.</li><li>Fixes an issue where Network BIOS Update would fail in Legacy mode.</li><li>Fixes an issue where system would not boot with a certain PCIe serial card installed.</li><li>Fixes a performance issue with a certain PCIe FireWire card.</li></ul>",
+          "Version" : "2.85",
+          "Filename" : "8e9bfcf011d2a6c38986d7bebdf5fc8b39e23bd3",
+          "Protocol" : "org.uefi.capsule",
+          "Categories" : [
+            "X-System"
+          ],
+          "Checksum" : [
+            "17fcf952384cbf17f1dce5a150303b4a38e0178b",
+            "f328b807e6318c51d531771bd9e1b17efffcad755d7ca9ac3913faa1015f340d"
+          ],
+          "License" : "LicenseRef-proprietary",
+          "Size" : 16781312,
+          "Created" : 1658274892,
+          "Locations" : [
+            "https://fwupd.org/downloads/f328b807e6318c51d531771bd9e1b17efffcad755d7ca9ac3913faa1015f340d-P62_0285.cab"
+          ],
+          "Uri" : "https://fwupd.org/downloads/f328b807e6318c51d531771bd9e1b17efffcad755d7ca9ac3913faa1015f340d-P62_0285.cab",
+          "Homepage" : "http://www.hp.com/go/workstations",
+          "Vendor" : "HP",
+          "Flags" : [
+            "is-downgrade"
+          ]
+        }
+      ]
+    },
+    {
+      "Name" : "TPM",
+      "DeviceId" : "c6a80ac3a22083423992a3cb15018989f37834d6",
+      "Guid" : [
+        "ff71992e-52f7-5eea-94ef-883e56e034c6",
+        "5eebb112-75ad-5536-b173-a11eb3399402",
+        "ddf995da-1b32-5a8a-bc1b-8d5af4b38b51",
+        "6d81ab63-db2e-50ac-934f-6be9accf5e02",
+        "301555de-680d-5ddc-b995-7553fc9138f1"
+      ],
+      "Plugin" : "tpm",
+      "Flags" : [
+        "internal",
+        "registered"
+      ],
+      "Vendor" : "Infineon",
+      "VendorId" : "TPM:IFX",
+      "Version" : "7.85.17.51968",
+      "VersionFormat" : "quad",
+      "VersionRaw" : 1970689910360832,
+      "Icons" : [
+        "computer"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "UEFI dbx",
+      "DeviceId" : "362301da643102b9f38477387e2193e57abaa590",
+      "ParentDeviceId" : "a45df35ac0e948ee180fe216a5f703f32dda163f",
+      "CompositeId" : "a45df35ac0e948ee180fe216a5f703f32dda163f",
+      "Guid" : [
+        "20716f78-5f65-5fe7-b32b-55a6a16392ab",
+        "f1d99738-25d4-5f76-a2ec-87750d294993",
+        "c6682ade-b5ec-57c4-b687-676351208742",
+        "f8ba2887-9411-5c36-9cee-88995bb39731"
+      ],
+      "Summary" : "UEFI revocation database",
+      "Plugin" : "uefi_dbx",
+      "Protocol" : "org.uefi.dbx",
+      "Flags" : [
+        "internal",
+        "updatable",
+        "registered",
+        "needs-reboot",
+        "only-version-upgrade",
+        "signed-payload"
+      ],
+      "VendorId" : "UEFI:Linux Foundation",
+      "Version" : "239",
+      "VersionLowest" : "239",
+      "VersionFormat" : "number",
+      "Icons" : [
+        "computer"
+      ],
+      "InstallDuration" : 1,
+      "Created" : 1693535931
+    }
+  ]
+}"""

--- a/extras/devices/LVFS/tests/test_LVFS.py
+++ b/extras/devices/LVFS/tests/test_LVFS.py
@@ -1,35 +1,46 @@
+"""Test LVFSDevice"""
+
+
 import unittest
 import json
 from devices import *
 from unittest.mock import patch
 from devices.LVFS.tests import fwupd_data
 
-device_results = json.loads(fwupd_data.get_results)
+device_results = json.loads(fwupd_data.GET_RESULTS_RESPONSE_DATA)
 
 
 class TestLVFSDevice(unittest.TestCase):
     def mock_run_cmd(*args, **kwargs):
+        """Mock run_cmd"""
         if "sudo fwupdmgr get-results" in args[1]:
             return 0, json.dumps(device_results), ""
         return 0, "", ""
 
-    # current System Firmware version is the previous version
     def test_upgradable(self):
+        """
+        Given fwupd data with only newer System Firmware releases available.
+        Test if upgrade function returns True. And test if downgrade function
+        returns False.
+        """
         with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
             mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
-            print(type(fwupd_data.get_device))
-            device._parse_fwupd_raw(fwupd_data.get_device)
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
             self.assertTrue(device.upgrade())
             self.assertFalse(device.downgrade())
 
-    # current System Firmware version is the latest version
     def test_downgradable(self):
+        """
+        Given fwupd data with only older System Firmware releases available.
+        Test if upgrade function returns False. And test if downgrade function
+        returns True.
+        """
         with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
             mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
 
-            device_info = json.loads(fwupd_data.get_device)
+            device_info = json.loads(fwupd_data.GET_DEVICES_RESPONSE_DATA)
             device_info["Devices"][5]["Version"] = "2.91"
             device_info["Devices"][5]["Releases"][0]["Flags"] = []
             device_info["Devices"][5]["Releases"][1]["Flags"] = [
@@ -39,28 +50,53 @@ class TestLVFSDevice(unittest.TestCase):
             self.assertFalse(device.upgrade())
             self.assertTrue(device.downgrade())
 
-    def test_results(self):
+    def test_check_results_failed_state(self):
+        """Validate UpdateState check in check_results"""
         global device_results
         with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
             mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
-            device._parse_fwupd_raw(fwupd_data.get_device)
-
-            # validate UpdateState check in check_results()
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
             device.fw_info[2]["targetVersion"] = "2.90"
+            device_results = json.loads(fwupd_data.GET_RESULTS_RESPONSE_DATA)
             device_results["UpdateState"] = 3
             self.assertFalse(device.check_results())
 
-            # validate version check in check_results()
+    def test_check_results_mismatched_version(self):
+        """Validate version check in check_results"""
+        global device_results
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd
+            device = LVFSDevice("", "", "")
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
             device.fw_info[2]["targetVersion"] = "2.91"
             self.assertFalse(device.check_results())
 
-            # validate a successful case in check_results()
+    def test_check_results_good(self):
+        """Test if check_results works with a valid case"""
+        global device_results
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd
+            device = LVFSDevice("", "", "")
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
+            device_results = json.loads(fwupd_data.GET_RESULTS_RESPONSE_DATA)
             device_results["UpdateState"] = 2
             device_results["Releases"][0]["Version"] = "2.90"
             device.fw_info[2]["targetVersion"] = "2.90"
             self.assertTrue(device.check_results())
 
-            # validate an error return of $fwupdmgr get-results
-            device_results = json.loads(fwupd_data.get_results_err)
+    def test_check_results_error(self):
+        """
+        Test error in check_results with an error return from ```$ fwupdmgr
+        get-results```
+        """
+        global device_results
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd
+            device = LVFSDevice("", "", "")
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
+            device.fw_info[2]["targetVersion"] = "2.90"
+            device_results = json.loads(
+                fwupd_data.GET_RESULTS_ERROR_RESPONSE_DATA
+            )
             self.assertFalse(device.check_results())

--- a/extras/devices/LVFS/tests/test_LVFS.py
+++ b/extras/devices/LVFS/tests/test_LVFS.py
@@ -1,0 +1,81 @@
+import unittest
+import json
+from devices import *
+from unittest.mock import patch
+from devices.LVFS.tests import fwupd_data
+
+device_info = json.loads(fwupd_data.get_device)
+device_results = json.loads(fwupd_data.get_results)
+
+
+class TestLVFSDevice(unittest.TestCase):
+    def mock_run_ssh(*args, **kwargs):
+        global device_info
+        global device_results
+        if args[1] == "sudo fwupdmgr refresh --force":
+            return 0, "", ""
+        elif args[1] == "sudo fwupdmgr get-devices --json":
+            return 0, json.dumps(device_info), ""
+        elif "sudo fwupdmgr upgrade" in args[1]:
+            return 0, "", ""
+        elif "sudo fwupdmgr download" in args[1]:
+            return 0, "", ""
+        elif "sudo fwupdmgr install" in args[1]:
+            return 0, "", ""
+        elif "sudo fwupdmgr get-results" in args[1]:
+            return 0, json.dumps(device_results), ""
+
+    # current System Firmware version is the previous version
+    def test_upgradable(self):
+        global device_info
+        device_info = json.loads(fwupd_data.get_device)
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_ssh
+            device = LVFSDevice("", "", "")
+
+            device.get_fw_info()
+            self.assertTrue(device.upgrade())
+            self.assertFalse(device.downgrade())
+
+    # current System Firmware version is the latest version
+    def test_downgradable(self):
+        global device_info
+        device_info = json.loads(fwupd_data.get_device)
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_ssh
+            device = LVFSDevice("", "", "")
+
+            device_info["Devices"][5]["Version"] = "2.91"
+            device_info["Devices"][5]["Releases"][0]["Flags"] = []
+            device_info["Devices"][5]["Releases"][1]["Flags"] = [
+                "is-downgrade"
+            ]
+            device.get_fw_info()
+            self.assertFalse(device.upgrade())
+            self.assertTrue(device.downgrade())
+
+    def test_results(self):
+        global device_results
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_ssh
+            device = LVFSDevice("", "", "")
+            device.get_fw_info()
+
+            # validate UpdateState check in check_results()
+            device.fw_info[2]["targetVersion"] = "2.90"
+            device_results["UpdateState"] = 3
+            self.assertFalse(device.check_results())
+
+            # validate version check in check_results()
+            device.fw_info[2]["targetVersion"] = "2.91"
+            self.assertFalse(device.check_results())
+
+            # validate a successful case in check_results()
+            device_results["UpdateState"] = 2
+            device_results["Releases"][0]["Version"] = "2.90"
+            device.fw_info[2]["targetVersion"] = "2.90"
+            self.assertTrue(device.check_results())
+
+            # validate an error return of $fwupdmgr get-results
+            device_results = json.loads(fwupd_data.get_results_err)
+            self.assertFalse(device.check_results())

--- a/extras/devices/LVFS/tests/test_LVFS.py
+++ b/extras/devices/LVFS/tests/test_LVFS.py
@@ -4,62 +4,47 @@ from devices import *
 from unittest.mock import patch
 from devices.LVFS.tests import fwupd_data
 
-device_info = json.loads(fwupd_data.get_device)
 device_results = json.loads(fwupd_data.get_results)
 
 
 class TestLVFSDevice(unittest.TestCase):
-    def mock_run_ssh(*args, **kwargs):
-        global device_info
-        global device_results
-        if args[1] == "sudo fwupdmgr refresh --force":
-            return 0, "", ""
-        elif args[1] == "sudo fwupdmgr get-devices --json":
-            return 0, json.dumps(device_info), ""
-        elif "sudo fwupdmgr upgrade" in args[1]:
-            return 0, "", ""
-        elif "sudo fwupdmgr download" in args[1]:
-            return 0, "", ""
-        elif "sudo fwupdmgr install" in args[1]:
-            return 0, "", ""
-        elif "sudo fwupdmgr get-results" in args[1]:
+    def mock_run_cmd(*args, **kwargs):
+        if "sudo fwupdmgr get-results" in args[1]:
             return 0, json.dumps(device_results), ""
+        return 0, "", ""
 
     # current System Firmware version is the previous version
     def test_upgradable(self):
-        global device_info
-        device_info = json.loads(fwupd_data.get_device)
         with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
-            mock_path.side_effect = self.mock_run_ssh
+            mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
-
-            device.get_fw_info()
+            print(type(fwupd_data.get_device))
+            device._parse_fwupd_raw(fwupd_data.get_device)
             self.assertTrue(device.upgrade())
             self.assertFalse(device.downgrade())
 
     # current System Firmware version is the latest version
     def test_downgradable(self):
-        global device_info
-        device_info = json.loads(fwupd_data.get_device)
         with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
-            mock_path.side_effect = self.mock_run_ssh
+            mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
 
+            device_info = json.loads(fwupd_data.get_device)
             device_info["Devices"][5]["Version"] = "2.91"
             device_info["Devices"][5]["Releases"][0]["Flags"] = []
             device_info["Devices"][5]["Releases"][1]["Flags"] = [
                 "is-downgrade"
             ]
-            device.get_fw_info()
+            device._parse_fwupd_raw(json.dumps(device_info))
             self.assertFalse(device.upgrade())
             self.assertTrue(device.downgrade())
 
     def test_results(self):
         global device_results
         with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
-            mock_path.side_effect = self.mock_run_ssh
+            mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
-            device.get_fw_info()
+            device._parse_fwupd_raw(fwupd_data.get_device)
 
             # validate UpdateState check in check_results()
             device.fw_info[2]["targetVersion"] = "2.90"

--- a/extras/devices/OEM/OEM.py
+++ b/extras/devices/OEM/OEM.py
@@ -1,10 +1,16 @@
+"""Device classes for flashing firmware on device with OEM-specific methods"""
+
 from devices.base import AbstractDevice
 
 
 class OEMDevice(AbstractDevice):
+    """Device class for devices that are not supported by LVFS-fwupd"""
+
     fw_update_type = "OEM-defined"
 
 
 class HPEDevice(OEMDevice):
+    """Place-holder for device class for HPE server"""
+
     fw_update_type = "OEM-defined"
     vendor = "HPE"

--- a/extras/devices/OEM/OEM.py
+++ b/extras/devices/OEM/OEM.py
@@ -1,0 +1,10 @@
+from devices.base import AbstractDevice
+
+
+class OEMDevice(AbstractDevice):
+    fw_update_type = "OEM-defined"
+
+
+class HPEDevice(OEMDevice):
+    fw_update_type = "OEM-defined"
+    vendor = "HPE"

--- a/extras/devices/__init__.py
+++ b/extras/devices/__init__.py
@@ -1,0 +1,12 @@
+from devices.base import AbstractDevice, logger
+from devices.LVFS.LVFS import LVFSDevice, LenovoNB
+from devices.OEM.OEM import OEMDevice, HPEDevice
+
+__all__ = [
+    "logger",
+    "AbstractDevice",
+    "LVFSDevice",
+    "LenovoNB",
+    "OEMDevice",
+    "HPEDevice",
+]

--- a/extras/devices/base.py
+++ b/extras/devices/base.py
@@ -1,9 +1,10 @@
 import logging
+from abc import ABC, abstractmethod
 
 logger = logging
 
 
-class AbstractDevice:
+class AbstractDevice(ABC):
     fw_update_type = ""
     vendor = ""
 
@@ -13,23 +14,30 @@ class AbstractDevice:
         self.password = password
         self.fw_info = []
 
+    @abstractmethod
     def run_cmd(self):
-        pass
+        return NotImplemented
 
+    @abstractmethod
     def get_fw_info(self):
-        pass
+        return NotImplemented
 
+    @abstractmethod
     def upgrade(self):
-        pass
+        return NotImplemented
 
+    @abstractmethod
     def downgrade(self):
-        pass
+        return NotImplemented
 
+    @abstractmethod
     def check_results(self):
-        pass
+        return NotImplemented
 
+    @abstractmethod
     def check_connectable(self):
-        pass
+        return NotImplemented
 
+    @abstractmethod
     def reboot(self):
-        pass
+        return NotImplemented

--- a/extras/devices/base.py
+++ b/extras/devices/base.py
@@ -1,3 +1,6 @@
+"""Base class for flashing firmware on devices"""
+
+
 import logging
 from abc import ABC, abstractmethod
 
@@ -8,7 +11,7 @@ class AbstractDevice(ABC):
     fw_update_type = ""
     vendor = ""
 
-    def __init__(self, ipaddr, user, password):
+    def __init__(self, ipaddr: str, user: str, password: str):
         self.ipaddr = ipaddr
         self.user = user
         self.password = password
@@ -16,28 +19,30 @@ class AbstractDevice(ABC):
 
     @abstractmethod
     def run_cmd(self):
-        return NotImplemented
+        raise NotImplementedError("Please, implement the run_cmd method")
 
     @abstractmethod
     def get_fw_info(self):
-        return NotImplemented
+        raise NotImplementedError("Please, implement the get_fw_info method")
 
     @abstractmethod
     def upgrade(self):
-        return NotImplemented
+        raise NotImplementedError("Please, implement the upgrade method")
 
     @abstractmethod
     def downgrade(self):
-        return NotImplemented
+        raise NotImplementedError("Please, implement the downgrade method")
 
     @abstractmethod
     def check_results(self):
-        return NotImplemented
+        raise NotImplementedError("Please, implement the check_results method")
 
     @abstractmethod
     def check_connectable(self):
-        return NotImplemented
+        raise NotImplementedError(
+            "Please, implement the check_connectable method"
+        )
 
     @abstractmethod
     def reboot(self):
-        return NotImplemented
+        raise NotImplementedError("Please, implement the reboot method")

--- a/extras/devices/base.py
+++ b/extras/devices/base.py
@@ -1,0 +1,35 @@
+import logging
+
+logger = logging
+
+
+class AbstractDevice:
+    fw_update_type = ""
+    vendor = ""
+
+    def __init__(self, ipaddr, user, password):
+        self.ipaddr = ipaddr
+        self.user = user
+        self.password = password
+        self.fw_info = []
+
+    def run_cmd(self):
+        pass
+
+    def get_fw_info(self):
+        pass
+
+    def upgrade(self):
+        pass
+
+    def downgrade(self):
+        pass
+
+    def check_results(self):
+        pass
+
+    def check_connectable(self):
+        pass
+
+    def reboot(self):
+        pass

--- a/extras/dmi.py
+++ b/extras/dmi.py
@@ -1,3 +1,6 @@
+"""This maps DMI chassis type to readable name"""
+
+
 class Dmi:
     chassis = (
         ("Undefined", "unknown"),  # 0x00

--- a/extras/dmi.py
+++ b/extras/dmi.py
@@ -1,0 +1,44 @@
+class Dmi:
+    chassis = (
+        ("Undefined", "unknown"),  # 0x00
+        ("Other", "unknown"),  # 0x01
+        ("Unknown", "unknown"),
+        ("Desktop", "LVFS"),  # 0x03
+        ("Low Profile Desktop", "unknown"),
+        ("Pizza Box", "unknown"),
+        ("Mini Tower", "unknown"),
+        ("Tower", "unknown"),
+        ("Portable", "unknown"),
+        ("Laptop", "unknown"),  # 0x09
+        ("Notebook", "unknown"),  # 0x0A
+        ("Hand Held", "unknown"),
+        ("Docking Station", "unknown"),
+        ("All In One", "LVFS"),  # 0x0D
+        ("Sub Notebook", "unknown"),
+        ("Space-saving", "unknown"),
+        ("Lunch Box", "unknown"),
+        ("Main Server Chassis", "unknown"),  # 0x11
+        ("Expansion Chassis", "unknown"),
+        ("Sub Chassis", "unknown"),
+        ("Bus Expansion Chassis", "unknown"),
+        ("Peripheral Chassis", "unknown"),
+        ("RAID Chassis", "unknown"),
+        ("Rack Mount Chassis", "OEM-defined,LVFS"),  # 0x17
+        ("Sealed-case PC", "unknown"),
+        ("Multi-system", "unknown"),
+        ("CompactPCI", "unknonw"),
+        ("AdvancedTCA", "unknown"),
+        ("Blade", "server"),
+        ("Blade Enclosure", "unknown"),
+        ("Tablet", "unknown"),
+        ("Convertible", "unknown"),  # 0x1F
+        ("Detachable", "unknown"),
+        ("IoT Gateway", "unknown"),  # 0x21
+        ("Embedded PC", "unknown"),
+        ("Mini PC", "LVFS"),  # 0x23
+        ("Stick PC", "unknown"),
+    )
+
+    chassis_names = tuple(c[0] for c in chassis)
+    chassis_types = tuple(c[1] for c in chassis)
+    chassis_name_to_type = dict(chassis)

--- a/extras/tests/test_upgrade_fw.py
+++ b/extras/tests/test_upgrade_fw.py
@@ -1,3 +1,6 @@
+"""Test detect_device in upgrade_fw.py"""
+
+
 import unittest
 import upgrade_fw
 import pytest
@@ -9,22 +12,31 @@ type_cmd = "sudo cat /sys/class/dmi/id/chassis_type"
 
 
 class TestUpgradeFW(unittest.TestCase):
-    # normal case
     def mock_run_cmd_supported(*args, **kwargs):
+        """
+        Mock run_cmd for a HP All In One device, which has a supported
+        Device class.
+        """
         if args[1] == vendor_cmd:
             return 0, "HP", ""
         elif args[1] == type_cmd:
             return 0, "13", ""
 
-    # CID 201808-26453
     def mock_run_cmd_unsupported(*args, **kwargs):
+        """
+        Mock run_cmd for an Intel Desktop device (201808-26453), which doesn't
+        have a supported Device class.
+        """
         if args[1] == vendor_cmd:
             return 0, "Default string", ""
         elif args[1] == type_cmd:
             return 0, "3", ""
 
-    # CID 201810-26506: no DMI info
     def mock_run_cmd_fail(*args, **kwargs):
+        """
+        Mock run_cmd for a Rigado Cascade 500 device (201810-26506), which doesn't
+        provide dmi data.
+        """
         if args[1] == vendor_cmd:
             return (
                 1,
@@ -38,8 +50,10 @@ class TestUpgradeFW(unittest.TestCase):
                 "",
             )
 
-    # unable to SSH to DUT
     def mock_run_cmd_nossh(*args, **kwargs):
+        """
+        Mock run_cmd to simulate an unreachable device.
+        """
         if args[1] == vendor_cmd:
             return (
                 255,
@@ -54,31 +68,44 @@ class TestUpgradeFW(unittest.TestCase):
             )
 
     def test_detect_device_supported(self):
+        """Test if detects_device returns a correct device class"""
         with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
             mock_path.side_effect = self.mock_run_cmd_supported
             device = upgrade_fw.detect_device("", "", "")
             self.assertTrue(isinstance(device, LVFSDevice))
 
     def test_detect_device_unsupported(self):
+        """Test if detects_device exits while given a unsupported device"""
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
                 mock_path.side_effect = self.mock_run_cmd_unsupported
                 upgrade_fw.detect_device("", "", "")
-        assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == 1
+        self.assertEqual(pytest_wrapped_e.type, SystemExit)
+        self.assertIn(
+            "Device is not in current support scope",
+            pytest_wrapped_e.value.code,
+        )
 
     def test_detect_device_fail(self):
+        """Test if detects_device exits while given a device without dmi data"""
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
                 mock_path.side_effect = self.mock_run_cmd_fail
                 upgrade_fw.detect_device("", "", "")
-        assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == 1
+        self.assertEqual(pytest_wrapped_e.type, SystemExit)
+        self.assertIn(
+            "Unable to detect device vendor/type due to lacking of dmi info",
+            pytest_wrapped_e.value.code,
+        )
 
     def test_detect_device_nossh(self):
+        """Test if detects_device exits while given an unreachable device"""
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
                 mock_path.side_effect = self.mock_run_cmd_nossh
                 upgrade_fw.detect_device("", "", "")
-        assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == 1
+        self.assertEqual(pytest_wrapped_e.type, SystemExit)
+        self.assertIn(
+            "Unable to detect device vendor/type due to lacking of dmi info",
+            pytest_wrapped_e.value.code,
+        )

--- a/extras/tests/test_upgrade_fw.py
+++ b/extras/tests/test_upgrade_fw.py
@@ -1,0 +1,89 @@
+import unittest
+import upgrade_fw
+from devices import *
+from unittest.mock import patch
+
+vendor_cmd = "sudo cat /sys/class/dmi/id/chassis_vendor"
+type_cmd = "sudo cat /sys/class/dmi/id/chassis_type"
+
+
+class TestUpgradeFW(unittest.TestCase):
+    # normal case
+    def mock_run_cmd_supported(*args, **kwargs):
+        if args[1] == vendor_cmd:
+            return 0, "HP", ""
+        elif args[1] == type_cmd:
+            return 0, "13", ""
+
+    # CID 201808-26453
+    def mock_run_cmd_unsupported(*args, **kwargs):
+        if args[1] == vendor_cmd:
+            return 0, "Default string", ""
+        elif args[1] == type_cmd:
+            return 0, "3", ""
+
+    # CID 201810-26506: no DMI info
+    def mock_run_cmd_fail(*args, **kwargs):
+        if args[1] == vendor_cmd:
+            return (
+                1,
+                "cat: /sys/class/dmi/id/chassis_vendor: No such file or directory",
+                "",
+            )
+        elif args[1] == type_cmd:
+            return (
+                1,
+                "cat: /sys/class/dmi/id/chassis_type: No such file or directory",
+                "",
+            )
+
+    # unable to SSH to DUT
+    def mock_run_cmd_nossh(*args, **kwargs):
+        if args[1] == vendor_cmd:
+            return (
+                255,
+                "",
+                "ssh: connect to host 10.102.161.93 port 22: No route to host",
+            )
+        elif args[1] == type_cmd:
+            return (
+                255,
+                "",
+                "ssh: connect to host 10.102.161.93 port 22: No route to host",
+            )
+
+    def test_detect_device_supported(self):
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd_supported
+            device = upgrade_fw.detect_device("", "", "")
+            self.assertTrue(isinstance(device, LVFSDevice))
+
+    def test_detect_device_unsupported(self):
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            try:
+                mock_path.side_effect = self.mock_run_cmd_unsupported
+                upgrade_fw.detect_device("", "", "")
+            except RuntimeError as e:
+                self.assertIn("Cannot find a proper Device class for", str(e))
+
+    def test_detect_device_fail(self):
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            try:
+                mock_path.side_effect = self.mock_run_cmd_fail
+                upgrade_fw.detect_device("", "", "")
+            except RuntimeError as e:
+                self.assertIn(
+                    "Unable to detect device vendor/type due to lacking of dmi info",
+                    str(e),
+                )
+
+    def test_detect_device_nossh(self):
+        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
+            try:
+                mock_path.side_effect = self.mock_run_cmd_nossh
+                upgrade_fw.detect_device("", "", "")
+            except RuntimeError as e:
+                self.assertIn(
+                    "Unable to detect device vendor/type due to lacking of dmi info",
+                    str(e),
+                )

--- a/extras/tests/test_upgrade_fw.py
+++ b/extras/tests/test_upgrade_fw.py
@@ -1,5 +1,6 @@
 import unittest
 import upgrade_fw
+import pytest
 from devices import *
 from unittest.mock import patch
 
@@ -59,31 +60,25 @@ class TestUpgradeFW(unittest.TestCase):
             self.assertTrue(isinstance(device, LVFSDevice))
 
     def test_detect_device_unsupported(self):
-        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
-            try:
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
                 mock_path.side_effect = self.mock_run_cmd_unsupported
                 upgrade_fw.detect_device("", "", "")
-            except RuntimeError as e:
-                self.assertIn("Cannot find a proper Device class for", str(e))
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
 
     def test_detect_device_fail(self):
-        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
-            try:
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
                 mock_path.side_effect = self.mock_run_cmd_fail
                 upgrade_fw.detect_device("", "", "")
-            except RuntimeError as e:
-                self.assertIn(
-                    "Unable to detect device vendor/type due to lacking of dmi info",
-                    str(e),
-                )
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
 
     def test_detect_device_nossh(self):
-        with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
-            try:
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            with patch("devices.LVFS.LVFS.LVFSDevice.run_cmd") as mock_path:
                 mock_path.side_effect = self.mock_run_cmd_nossh
                 upgrade_fw.detect_device("", "", "")
-            except RuntimeError as e:
-                self.assertIn(
-                    "Unable to detect device vendor/type due to lacking of dmi info",
-                    str(e),
-                )
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1

--- a/extras/upgrade_fw.py
+++ b/extras/upgrade_fw.py
@@ -65,7 +65,7 @@ def detect_device(
                 if dev.fw_update_type in upgrade_type
                 and any(x == vendor_string for x in dev.vendor)
             ][0]
-            logger.info("%s is a %s %s" % (ip, vendor_string, dev.__name__))
+            logger.info("%s is a %s %s", ip, vendor_string, dev.__name__)
         except IndexError:
             err_msg = f"{vendor_string} {Dmi.chassis_names[type_index]} Device is not in current support scope"
             logger.error(err_msg)

--- a/extras/upgrade_fw.py
+++ b/extras/upgrade_fw.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python3
+import subprocess
+import argparse
+import logging
+from dmi import Dmi
+from devices import *
+
+SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+target_device_username = "ubuntu"
+
+
+def all_subclasses(cls):
+    return cls.__subclasses__() + [
+        g for s in cls.__subclasses__() for g in all_subclasses(s)
+    ]
+
+
+def detect_device(ip: str, user: str, password: str = "", **options):
+    """
+    detect device's firmware upgrade type by checking on DMI data
+
+    :returns: device object
+    :rtype: object of subclass of AbstractDevice
+    """
+    temp_device = LVFSDevice(ip, user, password)
+    run_ssh = temp_device.run_cmd
+    devices = all_subclasses(AbstractDevice)
+    try:
+        dmi_chassis_vendor = "sudo cat /sys/class/dmi/id/chassis_vendor"
+        dmi_chassis_type = "sudo cat /sys/class/dmi/id/chassis_type"
+        rc1, vendor_string, stderr1 = run_ssh(
+            dmi_chassis_vendor, raise_stderr=False
+        )
+        rc2, type_string, stderr2 = run_ssh(
+            dmi_chassis_type, raise_stderr=False
+        )
+
+        err_msg = ""
+        if rc1 != 0:
+            err_msg = vendor_string + stderr1 + "\n"
+        if rc2 != 0:
+            err_msg = err_msg + type_string + stderr2
+        if err_msg:
+            err_msg = (
+                "Unable to detect device vendor/type due to lacking of dmi info.\n"
+                + err_msg
+            )
+            logger.error(err_msg)
+            raise RuntimeError(err_msg)
+
+        type_index = int(type_string)
+        upgrade_type = Dmi.chassis_types[type_index]
+        try:
+            dev = [
+                dev
+                for dev in devices
+                if dev.fw_update_type in upgrade_type
+                and any(x == vendor_string for x in dev.vendor)
+            ][0]
+            logger.info("%s is a %s %s" % (ip, vendor_string, dev.__name__))
+        except IndexError:
+            err_msg = "Cannot find a proper Device class for %s: %s" % (
+                vendor_string,
+                Dmi.chassis_names[type_index],
+            )
+            logger.error(err_msg)
+            raise RuntimeError(err_msg)
+
+        if issubclass(dev, LVFSDevice):
+            return dev(ip, user, password)
+        elif issubclass(dev, OEMDevice):
+            if not (
+                "bmc_ip" in options
+                and "bmc_user" in options
+                and "bmc_password" in options
+            ):
+                raise RuntimeError(
+                    "Please provide $BMC_IP, $BMC_USER, $BMC_PASSWORD for this device"
+                )
+            exit()
+            return dev(
+                options.get("bmc_ip"),
+                options.get("bmc_user"),
+                options.get("bmc_password"),
+            )
+    except subprocess.CalledProcessError as e:
+        logger.error(e.output)
+        raise RuntimeError(e.output)
+
+
+def main():
+    """
+    mandantory parameter: $DEVICE_IP (testflinger env variable)
+    extra parameters for Server: $BMC_IP, $BMC_USERNAME, $BMC_PASSWORD
+    (not yet provided by testflinger)
+    """
+    parser = argparse.ArgumentParser(
+        epilog="Example: %(prog)s upgrade 10.0.0.1",
+        usage="%(prog)s {upgrade, downgrade, detect} $DEVICE_IP [options]",
+    )
+    parser.add_argument(
+        choices=["upgrade", "downgrade", "detect"],
+        dest="action",
+        help="select to upgrade firmware, downgrade firmware, or just detect DUT info without further actions",
+    )
+    parser.add_argument("device_ip", help="$DEVICE_IP")
+    parser.add_argument(
+        "--bmc_ip",
+        "-i",
+        nargs="?",
+    )
+    parser.add_argument(
+        "--bmc_user",
+        "-u",
+        nargs="?",
+    )
+    parser.add_argument(
+        "--bmc_password",
+        "-p",
+        nargs="?",
+    )
+    args = parser.parse_args()
+
+    log_file = "/tmp/upgrade_fw.log"
+    logger.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s %(levelname)-8s %(message)s",
+        datefmt="%y-%m-%d %H:%M:%S",
+        filename=log_file,
+        filemode="w",
+    )
+
+    if args.bmc_ip and args.bmc_user and args.bmc_password:
+        target_device = detect_device(
+            args.device_ip,
+            target_device_username,
+            options=vars(args),
+        )
+    else:
+        target_device = detect_device(
+            args.device_ip, target_device_username, password="insecure"
+        )
+
+    target_device.get_fw_info()
+    if args.action == "detect":
+        print("Check %s for details." % log_file)
+        return
+    elif args.action == "upgrade":
+        reboot_required = target_device.upgrade()
+    else:
+        reboot_required = target_device.downgrade()
+    if reboot_required:
+        target_device.reboot()
+        target_device.check_results()
+    else:
+        print("Firmware %s is not performed." % args.action)
+    print("Check %s for more details." % log_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description
This is the prototype for firmware upgrade test. It will be temporarily placed in `/extras` folder until we figure out a proper way to merge it into device agent codes.

This tool relies on DMI chassis type and chassis vendor to determine which firmware update method should be applied on the device. Currently, it only supports `fwupd/LVFS` update method on selected device types (DMI chassis type: All In One, Desktop) with selected OEM (HP, Dell, and Lenovo). Note that it hasn't been widely tested on all supported devices.

More detailed usages can be found in README.

### Output logs
Here're the logs for two devices. Logs have been renamed (default: upgrade_fw.log) to reflect the different actions.
- HP Z4 G4 workstation (202102-28691)  chassis_type: Desktop
- Dell Optiplex AIO Plus 7410 (202209-30589)  chassis_type: All In One
[upgrade_fw_logs.zip](https://github.com/canonical/testflinger/files/12561104/upgrade_fw_logs.zip)

### Test
It passed `ruff check *` and unit tests as below.

```
nancy-chen@Ubuntu:~/git/testflinger/extras$ python -m coverage run -m pytest .
================================================================================= test session starts =================================================================================
platform linux -- Python 3.10.12, pytest-7.4.1, pluggy-0.13.0
rootdir: /home/nancy-chen/git/testflinger
configfile: pyproject.toml
plugins: cov-4.1.0
collected 7 items                                                                                                                                                                     

devices/LVFS/tests/test_LVFS.py ...                                                                                                                                             [ 42%]
tests/test_upgrade_fw.py ....                                                                                                                                                   [100%]

================================================================================== 7 passed in 0.04s ==================================================================================
```