### PR TITLE
Build the cli snap for all archs

### DIFF
--- a/cli/snapcraft.yaml
+++ b/cli/snapcraft.yaml
@@ -10,9 +10,8 @@ grade: stable
 adopt-info: testflinger-cli
 
 architectures:
-  - build-on: amd64
-  - build-on: arm64
-  - build-on: armhf
+  - build-on: [amd64]
+    build-for: [all]
 
 apps:
   testflinger-cli:


### PR DESCRIPTION
## Description

Simon just pushed a change to update the base to core22 and I noticed after it landed that it only built for amd64. This is because we're in a monorepo now, so we couldn't continue using the snapcraft.io build infrastructure and had to switch to self-hosted runners - but they are only am64 right now. Fortunately, it's python and we don't really need to build *on* other archs. It should be sufficient to build once and run on all.

## Resolved issues
Without this, we wouldn't have a snap for any other arch besides amd64. Which might not be an issue, or it might. At least it preserves that in case others are using it on other archs.

## Documentation
no doc changes needed, snap install still works the same for it

## Tests
Built locally
