### PR TITLE
Riverside: Workaround PDU issue LP#2039983

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -322,6 +322,20 @@ class MuxPi:
                 )
                 cmd = f"sudo cp {remote_tmp}/user-data {ci_path}"
                 self._run_control(cmd)
+
+                # Set grub timeouts to 0 to workaround reboot getting stuck
+                # if spurious input is received on serial
+                cmd = (
+                    "sudo sed -i 's/timeout=[0-9]*/timeout=0/g' "
+                    f"{base}/boot/grub/grub.cfg"
+                )
+                self._run_control(cmd)
+                cmd = (
+                    f"grep -rl 'GRUB_TIMEOUT=' {base}/etc/default/ | xargs "
+                    "sudo sed -i 's/GRUB_TIMEOUT=[0-9]*/GRUB_TIMEOUT=0/g'"
+                )
+                self._run_control(cmd)
+
                 self._configure_sudo()
                 return
             if image_type == "pi-desktop":


### PR DESCRIPTION
## Description
For Riverside, Jetson AGX, we experienced a weird issue while performing cold reboot with PDU (as part of the TF provisioning phase), with GRUB stopping its countdown counter and waiting while displaying its GRUB menu. This PR should workaround that issue by disabling the countdown counter and directly launching linux from GRUB.
<!--
Describe your changes here:
-->

## Resolved issues
This PR fixes issue https://bugs.launchpad.net/bugs/2039983

<!--
-->

## Documentation

<!--
-->

## Tests
I have tested the commands used to change the GRUB configuration, but not using snappy-device-agent

<!--
-->
