### PR TITLE
Build cli snap workflow

### DIFF
--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -1,0 +1,22 @@
+name: Publish Testflinger CLI snap to edge
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - cli/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1
+      id: build
+      with:
+        path: cli
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: edge

--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -4,6 +4,7 @@ on:
     branches: ["main"]
     paths:
       - cli/**
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/server-charm-release-edge.yml
+++ b/.github/workflows/server-charm-release-edge.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - server/**
+  workflow_dispatch:
 
 jobs:
   build:

--- a/cli/README.rst
+++ b/cli/README.rst
@@ -12,11 +12,19 @@ the status of them, and getting results.
 Installation
 ------------
 
-You can either run testflinger-cli from a checkout of the code, or
-install it like any other python project.
+It is recommended that you install testflinger-cli from the snap, however it
+can also be installed with pip directly from the source.
 
-To run it from a checkout, please make sure to first install python3-click
-and python3-requests
+To install testflinger using the snap:
+
+.. code-block:: console
+
+  $ sudo snap install testflinger-cli
+
+When changes are made to the CLI, the snap is automatically built and uploaded
+to the `edge` channel. Once sufficient testing has been performed, this snap
+is also published to the `stable` channel. If you prefer to use the latest
+code, then you can specify `edge` instead in the command above.
 
 To install it in a virtual environment:
 


### PR DESCRIPTION
## Description

Use a github workflow to build and publish the cli snap

## Resolved issues
Previously, I did this through the snapcraft.io builders and set them up to watch the testflinger-cli repo and build automatically. However, those do not work with a monorepo because they don't support building the snap if it's in a directory. So we need to move this to use the gh workflow instead.

## Documentation
N/A

## Tests

I'm testing this by temporarily adding the proposed branch to the list of ones to trigger it
**update**: tested here: https://github.com/canonical/testflinger/actions/runs/6670022069/job/18129054928?pr=151
I also installed the resulting snap and tested it locally, works great :)
