### PR TITLE
Add ZapperConnector base class for Zapper-based device connectors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # OEM Software Engineering
-device-connectors/src/testflinger_device_connectors/devices/iotscript @canonical/oem-swe-iot
+device-connectors/src/testflinger_device_connectors/devices/zapper_iot @canonical/oem-swe-iot

--- a/device-connectors/README.rst
+++ b/device-connectors/README.rst
@@ -23,7 +23,7 @@ testing on other types of devices.
 - noprovision - devices which need to run tests, but can't be provisioned (yet)
 - oemrecovery - anything (such as core fde images) that can't be provisioned but can run a set of commands to recover back to the initial state
 - oemscript - uses a script that supports some oem images and allows injection of an iso to the recovery partition to install that image
-- iotscript - IoT devices which require a Zapper for HW manipulation and OEM-specific actions to get provisioned (UUU, seed-override, ...) 
+- zapper-iot - IoT devices which require a Zapper for HW manipulation and OEM-specific actions to get provisioned (UUU, seed-override, ...) 
 
 
 Exit Status

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -16,6 +16,7 @@ requires-python = ">=3.8"
 dependencies = [
     "PyYAML>=3.11",
     "requests",
+    "rpyc~=5.3.1",
 ]
 
 [project.scripts]

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -39,7 +39,6 @@ DEVICE_CONNECTORS = (
     "dell_oemscript",
     "dragonboard",
     "hp_oemscript",
-    "iotscript",
     "lenovo_oemscript",
     "maas2",
     "multi",
@@ -48,6 +47,7 @@ DEVICE_CONNECTORS = (
     "noprovision",
     "oemrecovery",
     "oemscript",
+    "zapper_iot",
 )
 
 

--- a/device-connectors/src/testflinger_device_connectors/devices/iotscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/iotscript/__init__.py
@@ -1,8 +1,0 @@
-"""OEM IoT provisioner support code."""
-
-from testflinger_device_connectors.devices import DefaultDevice
-
-
-class DeviceConnector(DefaultDevice):
-    def provision(self, args):
-        pass

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -74,6 +74,7 @@ class ZapperConnector(ABC, DefaultDevice):
         Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.
         """
+        raise NotImplementedError
 
     def _run(self, zapper_ip, *args, **kwargs):
         """

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Package containing modules for implementing Zapper-driven device connectors.
+
+Modules inheriting from the provided abstract class will run Zapper-driven
+provisioning procedures via Zapper API. The provisioning logic is implemented
+in the Zapper codebase and the connector serves as a pre-processing step,
+validating the configuration and preparing the API arguments.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Tuple
+
+import rpyc
+import yaml
+
+import testflinger_device_connectors
+from testflinger_device_connectors.devices import (
+    DefaultDevice,
+    RecoveryError,
+    catch,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ZapperConnector(ABC, DefaultDevice):
+    """
+    Abstract base class defining a common interface for Zapper-driven
+    device connectors.
+    """
+
+    PROVISION_METHOD = ""  # to be defined in the implementation
+    ZAPPER_REQUEST_TIMEOUT = 60 * 90
+    ZAPPER_SERVICE_PORT = 60000
+
+    @catch(RecoveryError, 46)
+    def provision(self, args):
+        """Method called when the command is invoked."""
+        with open(args.config) as configfile:
+            config = yaml.safe_load(configfile)
+        testflinger_device_connectors.configure_logging(config)
+
+        (api_args, api_kwargs) = self._validate_configuration(
+            args.config, args.job_data
+        )
+
+        logger.info("BEGIN provision")
+        logger.info("Provisioning device")
+
+        self._run(args.config["controller_host"], *api_args, **api_kwargs)
+
+        logger.info("END provision")
+
+    @abstractmethod
+    def _validate_configuration(
+        self, config, job_data
+    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        """
+        Validate the job config and data and prepare the arguments
+        for the Zapper `provision` API.
+        """
+
+    def _run(self, zapper_ip, *args, **kwargs):
+        """
+        Run the Zapper `provision` API via RPyC. The arguments are
+        not stricly defined so that the same API can be used by different
+        implementations.
+
+        The connector logger is passed as an argument to the Zapper API
+        in order to get a real time feedback throughout the whole execution.
+        """
+
+        connection = rpyc.connect(
+            zapper_ip,
+            self.ZAPPER_SERVICE_PORT,
+            config={
+                "allow_public_attrs": True,
+                "sync_request_timeout": self.ZAPPER_REQUEST_TIMEOUT,
+            },
+        )
+
+        connection.root.provision(
+            self.PROVISION_METHOD,
+            *args,
+            logger=logger,
+            **kwargs,
+        )

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for Zapper base device connector."""
+
+
+import unittest
+from unittest.mock import patch
+from testflinger_device_connectors.devices.zapper import (
+    ZapperConnector,
+    logger,
+)
+
+
+class MockConnector(ZapperConnector):
+    PROVISION_METHOD = "Test"
+
+    def _validate_configuration(self, config, job_data):
+        return (), {}
+
+
+class ZapperConnectorTests(unittest.TestCase):
+    """Unit tests for ZapperConnector class."""
+
+    @patch("rpyc.connect")
+    def test_run(self, mock_connect):
+        """
+        Test the `run` function connects to a Zapper via RPyC
+        and runs the `provision` API.
+        """
+
+        args = (1, 2, 3)
+        kwargs = {"key1": 1, "key2": 2}
+
+        connector = MockConnector()
+        connector._run("localhost", *args, **kwargs)
+
+        api = mock_connect.return_value.root.provision
+        api.assert_called_with(
+            MockConnector.PROVISION_METHOD,
+            *args,
+            logger=logger,
+            **kwargs,
+        )

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Zapper Connector for IOT provisioning."""
+
+from typing import Any, Dict, Tuple
+
+from testflinger_device_connectors.devices.zapper import ZapperConnector
+
+
+class DeviceConnector(ZapperConnector):
+    """Tool for provisioning baremetal with a given image."""
+
+    PROVISION_METHOD = "zapper_iot"
+
+    def _validate_configuration(
+        self, config, job_data
+    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        """
+        Validate the job config and data and prepare the arguments
+        for the Zapper `provision` API.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
## Description

This PR introduces a new device connector base class for Zapper-based provisioning called `ZapperConnector`. Classes who inherits from it are responsible for config/data validation and preparation of arguments for the Zapper `provision` API. The actual logic of the provisioning procedure is implemented and executed on Zapper.

The base class implements the default `_run` method which connects to the Zapper RPyC service and runs the `provision` API. The local logger is passed via API as well so that the execution can be monitored from Testflinger.

Finally, I've removed the temporary _iotscript_ module, created a new starting point for the `zapper_iot` connector and adjusted CODEOWNER accordingly.

## Resolved issues

Resolves [ZAP-696](https://warthogs.atlassian.net/browse/ZAP-696)

## Documentation

Updated README.
Tests are included.

## Tests

Checked if CLI still works after the changes. Nothing else is really testable at this stage since this PR introduces only a base class and Zapper still doesn't provide any implementation.


[ZAP-696]: https://warthogs.atlassian.net/browse/ZAP-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ