### PR TITLE
Disable the renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "dependencyDashboard": false
 }


### PR DESCRIPTION
## Description

Turn off the dependency dashboard in renovate, which files periodic bugs with pointers to the PRs that it has recently created like this: https://github.com/canonical/testflinger/issues/29

## Resolved issues
Our jira sync tool has been automatically turning these into jira issues, which is really annoying. But I also don't feel like we need the github issue either, just to point us to some PRs. So I'm suggesting we turn it off.

## Documentation
Nothing for us, but the documentation [here](https://docs.renovatebot.com/key-concepts/dashboard/) seems to indicate that this should work.

## Tests

I'm not really sure how to test this since renovate has to see this merged in our repo in order to take action on it. But the docs above say this should work if I'm reading it right.