### PR TITLE
typo s/int/number

### DIFF
--- a/server/terraform/variables.tf
+++ b/server/terraform/variables.tf
@@ -31,7 +31,7 @@ variable "application_units" {
 
 variable "max_pool_size" {
   description = "Maximum number of concurrent connections to the database"
-  type        = int
+  type        = number
   default     = 100
 }
 


### PR DESCRIPTION
## Description
Terraform uses "number" instead of int... I forgot that when I first proposed this