### PR TITLE
Add updates to agent charm README for debugging methods

### DIFF
--- a/agent/charms/testflinger-agent-charm/README.md
+++ b/agent/charms/testflinger-agent-charm/README.md
@@ -1,10 +1,13 @@
 # Overview
 
-This is the charm to deploy the testflinger-agent project.  You can find
-the source for testflinger at: https://github.com/canonical/testflinger-agent
+This is the charm to deploy Testflinger agents to an agent host.  You can find
+the source for testflinger at: https://github.com/canonical/testflinger
 
 The source for testflinger-agent will be pulled directly from git trunk on the
-project listed above, for now.
+project listed above. This creates a sparse/shallow checkout of testflinger
+which only includes the "agent" and "device-connectors" directories since it
+doesn't require all of the other parts of the monorepo, and this keeps
+the space used for the git checkout to a minimum.
 
 # Building
 To build this charm, first install charmcraft (sudo snap install --classic
@@ -21,3 +24,15 @@ Supported options for this charm are:
       base64 encoded string with the config file for spi-agent
   - device-configfile:
       base64 encoded string with the config file for snappy-device-agents
+
+# Debugging
+For local debugging, it might be useful to switch branches and pull updates
+in order to test or debug new code. However, because we only clone the
+minimum required things from git, you will not see other branches
+automatically. In order to change your local clone so that you will see
+everythiing, run:
+
+   ```bash 
+   $ git remote set-branches origin '*'
+   $ git fetch origin
+   ```


### PR DESCRIPTION
This is something @nancyc12 and I were talking about earlier in the week, and might be useful to others also when working on agent changes, new agents, etc. If you need to do local debugging on an agent that has been deployed with the juju charm, it needs a few extra steps in order to update the code, switch branches, etc. due to the sparse/shallow checkout that we use.