### PR TITLE
Use importlib instead of imp

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/__init__.py
@@ -32,7 +32,6 @@ device_name = "cm3"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning baremetal with a given image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
@@ -32,7 +32,6 @@ logger = logging.getLogger()
 
 
 class CM3:
-
     """Device Connector for CM3."""
 
     IMAGE_PATH_IDS = {

--- a/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
@@ -36,7 +36,6 @@ device_name = "dell_oemscript"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning Dell OEM devices with an oem image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/dragonboard/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dragonboard/__init__.py
@@ -34,7 +34,6 @@ device_name = "dragonboard"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning baremetal with a given image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
@@ -33,7 +33,6 @@ logger = logging.getLogger()
 
 
 class Dragonboard:
-
     """Testflinger Device Connector for Dragonboard."""
 
     def __init__(self, config, job_data):

--- a/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
@@ -36,7 +36,6 @@ device_name = "hp_oemscript"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning HP OEM devices with an oem image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
@@ -36,7 +36,6 @@ device_name = "lenovo_oemscript"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning Lenovo OEM devices with an oem image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
@@ -33,7 +33,6 @@ device_name = "maas2"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning baremetal with a given image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -37,7 +37,6 @@ logger = logging.getLogger()
 
 
 class Maas2:
-
     """Device Connector for Maas2."""
 
     def __init__(self, config, job_data):

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
@@ -32,7 +32,6 @@ device_name = "multi"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Device Connector for provisioning multiple devices at the same time"""
 
     def init_device(self, args):

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
@@ -25,7 +25,6 @@ logger = logging.getLogger()
 
 
 class Multi:
-
     """Device Connector for multi-device"""
 
     def __init__(self, config, job_data, client):

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
@@ -32,7 +32,6 @@ device_name = "muxpi"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning baremetal with a given image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -32,7 +32,6 @@ logger = logging.getLogger()
 
 
 class MuxPi:
-
     """Device Connector for MuxPi."""
 
     IMAGE_PATH_IDS = {

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
@@ -34,7 +34,6 @@ device_name = "netboot"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning baremetal with a given image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
@@ -31,7 +31,6 @@ logger = logging.getLogger()
 
 
 class Netboot:
-
     """Testflinger Device Connector for Netboot."""
 
     def __init__(self, config):

--- a/device-connectors/src/testflinger_device_connectors/devices/noprovision/noprovision.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/noprovision/noprovision.py
@@ -29,7 +29,6 @@ logger = logging.getLogger()
 
 
 class Noprovision:
-
     """Testflinger Device Connector for Noprovision."""
 
     def __init__(self, config):

--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/__init__.py
@@ -33,7 +33,6 @@ device_name = "oemrecovery"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning baremetal with a given image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
@@ -30,7 +30,6 @@ logger = logging.getLogger()
 
 
 class OemRecovery:
-
     """Device Connector for OEM Recovery."""
 
     def __init__(self, config, job_data):

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/__init__.py
@@ -31,7 +31,6 @@ device_name = "oemscript"
 
 
 class DeviceConnector(DefaultDevice):
-
     """Tool for provisioning baremetal with a given image."""
 
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
@@ -1,6 +1,5 @@
 """Device class for flashing firmware on device supported by LVFS-fwupd"""
 
-
 import subprocess
 import json
 import time

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
@@ -1,6 +1,5 @@
 """Test LVFSDevice"""
 
-
 import unittest
 import json
 from unittest.mock import patch
@@ -93,9 +92,9 @@ class TestLVFSDevice(unittest.TestCase):
             device = LVFSDevice("", "", "")
             device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
             device_results = json.loads(fwupd_data.GET_RESULTS_RESPONSE_DATA)
-            device_results[
-                "UpdateState"
-            ] = FwupdUpdateState.FWUPD_UPDATE_STATE_SUCCESS.value
+            device_results["UpdateState"] = (
+                FwupdUpdateState.FWUPD_UPDATE_STATE_SUCCESS.value
+            )
             device_results["Releases"][0]["Version"] = "2.90"
             device.fw_info[2]["targetVersion"] = "2.90"
             self.assertTrue(device.check_results())

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
@@ -1,6 +1,5 @@
 """Test detect_device in firmware_update.py"""
 
-
 import unittest
 import pytest
 from unittest.mock import patch

--- a/device-connectors/src/tests/test_cmd.py
+++ b/device-connectors/src/tests/test_cmd.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+"""Tests for the cmd argument parser"""
+
+import pytest
+from testflinger_device_connectors.cmd import get_args
+
+
+def test_good_args():
+    """Test that we can parse good arguments"""
+    argv = ["noprovision", "reserve", "-c", "config.cfg", "job_data.json"]
+
+    args = get_args(argv)
+
+    assert args.device == "noprovision"
+    assert args.stage == "reserve"
+    assert args.config == "config.cfg"
+    assert args.job_data == "job_data.json"
+
+
+def test_invalid_device():
+    """Test that an invalid device raises an exception"""
+    argv = ["INVALID", "provision", "-c", "config.cfg", "job_data.json"]
+
+    with pytest.raises(SystemExit) as err:
+        get_args(argv)
+    assert err.value.code == 2
+
+
+def test_invalid_stage():
+    """Test that an invalid stage raises an exception"""
+    argv = ["INVALID", "provision", "-c", "config.cfg", "job_data.json"]
+
+    with pytest.raises(SystemExit) as err:
+        get_args(argv)
+    assert err.value.code == 2

--- a/device-connectors/src/tests/test_devices.py
+++ b/device-connectors/src/tests/test_devices.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+"""Tests for the devices module"""
+
+from importlib import import_module
+from itertools import product
+
+import pytest
+
+from testflinger_device_connectors.cmd import STAGES
+from testflinger_device_connectors.devices import (
+    DEVICE_CONNECTORS,
+    get_device_stage_func,
+)
+
+STAGES_CONNECTORS_PRODUCT = tuple(product(STAGES, DEVICE_CONNECTORS))
+
+
+@pytest.mark.parametrize("stage,device", STAGES_CONNECTORS_PRODUCT)
+def test_get_device_stage_func(stage, device):
+    """Check that we can load all stages from all device connectors"""
+    connector_instance = import_module(
+        f"testflinger_device_connectors.devices.{device}"
+    ).DeviceConnector()
+    orig_func = getattr(connector_instance, stage)
+    func = get_device_stage_func(device, stage)
+    assert func.__func__ is orig_func.__func__


### PR DESCRIPTION
## Description
- replace imp (deprecated in python 3.12) with importlib
- specify the list of supported connector modules rather than trying to detect them
- rework the argument subparsers to avoid loading unnecessary connectors
- add more tests

## Resolved issues

imp is deprecated and will no longer be available starting with python 3.12. That's not affecting us just yet, but noble looks likely to ship with python 3.12, so as an LTS it could be the new foundation that we deploy on very soon.
Also a good opportunity for some other related improvements

## Documentation
No real functional change, but should speed things up slightly when running the device connector.

## Tests
- added some unit tests, for argument parsing and initial load of the connectors
- tested on an agent running against staging
