### PR TITLE
Limit the charm libs check to server/charm/**

### DIFF
--- a/.github/workflows/server-charm-check-libs.yml
+++ b/.github/workflows/server-charm-check-libs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - server/charm/**
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/server-charm-check-libs.yml
+++ b/.github/workflows/server-charm-check-libs.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - server/**
+      - server/charm/**
 
 jobs:
   build:


### PR DESCRIPTION
## Description

Limits the charm libs check to `server/charm/**`

## Resolved issues

Just a small observation made when reviewing the fact that we have the action executed.

## Documentation

The workflow definition is the documentation.

## Tests

Fine to see if it just works.