### PR TITLE
fix(muxpi): shell-quote the URL

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -17,6 +17,7 @@
 import json
 import logging
 import subprocess
+import shlex
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -154,7 +155,7 @@ class MuxPi:
 
         test_device = self.config["test_device"]
         cmd = (
-            f"(set -o pipefail; curl -sf {url} | zstdcat| "
+            f"(set -o pipefail; curl -sf {shlex.quote(url)} | zstdcat| "
             f"sudo dd of={test_device} bs=16M)"
         )
         logger.info("Running: %s", cmd)


### PR DESCRIPTION
## Description

The provision data URL is pasted directly into the command without escaping. Special characters like `&` are interpreted by the shell, and not just passed as URL to curl:

```
job_queue: some-muxpi-queue
provision_data:
  url: http://example.com/a?b=c&d=e
test_data:
  test_cmds: |
    echo $DEVICE_IP
```

This runs the shell command as (literally, note the URL isn't quoted):

```
(set -o pipefail; curl -sf http://example.com/a?b=c&d=e | zstdcat| sudo dd of=/dev/sda bs=16M)
```

This is treated as backgrounding `curl -sf http://example.com/a?b=c` and trying to run a command `d=e` and piping its output into `zstdcat` (...). 

## Resolved issues

This fixes the quoting issue by quoting the URL properly before passing it on to the shell.

## Documentation

No changes.

## Tests

1. Create a job like above, with the URL containing `&` (or any other special character understood by the shell)
2. Submit it to a testflinger server
3. Check the URL and command output, note that curl doesn't retrieve `http://example.com/a?b=c&d=e`, but `http://example.com/a?b=c`, and the curl output isn't piped into `zstdcat`
4. After applying the fix, the URL in the command should be properly quoted