### PR TITLE
Encode datetime as ISO8601 when returning job search results

### DIFF
--- a/server/src/__init__.py
+++ b/server/src/__init__.py
@@ -29,6 +29,7 @@ from apiflask import APIFlask
 
 from src.database import mongo
 from src.api.v1 import v1
+from src.providers import ISODatetimeProvider
 from src.views import views
 
 # Constants for TTL indexes
@@ -55,6 +56,9 @@ def create_flask_app(config=None):
         tf_log.addHandler(stream_handler)
 
     tf_app.config["PROPAGATE_EXCEPTIONS"] = True
+
+    # Return datetime objects as RFC3339/ISO8601 strings
+    tf_app.json = ISODatetimeProvider(tf_app)
 
     if tf_app.config.get("TESTING") is not True:
         setup_mongodb(tf_app)

--- a/server/src/providers.py
+++ b/server/src/providers.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Custom JSON providers for when jsonify() doesn't do what we want
+"""
+
+from datetime import datetime
+from flask.json.provider import DefaultJSONProvider
+
+
+class ISODatetimeProvider(
+    DefaultJSONProvider
+):  # pylint: disable=too-few-public-methods
+    """Return datetime objects as RFC3339/ISO8601 strings with a 'Z' suffix."""
+
+    def default(self, obj):
+        """Encode datetime objects as ISO8601, no effect on other types."""
+        if isinstance(obj, datetime):
+            return obj.isoformat(timespec="seconds") + "Z"
+        return super().default(obj)


### PR DESCRIPTION
## Description

The spread backend wants RFC3339 compatible datetime fileds. This converts it to a format that is both compatible with that, as well as ISO8601. Nothing in the internal representation is changed, just the string that comes back in the json results from calls to the API.

## Documentation
N/A

## Tests
Unit test added to ensure the field is returned in the correct format