### PR TITLE
Allow setting the number of units as an option in the module

### DIFF
--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -2,7 +2,7 @@ resource "juju_application" "testflinger" {
   name  = "testflinger"
   model = local.app_model
 
-  units = 2
+  units = var.application_units
 
   charm {
     name    = "testflinger-k8s"

--- a/server/terraform/variables.tf
+++ b/server/terraform/variables.tf
@@ -23,6 +23,12 @@ variable "nginx_ingress_integrator_charm_whitelist_source_range" {
   default     = ""
 }
 
+variable "application_units" {
+  description = "Number of units (pods) to start"
+  type        = number
+  default     = 2
+}
+
 locals {
   app_model = "testflinger-${var.environment}"
 }


### PR DESCRIPTION
## Description
currently, the number of application we deploy is set in the terraform module. This makes the module-side changes to allow us to set this in the main plan from certification-ops instead.

## Tests
There used to be a bug back when we first started testing this, which wouldn't allow you to shrink the number of units - and if you tried, you would end up with a big juju mess. I've tested this in staging though, and it's working fine now. I think this bug got resolved up in an earlier version.
