### PR TITLE
Make max pool size adjustable

### DIFF
--- a/server/charm/config.yaml
+++ b/server/charm/config.yaml
@@ -7,3 +7,7 @@ options:
     default: 10
     description: Number of seconds to wait for keepalive connections
     type: int
+  max_pool_size:
+    default: 100
+    description: Maximum number of concurrent connections to the database
+    type: int

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -199,6 +199,7 @@ class TestflingerCharm(ops.CharmBase):
             "MONGODB_USERNAME": db_data.get("db_username"),
             "MONGODB_PASSWORD": db_data.get("db_password"),
             "MONGODB_DATABASE": db_data.get("db_database"),
+            "MONGODB_MAX_POOL_SIZE": str(self.config["max_pool_size"]),
         }
         return env
 

--- a/server/src/__init__.py
+++ b/server/src/__init__.py
@@ -124,6 +124,7 @@ def setup_mongodb(application):
         uri=mongo_uri,
         uuidRepresentation="standard",
         serverSelectionTimeoutMS=2000,
+        maxPoolSize=os.environ.get("MONGODB_MAX_POOL_SIZE", 100),
     )
 
     # Initialize collections and indices in case they don't exist already

--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -12,6 +12,7 @@ resource "juju_application" "testflinger" {
 
   config = {
     external_hostname = var.external_ingress_hostname
+    max_pool_size = var.max_pool_size
   }
 }
 

--- a/server/terraform/variables.tf
+++ b/server/terraform/variables.tf
@@ -29,6 +29,12 @@ variable "application_units" {
   default     = 2
 }
 
+variable "max_pool_size" {
+  description = "Maximum number of concurrent connections to the database"
+  type        = int
+  default     = 100
+}
+
 locals {
   app_model = "testflinger-${var.environment}"
 }


### PR DESCRIPTION
## Description
In an attempt to still try to resolve why sometimes connections timeout, I'm trying to look at the possibility that the connections pools may be getting exhausted and staying that way for a while. I've tried increasing the number of pods to get more available connections and so far it hasn't helped too much. But I'm hoping maybe this could also give me something to tweak.