### PR TITLE
When building the arch-independent snap, don't pip install binaries

### DIFF
--- a/cli/snapcraft.yaml
+++ b/cli/snapcraft.yaml
@@ -29,6 +29,8 @@ parts:
   testflinger-cli:
     plugin: python
     source: .
+    build-environment:
+    - PIP_NO_BINARY: ":all:"
     override-pull: |
       set -e
       craftctl default


### PR DESCRIPTION
## Description
Adjust snapcraft.yaml to avoid installing binaries with pip for the arch-independent snap.

## Resolved issues
Snap publication was previously failing in the new github action due to this error:
```
- found binaries for architecture 'all': lib/python3.10/site-packages/charset_normalizer/md.cpython-310-x86_64-linux-gnu.so, lib/python3.10/site-packages/charset_normalizer/md__mypyc.cpython-310-x86_64-linux-gnu.so, lib/python3.10/site-packages/yaml/_yaml.cpython-310-x86_64-linux-gnu.so
```
Basically we were pulling binaries for some things like cpython. However we don't really need those binaries for it to run correctly. We can prevent this through some extra pip options, which are now set in the build-environment section of the snapcraft yaml.

## Documentation
n/a

## Tests

I forced the action to run against this branch and the snap built and published - https://canonical.greenhouse.io/scorecards/75984869
