### PR TITLE
Use aproxy for the oci-publish step for self-hosted runners

### DIFF
--- a/.github/workflows/server-publish-oci-image.yml
+++ b/.github/workflows/server-publish-oci-image.yml
@@ -27,6 +27,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install Aproxy Snap
+        run: |
+          sudo snap install --edge aproxy
+
+      - name: Configure Aproxy
+        run: |
+          sudo snap set aproxy proxy=squid.internal:3128
+          sudo nft -f - << EOF
+          define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
+          define private-ips = { 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16 }
+          table ip aproxy
+          flush table ip aproxy
+          table ip aproxy {
+                  chain prerouting {
+                          type nat hook prerouting priority dstnat; policy accept;
+                          ip daddr != \$private-ips tcp dport { 80, 443 } counter dnat to \$default-ip:8443
+                  }
+
+                  chain output {
+                          type nat hook output priority -100; policy accept;
+                          ip daddr != \$private-ips tcp dport { 80, 443 } counter dnat to \$default-ip:8443
+                  }
+          }
+          EOF
+
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:


### PR DESCRIPTION
self-hosted runners have very restrictive rules for network access. As a result, pulling docker base images to build and publish OCI images requires a proxy. IS devops has been working on this solution called aproxy, which will eventually be installed by default on the self-hosted runners. So eventually we can just remove this section from the workflow, but for now it's needed in order to get OCI image publishing working again.

## Testing
I ran the action against this branch and it passed here: https://github.com/canonical/testflinger/actions/runs/6795492316/job/18473690576