### PR TITLE
Fix oci image builds due to Dockerfile being in a subdir now

### DIFF
--- a/.github/workflows/server-publish-oci-image.yml
+++ b/.github/workflows/server-publish-oci-image.yml
@@ -40,7 +40,6 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: ./server
-          file: Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
OCI images weren't working because we had "file: Dockerfile". This would normally be ok, except the context was set to ./server, so the file specified should have been {context}/Dockerfile. Turns out this is the default though, so all we need to do is remove it.