### PR TITLE
Fix potential unhandled exception when no advertised queues found

### DIFF
--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -372,6 +372,8 @@ def images_get(queue):
     queue_data = mongo.db.queues.find_one(
         {"name": queue}, {"_id": False, "images": True}
     )
+    if not queue_data:
+        return jsonify({})
     # It's ok for this to just return an empty result if there are none found
     return jsonify(queue_data.get("images", {}))
 


### PR DESCRIPTION
## Description
Small opportunistic fix for something I spotted in the log files. Not causing any real problem that I can see, but it spams the logs a bit when it happens.

## Resolved issues
```
│2024-01-30T05:31:17.855Z [testflinger] Unhandled Exception: 'NoneType' object has no attribute 'get'                                                                                 │
│2024-01-30T05:31:17.855Z [testflinger] Traceback (most recent call last):                                                                                                            │
│2024-01-30T05:31:17.855Z [testflinger]   File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 867, in full_dispatch_request                                             │
│2024-01-30T05:31:17.855Z [testflinger]     rv = self.dispatch_request()                                                                                                              │
│2024-01-30T05:31:17.855Z [testflinger]   File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 852, in dispatch_request                                                  │
│2024-01-30T05:31:17.855Z [testflinger]     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)                                                                  │
│2024-01-30T05:31:17.855Z [testflinger]   File "/usr/local/lib/python3.10/dist-packages/apiflask/scaffold.py", line 87, in wrapper                                                    │
│2024-01-30T05:31:17.855Z [testflinger]     return current_app.ensure_sync(f)(*args, **kwargs)                                                                                        │
│2024-01-30T05:31:17.855Z [testflinger]   File "/srv/testflinger/src/api/v1.py", line 339, in images_get                                                                              │
│2024-01-30T05:31:17.855Z [testflinger]     return jsonify(queue_data.get("images", {}))                                                                                              │
│2024-01-30T05:31:17.855Z [testflinger] AttributeError: 'NoneType' object has no attribute 'get'
```

