### PR TITLE
Remove the pymongo SocketTimeoutMS setting

### DIFF
--- a/server/src/__init__.py
+++ b/server/src/__init__.py
@@ -124,7 +124,6 @@ def setup_mongodb(application):
         uri=mongo_uri,
         uuidRepresentation="standard",
         serverSelectionTimeoutMS=2000,
-        socketTimeoutMS=10000,
     )
 
     # Initialize collections and indices in case they don't exist already


### PR DESCRIPTION
## Description
I managed to find something here, that may at least explain the errors on the application side. I think there's still more to the problem though, as it shouldn't be timing out after that long in any case, but keeping the socket timeout back at the default should at least help somewhat.

I think I had originally set this to this value because of some concerns about the firewall in the middle (that's what the setting is there for), but it looks like that might not be a problem after all.

I have some other things that I'm testing that could help as well.

## Tests
I tested this on the staging instance, along with some load testing using locust and wasn't able to see any negative effects from it.