### PR TITLE
Add provision_type field to agent data

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -32,13 +32,19 @@ class TestflingerAgent:
     def _post_initial_agent_data(self):
         """Post the initial agent data to the server once on agent startup"""
 
-        location = self.client.config.get("location", "")
         self._post_advertised_queues()
         self._post_advertised_images()
 
-        queues = self.client.config.get("job_queues", [])
         identifier = self.client.config.get("identifier")
-        agent_data = {"queues": queues, "location": location}
+        location = self.client.config.get("location", "")
+        provision_type = self.client.config.get("provision_type", "")
+        queues = self.client.config.get("job_queues", [])
+
+        agent_data = {
+            "location": location,
+            "queues": queues,
+            "provision_type": provision_type,
+        }
         if identifier:
             agent_data["identifier"] = identifier
 

--- a/agent/testflinger_agent/tests/test_agent.py
+++ b/agent/testflinger_agent/tests/test_agent.py
@@ -25,6 +25,7 @@ class TestClient:
             "server_address": "127.0.0.1:8000",
             "job_queues": ["test"],
             "location": "nowhere",
+            "provision_type": "noprovision",
             "execution_basedir": self.tmpdir,
             "logging_basedir": self.tmpdir,
             "results_basedir": os.path.join(self.tmpdir, "results"),
@@ -219,5 +220,6 @@ class TestClient:
                     "identifier": self.config["identifier"],
                     "queues": self.config["job_queues"],
                     "location": self.config["location"],
+                    "provision_type": self.config["provision_type"],
                 }
             )

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -27,6 +27,7 @@ class AgentIn(Schema):
     state = fields.String(required=False)
     queues = fields.List(fields.String(), required=False)
     location = fields.String(required=False)
+    provision_type = fields.String(required=False)
     job_id = fields.String(required=False)
     log = fields.List(fields.String(), required=False)
 
@@ -37,6 +38,7 @@ class AgentOut(Schema):
     state = fields.String(required=False)
     queues = fields.List(fields.String(), required=False)
     location = fields.String(required=False)
+    provision_type = fields.String(required=False)
     job_id = fields.String(required=False)
 
 

--- a/server/src/templates/agent_detail.html
+++ b/server/src/templates/agent_detail.html
@@ -6,6 +6,7 @@
     Agent Name: {{ agent.name }}<br>
     State: {{ agent.state }}<br>
     Location: {{ agent.location }}<br>
+    Provision Type: {{ agent.provision_type }}<br>
     Last Updated: {{ agent.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}<br>
     </p>
     <p>


### PR DESCRIPTION
## Description
Add provision_type to the agent data that we store on the server

## Resolved issues
CERTTF-277

## Documentation
Nothing really, but openapi schema updated appropriately so that it will show up there for reference.

## Tests
Tested locally, and unit tests adjusted
