### PR TITLE
Maasstorageerror is provisionerror

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
@@ -64,12 +64,15 @@ class MaasStorage:
         :return: subprocess stdout
         :raises MaasStorageError: on subprocess non-zero return code
         """
-        proc = subprocess.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=False,
-        )
+        try:
+            proc = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+        except FileNotFoundError as err:
+            raise MaasStorageError(err) from err
 
         if proc.returncode != 0:
             raise MaasStorageError(proc.stdout.decode())

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
@@ -19,12 +19,13 @@ import subprocess
 import collections
 import json
 import math
+from testflinger_device_connectors.devices import ProvisioningError
 
 
 logger = logging.getLogger()
 
 
-class MaasStorageError(Exception):
+class MaasStorageError(ProvisioningError):
     pass
 
 

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Maas2 agent module unit tests."""
+
+
+import json
+import pytest
+import yaml
+from testflinger_device_connectors.devices.maas2 import Maas2
+from testflinger_device_connectors.devices import ProvisioningError
+from testflinger_device_connectors.devices.maas2.maas_storage import (
+    MaasStorageError,
+)
+
+
+def test_maas2_agent_invalid_storage(tmp_path):
+    """Test that the maas2 agent raises an exception when storage init fails"""
+    config_yaml = tmp_path / "config.yaml"
+    config = {"maas_user": "user", "node_id": "abc", "agent_name": "agent001"}
+    config_yaml.write_text(yaml.safe_dump(config))
+
+    job_json = tmp_path / "job.json"
+    job = {}
+    job_json.write_text(json.dumps(job))
+
+    with pytest.raises(MaasStorageError) as err:
+        Maas2(config=config_yaml, job_data=job_json)
+
+    # MaasStorageError should also be a subclass of ProvisioningError
+    assert isinstance(err.value, ProvisioningError)


### PR DESCRIPTION
## Description

Since the maas storage setup stuff is only called during provisioning, any exceptions raised there should be handled the same way we handle ProvisionError. Currently though, it uses a MaasStorageError. Let's make it a subclass of ProvisionError instead, since we already log those and handle them, and add some additional tests.

## Resolved issues

Resolves #196 and [CERTTF-288](https://warthogs.atlassian.net/browse/CERTTF-288)

## Documentation
No impact here, should just see nicer errors when this situation comes up.

## Tests
Additional unit test added


[CERTTF-288]: https://warthogs.atlassian.net/browse/CERTTF-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ