### PR TITLE
Remove aproxy since self-hosted runners should have it now

### DIFF
--- a/.github/workflows/server-publish-oci-image.yml
+++ b/.github/workflows/server-publish-oci-image.yml
@@ -27,31 +27,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Aproxy Snap
-        run: |
-          sudo snap install --edge aproxy
-
-      - name: Configure Aproxy
-        run: |
-          sudo snap set aproxy proxy=squid.internal:3128
-          sudo nft -f - << EOF
-          define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
-          define private-ips = { 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16 }
-          table ip aproxy
-          flush table ip aproxy
-          table ip aproxy {
-                  chain prerouting {
-                          type nat hook prerouting priority dstnat; policy accept;
-                          ip daddr != \$private-ips tcp dport { 80, 443 } counter dnat to \$default-ip:8443
-                  }
-
-                  chain output {
-                          type nat hook output priority -100; policy accept;
-                          ip daddr != \$private-ips tcp dport { 80, 443 } counter dnat to \$default-ip:8443
-                  }
-          }
-          EOF
-
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:

--- a/.github/workflows/server-publish-oci-image.yml
+++ b/.github/workflows/server-publish-oci-image.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          config-inline: |
+            [registry."docker.io"]
+              mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
 
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description
Remove aproxy setup and add docker-registry settings for self-hosted runners

## Resolved issues
Fix issues with oci image publication

## Documentation
n/a

## Tests

Tested here:
https://github.com/canonical/testflinger/actions/runs/7186345158/job/19571853028
