### PR TITLE
Enable buildx support for building oci containers

### DIFF
--- a/.github/workflows/server-publish-oci-image.yml
+++ b/.github/workflows/server-publish-oci-image.yml
@@ -20,6 +20,9 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Checkout repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
## Description

Enable buildx in the workflow for building and publishing oci containers

## Resolved issues

Ever since moving to self-hosted runners, oci image builds seem to fail. See https://github.com/canonical/testflinger/actions/runs/6710170556

## Documentation

It's a well-known action, documentation on this is at https://github.com/docker/setup-buildx-action

## Tests

The oci publisher workflow is itself the test, since it runs whenever we update the server code. I think I should be able to run this manually either once this is proposed, or if not, then once it lands. It's a well known issue with self-hosted runners it seems, and other projects we use have already enabled it the same way though.
