### PR TITLE
Add git workflow for automatic documentation checks

### DIFF
--- a/.github/workflows/documentation_checks.yml
+++ b/.github/workflows/documentation_checks.yml
@@ -1,0 +1,19 @@
+name: Documentation checks
+
+on:  
+  pull_request:
+    branches: 
+      - main
+    paths:
+      - 'docs/**'  
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true  
+
+jobs:
+  documentation-checks:
+    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
+    with:
+      working-directory: 'docs/'

--- a/.github/workflows/documentation_checks.yml
+++ b/.github/workflows/documentation_checks.yml
@@ -13,7 +13,67 @@ concurrency:
   cancel-in-progress: true  
 
 jobs:
-  documentation-checks:
-    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
-    with:
-      working-directory: 'docs/'
+  spellcheck:
+    name: Spelling check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Aspell
+        run: |
+          sudo apt-get install aspell aspell-en
+
+      - name: Install the doc framework
+        working-directory: docs/
+        run: |
+          make install
+
+      - name: Build docs and run spelling checker
+        working-directory: docs/
+        run: |
+          make spelling
+
+  woke:
+    name: Inclusive language check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install the doc framework
+        working-directory: docs/
+        run: |
+          make install
+
+      - name: Run Woke
+        working-directory: docs/
+        run: |
+          make woke
+
+  linkcheck:
+    name: Link check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install the doc framework
+        working-directory: docs/
+        run: |
+          make install
+
+      - name: Run linkchecker
+        working-directory: docs/
+        run: |
+          make linkcheck
+  

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -9,6 +9,8 @@ Diátaxis
 EBS
 EKS
 favicon
+Git
+GitHub
 Grafana
 IAM
 installable
@@ -34,6 +36,7 @@ RTD
 subdirectories
 subtree
 subfolders
+Testflinger
 txt
 UI
 VM

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,0 +1,92 @@
+Testflinger Documentation
+===========================
+
+.. Note:: The Testflinger documentation set is built with Sphinx and reStructuredText. 
+   See the `Sphinx and Read the Docs <https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/>`_  guide for instructions on how to get started with Sphinx documentation.
+
+This documentation contains `make`` targets defined in the ``Makefile`` that do various things. To get started, we will:
+
+#. Install prerequisite software
+#. View the documentation
+#. Validate documentation checks
+
+Install prerequisite software
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install the prerequisites:
+
+.. code-block:: shell
+
+   make install
+
+This will create a virtual environment (``.sphinx/venv``) and install
+dependency software (``.sphinx/requirements.txt``) within it.
+
+A complete set of pinned, known-working dependencies is included in
+``.sphinx/pinned-requirements.txt``.
+
+View the documentation
+~~~~~~~~~~~~~~~~~~~~~~
+
+To preview the documentation locally:
+
+.. code-block:: shell
+
+   make run
+
+This will do several things:
+
+* activate the virtual environment
+* build the documentation
+* serve the documentation on **127.0.0.1:8000**
+* rebuild the documentation each time a file is saved
+* send a reload page signal to the browser when the documentation is rebuilt
+
+The ``run`` target is therefore very convenient when preparing to submit a
+change to the documentation.
+
+You can also run local checks separately before submitting the changes.
+
+.. Important:: By default, the `fail_on_warning` attribute is enabled in the doc build configuration. Any warning messages occurred during the local build will cause failures on the server side. Please fix all warning messages before making a pull request.
+
+Local checks
+~~~~~~~~~~~~
+
+Before committing and pushing changes, it's a good practice to run various checks locally to catch issues early in the development process.
+
+Local build
+^^^^^^^^^^^
+
+Run a clean build of the docs to surface any build errors that would occur in RTD:
+
+.. code-block:: shell
+
+   make clean-doc
+   make html
+
+Spelling check
+^^^^^^^^^^^^^^
+
+Ensure there are no spelling errors in the documentation:
+
+.. code-block:: shell
+
+   make spelling
+
+Inclusive language check
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ensure the documentation uses inclusive language:
+
+.. code-block:: shell
+
+   make woke
+
+Link check
+^^^^^^^^^^
+
+Validate links within the documentation:
+
+.. code-block:: shell
+
+   make linkcheck

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -125,6 +125,7 @@ custom_extensions = []
 # Add files or directories that should be excluded from processing.
 custom_excludes = [
     'doc-cheat-sheet*',
+    'README.rst'
 ]
 
 # Add CSS files (located in .sphinx/_static/)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,12 +64,12 @@ In this documentation
 Project and community
 ---------------------
 
-Testflinger is a member of the Ubuntu family. It’s an open source project that
+Testflinger is a member of the Ubuntu family. It's an open source project that
 warmly welcomes community projects, contributions, suggestions, fixes and
 constructive feedback.
 
 * This project follows the `Ubuntu Code of Conduct`_
-* This project is `hosted on Github`_, contributions welcome
+* This project is `hosted on GitHub`_, contributions welcome
 * :ref:`Thinking about using Testflinger for your next project? Get in touch! <home>`
 
 
@@ -83,4 +83,4 @@ constructive feedback.
    explanation/index
 
 .. _Ubuntu Code of Conduct: https://ubuntu.com/community/ethos/code-of-conduct
-.. _hosted on Github: https://github.com/canonical/testflinger
+.. _hosted on GitHub: https://github.com/canonical/testflinger


### PR DESCRIPTION
- Add automatic documentation checks against changes to the `docs/` folder. The workflow file references to https://github.com/canonical/documentation-workflows :
  - spell check (words in `docs/.wordlist.txt` are exempted)
  - inclusive language check
  - link check
- Add README in the `/docs` folder to explain local builds 


This PR resovles [CERTTF-215](https://warthogs.atlassian.net/browse/CERTTF-215). (Requires that https://github.com/canonical/testflinger/pull/105 being merged first)

[CERTTF-215]: https://warthogs.atlassian.net/browse/CERTTF-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ