### PR TITLE
Send all queues in agent data

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -33,13 +33,11 @@ class TestflingerAgent:
         """Post the initial agent data to the server once on agent startup"""
 
         location = self.client.config.get("location", "")
-        advertised_queues = self._post_advertised_queues()
+        self._post_advertised_queues()
         self._post_advertised_images()
 
-        if advertised_queues or location:
-            self.client.post_agent_data(
-                {"queues": advertised_queues, "location": location}
-            )
+        queues = self.client.config.get("job_queues", [])
+        self.client.post_agent_data({"queues": queues, "location": location})
 
     def _post_advertised_queues(self):
         """
@@ -50,7 +48,6 @@ class TestflingerAgent:
         advertised_queues = self.client.config.get("advertised_queues", {})
         if advertised_queues:
             self.client.post_queues(advertised_queues)
-        return advertised_queues
 
     def _post_advertised_images(self):
         """

--- a/agent/testflinger_agent/tests/test_agent.py
+++ b/agent/testflinger_agent/tests/test_agent.py
@@ -23,6 +23,7 @@ class TestClient:
             "polling_interval": "2",
             "server_address": "127.0.0.1:8000",
             "job_queues": ["test"],
+            "location": "nowhere",
             "execution_basedir": self.tmpdir,
             "logging_basedir": self.tmpdir,
             "results_basedir": os.path.join(self.tmpdir, "results"),
@@ -203,3 +204,16 @@ class TestClient:
             assert agent.check_offline()
         if os.path.exists(OFFLINE_FILE):
             os.unlink(OFFLINE_FILE)
+
+    def test_post_agent_data(self, agent):
+        # Make sure we post the initial agent data
+        with patch.object(
+            testflinger_agent.client.TestflingerClient, "post_agent_data"
+        ) as mock_post_agent_data:
+            agent._post_initial_agent_data()
+            mock_post_agent_data.assert_called_with(
+                {
+                    "queues": self.config["job_queues"],
+                    "location": self.config["location"],
+                }
+            )

--- a/agent/testflinger_agent/tests/test_agent.py
+++ b/agent/testflinger_agent/tests/test_agent.py
@@ -16,7 +16,7 @@ from testflinger_agent.agent import TestflingerAgent as _TestflingerAgent
 
 class TestClient:
     @pytest.fixture
-    def agent(self):
+    def agent(self, requests_mock):
         self.tmpdir = tempfile.mkdtemp()
         self.config = {
             "agent_id": "test01",
@@ -31,6 +31,8 @@ class TestClient:
         }
         testflinger_agent.configure_logging(self.config)
         client = _TestflingerClient(self.config)
+        requests_mock.get(rmock.ANY)
+        requests_mock.post(rmock.ANY)
         yield _TestflingerAgent(client)
         # Inside tests, we patch rmtree so that we can check files after the
         # run, so we need to clean up the tmpdirs here

--- a/server/src/templates/agent_detail.html
+++ b/server/src/templates/agent_detail.html
@@ -2,17 +2,27 @@
 {% set active_page = 'agents' %}
 {% block content %}
 <div class="center">
+    <p>
     Agent Name: {{ agent.name }}<br>
     State: {{ agent.state }}<br>
     Location: {{ agent.location }}<br>
     Last Updated: {{ agent.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}<br>
-    <br>
-    <br>
+    </p>
+    <p>
+    Queues:
+    <ul>
+        {% for queue in agent.queues %}
+        <li><a href="/queues/{{ queue }}">{{ queue }}</a></li>
+        {% endfor %}
+    </ul>
+    </p>
+    <p>
     Agent Log:
     <div class="center scrollable">
         <span style="white-space: pre-line">
             {{ agent.log|join('\n') }}
         </span>
     </div>
+    </p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Description
- Send all known queues for the agent instead of just the advertised ones to the server for the initial_agent_data
- Modify the agent_detail page so that it displays all of these queues for each agent, along with a link to the queue details page
- **BONUS** small change to speed up test_agent.py execution significantly (from 161s to 16s on my system)

## Resolved issues
Fixes CERTTF-141

## Documentation
N/A

## Tests
Unit test added for this method, and I also set it up locally and connected an agent to it so that I could see the change to the html. Here's an example of what it looks like:
![image](https://github.com/canonical/testflinger/assets/1255513/6cb4e2f6-22db-4c14-9e78-a68bff8b0c88)

