### PR TITLE
Tagged job searching

### DIFF
--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -13,3 +13,4 @@ Work with jobs via Testflinger CLI
     change-server
     submit-job
     cancel-job
+    search-job

--- a/docs/how-to/search-job.rst
+++ b/docs/how-to/search-job.rst
@@ -1,0 +1,63 @@
+Search Jobs
+=============
+
+You can search for jobs based on the following criteria:
+   * tags
+   * state
+
+
+Searching by Tags
+------------------
+
+Tags can make it easier to find related jobs later. For instance, tools like
+spread have a need to find currently running jobs so that they can be
+cancelled once they are done using those devices for their testing.
+
+To add tags to a job submission, add a section like this with one or more tags
+in your job yaml:
+
+.. code-block:: yaml
+
+      tags:
+        - myproject
+        - client
+
+Testflinger doesn't use any of this information, but it makes it easier for
+you to search for those jobs later.
+
+The search API allows you to search for jobs based on tags and state. To
+search for a jobs by tag, you can provide one or more tags in the query string:
+
+.. code-block:: console
+
+      $ curl 'http://localhost:8000/v1/job/search?tags=foo&tags=bar'
+
+By default, the search API will return jobs that match any of the tags. To
+require that all tags match, you can provide the "match" query parameter with
+the value "all":
+
+.. code-block:: console
+
+      $ curl 'http://localhost:8000/v1/job/search?tags=foo&tags=bar&match=all'
+
+Searching by Job State
+-----------------------
+
+By default, the search API will only return jobs that are not already marked as
+cancelled or completed. To specify searching for jobs in a specific state, you
+can provide the "state" query parameter with one of the
+:doc:`test phases <../reference/test-phases>`:
+
+.. code-block:: console
+
+      $ curl 'http://localhost:8000/v1/job/search?state=provision'
+
+You can also search specify more than one state to match against. Obviously,
+since a job can only be in one state at a given moment, the matching mode
+for this will always be "any".
+
+.. code-block:: console
+
+      $ curl 'http://localhost:8000/v1/job/search?state=cancelled&state=completed'
+
+This can be done with or without providing tags in the search query.

--- a/docs/how-to/search-job.rst
+++ b/docs/how-to/search-job.rst
@@ -43,10 +43,9 @@ the value "all":
 Searching by Job State
 -----------------------
 
-By default, the search API will only return jobs that are not already marked as
-cancelled or completed. To specify searching for jobs in a specific state, you
-can provide the "state" query parameter with one of the
-:doc:`test phases <../reference/test-phases>`:
+By default, the search API will match jobs in any state.  To specify searching
+for jobs in a specific state, you can provide the "state" query parameter with
+one of the :doc:`test phases <../reference/test-phases>`:
 
 .. code-block:: console
 
@@ -60,4 +59,12 @@ for this will always be "any".
 
       $ curl 'http://localhost:8000/v1/job/search?state=cancelled&state=completed'
 
-This can be done with or without providing tags in the search query.
+To only search for jobs that have not been cancelled or completed, you can
+specify "active" for the state.
+
+.. code-block:: console
+
+      $ curl 'http://localhost:8000/v1/job/search?state=active'
+
+Searching for jobs by state can be done with or without providing tags in the
+search query.

--- a/docs/reference/job-schema.rst
+++ b/docs/reference/job-schema.rst
@@ -16,6 +16,11 @@ The following table lists the key elements that a job definition file should con
     - String
     - /
     - Name of the job queue to which you want to submit the job. This field is mandatory.
+  * - ``tags``
+    - List of strings
+    - /
+    - | (Optional) List of tags that you want to associate with the job. 
+      | Tags can be used to search for jobs with the search API.
   * - ``global_timeout``
     - integer
     - | 14400

--- a/server/README.rst
+++ b/server/README.rst
@@ -142,7 +142,7 @@ Parameters:
 
 tags (array): List of string tags to search for
 match (string): Match mode for tags - "all" or "any" (default "any")
-state (array): List of job states to include (default all states other than cancelled and completed)
+state (array): List of job states to include (or "active" to search all states other than cancelled and completed)
 Returns:
 
 Array of matching jobs

--- a/server/README.rst
+++ b/server/README.rst
@@ -136,6 +136,26 @@ server will only return one job.
     $ curl http://localhost:8000/v1/job?queue=foo\&queue=bar
 
 
+** [GET] /v1/job/search ** - Search for jobs by tag(s) and state(s)
+
+Parameters:
+
+tags (array): List of string tags to search for
+match (string): Match mode for tags - "all" or "any" (default "any")
+state (array): List of job states to include (default all states other than cancelled and completed)
+Returns:
+
+Array of matching jobs
+
+Example:
+
+.. code-block:: console
+
+$ curl 'http://localhost:8000/v1/job/search?tags=foo&tags=bar&match=all'
+
+This will find jobs tagged with both "foo" and "bar".
+
+
 **[POST] /v1/result/<job_id>** - post job outcome data for the specified job_id
 
 - Parameters:

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -21,6 +21,21 @@ from apiflask import Schema, fields
 from apiflask.validators import OneOf
 
 
+ValidJobStates = (
+    "setup",
+    "provision",
+    "firmware_update",
+    "test",
+    "allocate",
+    "allocated",
+    "reserve",
+    "cleanup",
+    "cancelled",
+    "completed",
+    "active",  # fake state for jobs that are not completed or cancelled
+)
+
+
 class AgentIn(Schema):
     """Agent data input schema"""
 
@@ -78,10 +93,12 @@ class JobSearchRequest(Schema):
 
     tags = fields.List(fields.String, description="List of tags to search for")
     match = fields.String(
-        description="Match mode - 'all' or 'any' (default 'any')"
+        description="Match mode - 'all' or 'any' (default 'any')",
+        validate=OneOf(["any", "all"]),
     )
     state = fields.List(
-        fields.String, description="List of job states to include"
+        fields.String(validate=OneOf(ValidJobStates)),
+        description="List of job states to include",
     )
 
 

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -73,6 +73,24 @@ class JobId(Schema):
     job_id = fields.String(required=True)
 
 
+class JobSearchRequest(Schema):
+    """Job search request schema"""
+
+    tags = fields.List(fields.String, description="List of tags to search for")
+    match = fields.String(
+        description="Match mode - 'all' or 'any' (default 'any')"
+    )
+    state = fields.List(
+        fields.String, description="List of job states to include"
+    )
+
+
+class JobSearchResponse(Schema):
+    """Job search response schema"""
+
+    jobs = fields.List(fields.Nested(Job), required=True)
+
+
 class Result(Schema):
     """Result schema"""
 

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -55,6 +55,7 @@ class Job(Schema):
     job_id = fields.String(required=False)
     parent_job_id = fields.String(required=False)
     name = fields.String(required=False)
+    tags = fields.List(fields.String(), required=False)
     job_queue = fields.String(required=True)
     global_timeout = fields.Integer(required=False)
     output_timeout = fields.Integer(required=False)

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -155,20 +155,16 @@ def search_jobs(query_data):
     match = request.args.get("match", "any")
     states = request.args.getlist("state")
 
-    if match not in ["any", "all"]:
-        abort(400, "Invalid match mode")
-
     query = {}
     if tags and match == "all":
         query["job_data.tags"] = {"$all": tags}
     elif tags and match == "any":
         query["job_data.tags"] = {"$in": tags}
 
-    if states:
-        query["result_data.job_state"] = {"$in": states}
-    else:
-        # Exclude terminal states by default
+    if "active" in states:
         query["result_data.job_state"] = {"$nin": ["cancelled", "complete"]}
+    elif states:
+        query["result_data.job_state"] = {"$in": states}
 
     pipeline = [
         {"$match": query},

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -33,7 +33,7 @@ def test_home(mongo_app):
 
 def test_add_job_good(mongo_app):
     """Test that adding a new job works"""
-    job_data = {"job_queue": "test"}
+    job_data = {"job_queue": "test", "tags": ["foo", "bar"]}
     # Place a job on the queue
     app, _ = mongo_app
     output = app.post("/v1/job", json=job_data)


### PR DESCRIPTION
## Description

The motivation for this is to help support the creation of a spread backend for testflinger. (see jira card below)
The spread backend would submit a job that requests the devices it wants but only have them provision and stay in the allocate state. Then it would later go clean up the ones that were left. Ideally, it should just use the job_id and cancel the jobs once it's done with them, but they have some circumstances where they are unable to retain those job IDs and need to find the jobs somehow. They accomplish this on some of the cloud backends they support by tagging the systems they are using, then searching for them by that tag name. They also need the timestamp when the job was created so they can automate cancellation of the ones that are old.

The search API here defaults to only consider jobs that are active (not cancelled or completed). However, it was pretty straightforward to also add support for specifying that you wan to search for jobs in a specific state. This could be used for all sorts of other things, and I think the search API might be extended in the future to cover some other needs that we haven't though of yet.

## Resolved issues

Fixes [CERTTF-192](https://warthogs.atlassian.net/browse/CERTTF-192https://warthogs.atlassian.net/browse/CERTTF-192)

## Documentation

Documentation added to the README and also to the job_schema reference docs.

## Tests

Unit tests modified and added to cover both the addition of tags to the job, as well as the search API and all the different ways it can be used. I also tried this out locally of course.


[CERTTF-192]: https://warthogs.atlassian.net/browse/CERTTF-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ