### PR TITLE
Use the same docker container version in docker-compose as production

### DIFF
--- a/server/devel/docker-compose.override.yml
+++ b/server/devel/docker-compose.override.yml
@@ -1,10 +1,8 @@
 services:
   mongo:
     environment:
-      - MONGODB_USERNAME=testflinger
-      - MONGODB_PASSWORD=testflinger
-      - MONGODB_DATABASE=testflinger_db
-      - MONGODB_ROOT_PASSWORD=testflinger
+      - MONGO_INITDB_ROOT_USERNAME=testflinger
+      - MONGO_INITDB_ROOT_PASSWORD=testflinger
 
   testflinger:
     command: gunicorn --bind 0.0.0.0:5000 --reload testflinger:app
@@ -13,7 +11,7 @@ services:
       - MONGODB_PASSWORD=testflinger
       - MONGODB_DATABASE=testflinger_db
       - MONGODB_HOST=mongo
-      - MONGODB_AUTH_SOURCE=testflinger_db
+      - MONGODB_AUTH_SOURCE=admin
     volumes:
       - .:/srv/testflinger
 

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   mongo:
-    image: bitnami/mongodb:latest
+    image: mongo:5
     env_file:
       - testflinger.env
     ports:


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

Previously, we were using the bitnami version of the mongodb containers when we thought we were going to do pure k8s deployments. However, now that we are deploying with juju, the charm is using the upstream default "mongo" docker container at version 5. Let's make the local dev env you can deploy with docker-compose match that so that it's more consistent.

## Resolved issues

No major issues that I've run into, but I think it's a good idea to have it be as consistent as we can for local testing.

## Documentation
I updated the example docker-compose.override.yml with the updated env var names for the docker container, since those changed.

## Tests
Tested locally by following the instructions in HACKING.md and launching docker compose.
