### PR TITLE
Fix jobid wrapping on agent page, and add link for jobs

### DIFF
--- a/server/src/templates/agents.html
+++ b/server/src/templates/agents.html
@@ -29,7 +29,7 @@
             <td><a href="/agents/{{ agent.name }}">{{ agent.name }}</a></td>
             <td>{{ agent.state }}</td>
             <td>{{ agent.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
-            <td>{{ agent.job_id }}</td>
+            <td class="u-align--right u-truncate"><a href="/jobs/{{ agent.job_id }}">{{ agent.job_id }}</a></td>
         </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
## Description
Sometimes jobids might wrap on the agent page, which looks really inconsistent. This forces it to overflow instead, since I couldn't see that there was any good way to adjust the column sizes.
Also, it adds a link to the job page when a job exists.
