### PR TITLE
Enable self-hosted workflow runners

### DIFF
--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: agent
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     strategy:
       matrix:
         python: ["3.8", "3.10"]

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -2,7 +2,7 @@ name: "[cli] Run unit tests"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, try-self-hosted ]
     paths:
       - cli/**
   pull_request:
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: cli
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     strategy:
       matrix:
         python: ["3.8", "3.10"]

--- a/.github/workflows/device-tox.yml
+++ b/.github/workflows/device-tox.yml
@@ -2,7 +2,7 @@ name: "[device-connectors] Run unit tests"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, try-self-hosted ]
     paths:
       - device-connectors/**
   pull_request:
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: device-connectors
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     strategy:
       matrix:
         python: ["3.8", "3.10"]

--- a/.github/workflows/server-charm-check-libs.yml
+++ b/.github/workflows/server-charm-check-libs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Check charm libraries
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/server-charm-release-edge.yml
+++ b/.github/workflows/server-charm-release-edge.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Release to Charmhub
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/server-publish-oci-image.yml
+++ b/.github/workflows/server-publish-oci-image.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-push-backend-image:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -2,7 +2,7 @@ name: "[server] Run unit tests"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, try-self-hosted ]
     paths:
       - server/**
   pull_request:
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: server
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     strategy:
       matrix:
         python: ["3.8", "3.10"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to Testflinger
+
+## Introduction
+
+This document provides the information needed to contribute to Testflinger,
+its providers and its documentation.
+
+## General recommendations
+
+This is a monorepo with a subproject directory for each of the major
+components of Testflinger, such as `agent`, `cli`, `device-connectors`, and
+`server`.
+
+All of the linters, format checkers, and unit tests can be run automatically.
+Before pushing anything, it's a good idea to run `tox` from the root of the
+subproject where you made changes.
+
+## Signed commits required
+
+- To get your changes accepted, please [sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). This practice is enforced by many of the CI pipelines executed in the repository (pipelines which use Canonical's [github-runner-operator](https://github.com/canonical/github-runner-operator) operated runners).
+- If you have just discovered the requirement for signed commits after already creating a feature branch with unsigned commits, you can issue `git rebase --exec 'git commit --amend --no-edit -n -S' -i main` to sign them. To translate this into English:
+   - `git rebase --exec`: rebases commits
+   - `--exec '...'`: exec command `'...'` after each commit, creating a new commit
+   - `git commit --amend --no-edit`: amend a commit without changing its message
+      - `-n`: bypass pre-commit and commit-msg hooks
+      - `-S`: GPG sign commit
+      - `-i`: let the user see and edit the list of commits to rebase
+      - `main`: to all the commits until you reach main  
+- To make commit signing convenient, as per https://stackoverflow.com/a/70484849/504931, do the following:
+
+   ```bash
+   git config --global user.signingkey <your-key-id>
+   git config --global commit.gpgSign true
+   git config --global tag.gpgSign true
+   git config --global push.gpgSign if-asked


### PR DESCRIPTION
## Description
This enables the self-hosted runners for all of our existing workflows

## Resolved issues
Resolves long wait times which hit us frequently

## Documentation

I added a CONTRIBUTING.md file in the root of the repo with some useful information as well as a section about dealing with signed commits shamelessly stolen from the excellent one in checkbox.

## Tests
I tested this in a different branch to ensure everything works. You should still be able to see the results [here](https://github.com/canonical/testflinger/pull/152/checks)
