### PR TITLE
Add identifier to the schema so that it's imported properly

### DIFF
--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -24,11 +24,12 @@ from apiflask.validators import OneOf
 class AgentIn(Schema):
     """Agent data input schema"""
 
-    state = fields.String(required=False)
-    queues = fields.List(fields.String(), required=False)
-    location = fields.String(required=False)
+    identifier = fields.String(required=False)
     job_id = fields.String(required=False)
+    location = fields.String(required=False)
     log = fields.List(fields.String(), required=False)
+    queues = fields.List(fields.String(), required=False)
+    state = fields.String(required=False)
 
 
 class AgentOut(Schema):


### PR DESCRIPTION
## Description
I think I may have just missed git adding the schema file from when I originally merged the support for sending identifer.

## Resolved issues
Without this, the identifier will be sent to the server, but it will just be thrown out as it's not part of the expected input data.

## Documentation
No changes, but adding it to the schema will automatically update the openapi docs

## Tests
Tested locally
