### PR TITLE
rearrange and simplify how advertised queues/images are handled

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -32,8 +32,8 @@ class TestflingerAgent:
     def _post_initial_agent_data(self):
         """Post the initial agent data to the server once on agent startup"""
 
-        self._post_advertised_queues()
-        self._post_advertised_images()
+        self.client.post_advertised_queues()
+        self.client.post_advertised_images()
 
         identifier = self.client.config.get("identifier")
         location = self.client.config.get("location", "")
@@ -49,24 +49,6 @@ class TestflingerAgent:
             agent_data["identifier"] = identifier
 
         self.client.post_agent_data(agent_data)
-
-    def _post_advertised_queues(self):
-        """
-        Get the advertised queues from the config and send them to the server
-
-        :return: Dictionary of advertised queues
-        """
-        advertised_queues = self.client.config.get("advertised_queues", {})
-        if advertised_queues:
-            self.client.post_queues(advertised_queues)
-
-    def _post_advertised_images(self):
-        """
-        Get the advertised images from the config and post them to the server
-        """
-        advertised_images = self.client.config.get("advertised_images")
-        if advertised_images:
-            self.client.post_images(advertised_images)
 
     def set_agent_state(self, state):
         """Send the agent state to the server"""

--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -266,27 +266,27 @@ class TestflingerClient:
             return False
         return bool(job_request)
 
-    def post_queues(self, data):
-        """Post the list of advertised queues to testflinger server
-
-        :param data:
-            dict of queue name and descriptions to send to the server
-        """
+    def post_advertised_queues(self):
+        """Post the list of advertised queues to testflinger server"""
+        if "advertised_queues" not in self.config:
+            return
         queues_uri = urljoin(self.server, "/v1/agents/queues")
         try:
-            self.session.post(queues_uri, json=data, timeout=30)
+            self.session.post(
+                queues_uri, json=self.config["advertised_queues"], timeout=30
+            )
         except RequestException as exc:
             logger.error(exc)
 
-    def post_images(self, data):
-        """Post the list of advertised images to testflinger server
-
-        :param data:
-            dict of queues containing dicts of imgae names and provision data
-        """
+    def post_advertised_images(self):
+        """Post the list of advertised images to testflinger server"""
+        if "advertised_images" not in self.config:
+            return
         images_uri = urljoin(self.server, "/v1/agents/images")
         try:
-            self.session.post(images_uri, json=data, timeout=30)
+            self.session.post(
+                images_uri, json=self.config["advertised_images"], timeout=30
+            )
         except RequestException as exc:
             logger.error(exc)
 

--- a/agent/testflinger_agent/tests/test_client.py
+++ b/agent/testflinger_agent/tests/test_client.py
@@ -23,7 +23,14 @@ from testflinger_agent.client import TestflingerClient as _TestflingerClient
 class TestClient:
     @pytest.fixture
     def client(self):
-        yield _TestflingerClient({"server_address": "127.0.0.1:8000"})
+        config = {
+            "server_address": "127.0.0.1:8000",
+            "advertised_queues": {"test_queue": "test_queue"},
+            "advertised_images": {
+                "test_queue": {"test_image": "url: http://foo"}
+            },
+        }
+        yield _TestflingerClient(config)
 
     def test_check_jobs_empty(self, client, requests_mock):
         requests_mock.get(rmock.ANY, status_code=200)
@@ -38,3 +45,25 @@ class TestClient:
         requests_mock.get(rmock.ANY, json=fake_job_data)
         job_data = client.check_jobs()
         assert job_data == fake_job_data
+
+    def test_post_advertised_queues(self, client, requests_mock):
+        """
+        ensure that the server api /v1/agents/queues was called with
+        the correct queue data
+        """
+        requests_mock.post(rmock.ANY, status_code=200)
+        client.post_advertised_queues()
+        assert requests_mock.last_request.json() == {
+            "test_queue": "test_queue"
+        }
+
+    def test_post_advertised_images(self, client, requests_mock):
+        """
+        ensure that the server api /v1/agents/images was called with
+        the correct image data
+        """
+        requests_mock.post(rmock.ANY, status_code=200)
+        client.post_advertised_images()
+        assert requests_mock.last_request.json() == {
+            "test_queue": {"test_image": "url: http://foo"}
+        }


### PR DESCRIPTION
## Description
I noticed that we are going through some extra steps that we really don't need to do in order to send the advertised queues/images. This doesn't affect the way it works or anything for now, but simplifies the code and improves the testing of it a bit.

## Tests
Updated the unit tests
