### PR TITLE
remove oem image once provision is completed

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
@@ -103,6 +103,10 @@ class OemScript:
 
         self.check_device_booted()
 
+        # remove the .iso image
+        cmd = f"rm -f {image_file}"
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=60)
+
     def run_recovery_script(self, image_file):
         """Download and run the OEM recovery script"""
         device_ip = self.config["device_ip"]

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
@@ -97,15 +97,16 @@ class OemScript:
                 "Please provide an image 'url' in the provision_data section"
             )
             raise ProvisioningError("No image url provided")
-        image_file = download(image_url)
+        try:
+            image_file = download(image_url)
 
-        self.run_recovery_script(image_file)
+            self.run_recovery_script(image_file)
 
-        self.check_device_booted()
-
-        # remove the .iso image
-        cmd = f"rm -f {image_file}"
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=60)
+            self.check_device_booted()
+        finally:
+            # remove the .iso image
+            if image_file:
+                os.unlink(image_file)
 
     def run_recovery_script(self, image_file):
         """Download and run the OEM recovery script"""


### PR DESCRIPTION
## Description
Currently testflinger agent won't remove the .iso images from /testflingere/run folder once provision is completed. Propose to add a step to remove image file at the end of provision phase for oemscript devices.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Reduce the manual effort to clean up accumulated image files in /testflinger/run folder.
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
