### PR TITLE
Add new indexes

### DIFF
--- a/server/src/__init__.py
+++ b/server/src/__init__.py
@@ -27,14 +27,10 @@ from werkzeug.exceptions import NotFound
 from pymongo.errors import ConnectionFailure
 from apiflask import APIFlask
 
-from src.database import mongo
+from src.database import mongo, create_indexes
 from src.api.v1 import v1
 from src.providers import ISODatetimeProvider
 from src.views import views
-
-# Constants for TTL indexes
-DEFAULT_EXPIRATION = 60 * 60 * 24 * 7  # 7 days
-OUTPUT_EXPIRATION = 60 * 60 * 4  # 4 hours
 
 try:
     import sentry_sdk
@@ -126,19 +122,4 @@ def setup_mongodb(application):
         serverSelectionTimeoutMS=2000,
     )
 
-    # Initialize collections and indices in case they don't exist already
-    # Automatically expire jobs after 7 days if nothing runs them
-    mongo.db.jobs.create_index(
-        "created_at", expireAfterSeconds=DEFAULT_EXPIRATION
-    )
-    # Remove output 4 hours after the last entry if nothing polls for it
-    mongo.db.output.create_index(
-        "updated_at", expireAfterSeconds=OUTPUT_EXPIRATION
-    )
-    # Remove artifacts after 7 days
-    mongo.db.fs.chunks.create_index(
-        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
-    )
-    mongo.db.fs.files.create_index(
-        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
-    )
+    create_indexes()

--- a/server/src/database.py
+++ b/server/src/database.py
@@ -19,4 +19,30 @@ This returns a db object for talking to MongoDB
 
 from flask_pymongo import PyMongo
 
+# Constants for TTL indexes
+DEFAULT_EXPIRATION = 60 * 60 * 24 * 7  # 7 days
+OUTPUT_EXPIRATION = 60 * 60 * 4  # 4 hours
+
 mongo = PyMongo()
+
+
+def create_indexes():
+    """Initialize collections and indexes in case they don't exist already"""
+
+    # Automatically expire jobs after 7 days if nothing runs them
+    mongo.db.jobs.create_index(
+        "created_at", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
+
+    # Remove output 4 hours after the last entry if nothing polls for it
+    mongo.db.output.create_index(
+        "updated_at", expireAfterSeconds=OUTPUT_EXPIRATION
+    )
+
+    # Remove artifacts after 7 days
+    mongo.db.fs.chunks.create_index(
+        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
+    mongo.db.fs.files.create_index(
+        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
+    )

--- a/server/src/database.py
+++ b/server/src/database.py
@@ -19,6 +19,7 @@ This returns a db object for talking to MongoDB
 
 from flask_pymongo import PyMongo
 
+
 # Constants for TTL indexes
 DEFAULT_EXPIRATION = 60 * 60 * 24 * 7  # 7 days
 OUTPUT_EXPIRATION = 60 * 60 * 4  # 4 hours
@@ -46,3 +47,7 @@ def create_indexes():
     mongo.db.fs.files.create_index(
         "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
     )
+
+    # Faster lookups for common queries
+    mongo.db.jobs.create_index("job_id")
+    mongo.db.jobs.create_index(["result_data.job_state", "job_data.job_queue"])


### PR DESCRIPTION
## Description
Add 2 new indexes to help with performance on some common query terms. These indexes already exist in the live db, this just puts it code so that it will be there from the beginning if it's ever reinstalled.

## Resolved issues
[CERTTF-281](https://warthogs.atlassian.net/browse/CERTTF-281)

## Tests
Dropped the indexes in my local db, restarted the server, and saw that they were created again. And in case you are concerned, creating an index that already exists does nothing, it just ignores it.


[CERTTF-281]: https://warthogs.atlassian.net/browse/CERTTF-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ