### PR TITLE
Switch `testflinger-cli` to `core22` base

### DIFF
--- a/cli/snapcraft.yaml
+++ b/cli/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
   server for submitting test jobs, checking status, getting results, and
   streaming output.
 confinement: strict
-base: core20
+base: core22
 adopt-info: testflinger-cli
 
 architectures:

--- a/cli/snapcraft.yaml
+++ b/cli/snapcraft.yaml
@@ -31,6 +31,6 @@ parts:
     source: .
     override-pull: |
       set -e
-      snapcraftctl pull
-      snapcraftctl set-version "$(date +%Y%m%d)"
-      snapcraftctl set-grade "stable"
+      craftctl default
+      craftctl set-version "$(date +%Y%m%d)"
+      craftctl set-grade "stable"

--- a/cli/snapcraft.yaml
+++ b/cli/snapcraft.yaml
@@ -33,4 +33,4 @@ parts:
     override-pull: |
       set -e
       craftctl default
-      craftctl set-version "$(date +%Y%m%d)"
+      craftctl set version="$(date +%Y%m%d)"

--- a/cli/snapcraft.yaml
+++ b/cli/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   streaming output.
 confinement: strict
 base: core22
+grade: stable
 adopt-info: testflinger-cli
 
 architectures:
@@ -33,4 +34,3 @@ parts:
       set -e
       craftctl default
       craftctl set-version "$(date +%Y%m%d)"
-      craftctl set-grade "stable"


### PR DESCRIPTION
Switching to `core22` will use `python3.10` instead of `python3.8` from `core20`.