### PR TITLE
device-name in connector modules is no longer needed

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/__init__.py
@@ -28,8 +28,6 @@ from testflinger_device_connectors.devices import (
 )
 from testflinger_device_connectors.devices.cm3.cm3 import CM3
 
-device_name = "cm3"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
@@ -32,8 +32,6 @@ from testflinger_device_connectors.devices import (
 )
 from .dell_oemscript import DellOemScript
 
-device_name = "dell_oemscript"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning Dell OEM devices with an oem image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/dragonboard/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dragonboard/__init__.py
@@ -30,8 +30,6 @@ from testflinger_device_connectors.devices.dragonboard.dragonboard import (
     Dragonboard,
 )
 
-device_name = "dragonboard"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
@@ -32,8 +32,6 @@ from testflinger_device_connectors.devices import (
 )
 from .hp_oemscript import HPOemScript
 
-device_name = "hp_oemscript"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning HP OEM devices with an oem image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/iotscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/iotscript/__init__.py
@@ -2,8 +2,6 @@
 
 from testflinger_device_connectors.devices import DefaultDevice
 
-device_name = "iotscript"
-
 
 class DeviceConnector(DefaultDevice):
     def provision(self, args):

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
@@ -32,8 +32,6 @@ from testflinger_device_connectors.devices import (
 )
 from .lenovo_oemscript import LenovoOemScript
 
-device_name = "lenovo_oemscript"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning Lenovo OEM devices with an oem image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
@@ -29,8 +29,6 @@ from testflinger_device_connectors.devices import (
 )
 from testflinger_device_connectors.devices.maas2.maas2 import Maas2
 
-device_name = "maas2"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
@@ -28,8 +28,6 @@ from testflinger_device_connectors.devices import (
 from testflinger_device_connectors.devices.multi.multi import Multi
 from testflinger_device_connectors.devices.multi.tfclient import TFClient
 
-device_name = "multi"
-
 
 class DeviceConnector(DefaultDevice):
     """Device Connector for provisioning multiple devices at the same time"""

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
@@ -28,8 +28,6 @@ from testflinger_device_connectors.devices import (
 )
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
 
-device_name = "muxpi"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
@@ -30,8 +30,6 @@ import testflinger_device_connectors
 from testflinger_device_connectors import logmsg
 from testflinger_device_connectors.devices.netboot.netboot import Netboot
 
-device_name = "netboot"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/noprovision/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/noprovision/__init__.py
@@ -29,8 +29,6 @@ from testflinger_device_connectors.devices.noprovision.noprovision import (
     Noprovision,
 )
 
-device_name = "noprovision"
-
 
 class DeviceConnector(DefaultDevice):
     @catch(RecoveryError, 46)

--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/__init__.py
@@ -29,8 +29,6 @@ from testflinger_device_connectors.devices.oemrecovery.oemrecovery import (
     OemRecovery,
 )
 
-device_name = "oemrecovery"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/__init__.py
@@ -27,8 +27,6 @@ from testflinger_device_connectors.devices import (
 )
 from testflinger_device_connectors.devices.oemscript.oemscript import OemScript
 
-device_name = "oemscript"
-
 
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""


### PR DESCRIPTION
These names are no longer needed since we don't try to detect the device connectors automatically anymore.
