### PR TITLE
Add add hp_oemscript device connector

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2023 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Ubuntu OEM Recovery Provisioning for HP OEM devices
+Use this for systems that can use the oem recovery-from-iso.sh script
+for provisioning, but require the --ubr flag in order to use the
+"ubuntu recovery" method.
+"""
+
+import logging
+
+import yaml
+
+import testflinger_device_connectors
+from testflinger_device_connectors import logmsg
+from testflinger_device_connectors.devices import (
+    DefaultDevice,
+    RecoveryError,
+    catch,
+)
+from .hp_oemscript import HPOemScript
+
+device_name = "hp_oemscript"
+
+
+class DeviceConnector(DefaultDevice):
+
+    """Tool for provisioning HP OEM devices with an oem image."""
+
+    @catch(RecoveryError, 46)
+    def provision(self, args):
+        """Method called when the command is invoked."""
+        with open(args.config) as configfile:
+            config = yaml.safe_load(configfile)
+        testflinger_device_connectors.configure_logging(config)
+        device = HPOemScript(args.config, args.job_data)
+        logmsg(logging.INFO, "BEGIN provision")
+        logmsg(logging.INFO, "Provisioning device")
+        device.provision()
+        logmsg(logging.INFO, "END provision")

--- a/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/hp_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/hp_oemscript.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Ubuntu OEM Script provisioning for HP OEM devices
+this for systems that can use the oem recovery-from-iso.sh script
+for provisioning, but require the --ubr flag in order to use the
+"ubuntu recovery" method.
+"""
+
+import logging
+from testflinger_device_connectors.devices.oemscript.oemscript import OemScript
+
+logger = logging.getLogger()
+
+
+class HPOemScript(OemScript):
+    """Device Agent for HP OEM devices."""
+
+    # Extra arguments to pass to the OEM script
+    extra_script_args = ["--ubr"]

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -30,3 +30,5 @@ To specify the commands to run by the device in each test phase, set the ``testf
      - This device connector is used for Dell OEM devices running certain versions of OEM supported images that can use a recovery partition to recover not only the same image, but in some cases, other OEM image versions as well.
    * - ``lenovo_oemscript`` 
      - This device connector is used for Lenovo OEM devices running certain versions of OEM supported images that can use a recovery partition to recover not only the same image, but in some cases, other OEM image versions as well.
+   * - ``hp_oemscript`` 
+     - This device connector is used for HP OEM devices running certain versions of OEM supported images that can use a recovery partition to recover not only the same image, but in some cases, other OEM image versions as well.


### PR DESCRIPTION
## Description

This adds oemscript provisioning for hp devices explicitly. Functionally, there's no difference right now between this and the lenovo one since both require the ubr flag, but that might change in the future.

## Resolved issues
Allows hp oem systems to be configured for provisioning oem images.

## Documentation
Added a mention of it in the reference section of the docs like the other types have.

## Tests
This was tested a while back by Kevin, though I think at the time he was just using the lenovo one. Since all that's happening here are string changes, I don't suspect there should be a problem, but it might be useful to try it on one system first before rolling it out to all the others.
