### PR TITLE
Fix: Change expected master boot string for netboot back

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
@@ -189,7 +189,7 @@ class Netboot:
         except Exception:
             # Any connection error will fail through the normal path
             pass
-        if "Testflinger Test Device Imager" in str(data):
+        if "Snappy Test Device Imager" in str(data):
             return True
         else:
             return False


### PR DESCRIPTION
## Description

For netboot images (just plano gadgets use this), there's an initramfs with a small binary that let's us push around images, reformat the drive, etc. There's a string that it sends back if you hit it to confirm that we are in that image, and this device connector needs to expect that properly, even though it uses old names.

## Resolved issues

Right now, netboot provisioning won't work on a few devices because this is expecting the wrong thing back

## Documentation
## Tests

No changes, this is just changing the expected output back to how it previously was when it worked.
