### PR TITLE
Add: Zapper KVM connector

### DIFF
--- a/device-connectors/README.rst
+++ b/device-connectors/README.rst
@@ -24,6 +24,7 @@ testing on other types of devices.
 - oemrecovery - anything (such as core fde images) that can't be provisioned but can run a set of commands to recover back to the initial state
 - oemscript - uses a script that supports some oem images and allows injection of an iso to the recovery partition to install that image
 - zapper-iot - IoT devices which require a Zapper for HW manipulation and OEM-specific actions to get provisioned (UUU, seed-override, ...) 
+- zapper-kvm - autoinstall-based provisioning driven by Zapper KVM capabilities
 
 
 Exit Status

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -48,6 +48,7 @@ DEVICE_CONNECTORS = (
     "oemrecovery",
     "oemscript",
     "zapper_iot",
+    "zapper_kvm",
 )
 
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -57,8 +57,6 @@ class ZapperConnector(ABC, DefaultDevice):
         with open(args.job_data, encoding="utf-8") as job_json:
             self.job_data = json.load(job_json)
 
-        testflinger_device_connectors.configure_logging(self.config)
-
         logger.info("BEGIN provision")
         logger.info("Provisioning device")
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -70,7 +70,7 @@ class ZapperConnector(ABC, DefaultDevice):
     @abstractmethod
     def _validate_configuration(
         self,
-    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+    ) -> Tuple[Tuple, Dict[str, Any]]:
         """
         Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -29,7 +29,6 @@ from typing import Any, Dict, Tuple
 import rpyc
 import yaml
 
-import testflinger_device_connectors
 from testflinger_device_connectors.devices import (
     DefaultDevice,
     RecoveryError,

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -25,7 +25,7 @@ from testflinger_device_connectors.devices.zapper import (
 class MockConnector(ZapperConnector):
     PROVISION_METHOD = "Test"
 
-    def _validate_configuration(self, config, job_data):
+    def _validate_configuration(self):
         return (), {}
 
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -26,7 +26,7 @@ class DeviceConnector(ZapperConnector):
 
     def _validate_configuration(
         self,
-    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+    ) -> Tuple[Tuple, Dict[str, Any]]:
         """
         Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -22,10 +22,10 @@ from testflinger_device_connectors.devices.zapper import ZapperConnector
 class DeviceConnector(ZapperConnector):
     """Tool for provisioning baremetal with a given image."""
 
-    PROVISION_METHOD = "zapper_iot"
+    PROVISION_METHOD = "ProvisioningIoT"
 
     def _validate_configuration(
-        self, config, job_data
+        self,
     ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         """
         Validate the job config and data and prepare the arguments

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -50,19 +50,14 @@ class DeviceConnector(ZapperConnector):
         for the Zapper `provision` API.
         """
 
-        provisioning_data = {}
-        provisioning_data["url"] = self.job_data["provision_data"]["url"]
-        provisioning_data["username"] = self.job_data.get("test_data", {}).get(
-            "test_username", "ubuntu"
-        )
-        provisioning_data["password"] = self.job_data.get(
-            "test_password", {}
-        ).get("test_password", "ubuntu")
-        provisioning_data["autoinstall_conf"] = self._get_autoinstall_conf()
-        provisioning_data["reboot_script"] = self.config["reboot_script"]
-        provisioning_data["device_ip"] = self.config["device_ip"]
-        provisioning_data["robot_tasks"] = self.job_data["provision_data"][
-            "robot_tasks"
-        ]
+        provisioning_data = {
+            "url": self.job_data["provision_data"]["url"],
+            "username": self.job_data.get("test_data", {}).get("test_username", "ubuntu"),
+            "password": self.job_data.get("test_password", {}).get("test_password", "ubuntu"),
+            "autoinstall_conf": self._get_autoinstall_conf(),
+            "reboot_script": self.config["reboot_script"],
+            "device_ip": self.config["device_ip"],
+            "robot_tasks": self.job_data["provision_data"]["robot_tasks"]
+        }
 
         return ((), provisioning_data)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -27,19 +27,15 @@ class DeviceConnector(ZapperConnector):
 
     def _get_autoinstall_conf(self) -> Dict[str, Any]:
         """Prepare autoinstall-related configuration."""
+        provision = self.job_data["provision_data"]
+
         autoinstall_conf = {
-            "storage_layout": self.job_data["provision_data"][
-                "storage_layout"
-            ],
-            "storage_password": self.job_data["provision_data"].get(
-                "storage_password"
-            ),
+            "storage_layout": provision["storage_layout"],
+            "storage_password": provision.get("storage_password"),
         }
 
-        if "base_user_data" in self.job_data["provision_data"]:
-            autoinstall_conf["base_user_data"] = self.job_data[
-                "provision_data"
-            ]["base_user_data"]
+        if "base_user_data" in provision:
+            autoinstall_conf["base_user_data"] = provision["base_user_data"]
 
         with open(os.path.expanduser("~/.ssh/id_rsa.pub")) as pub:
             autoinstall_conf["authorized_keys"] = [pub.read()]
@@ -59,7 +55,7 @@ class DeviceConnector(ZapperConnector):
             "username": self.job_data.get("test_data", {}).get(
                 "test_username", "ubuntu"
             ),
-            "password": self.job_data.get("test_password", {}).get(
+            "password": self.job_data.get("test_data", {}).get(
                 "test_password", "ubuntu"
             ),
             "autoinstall_conf": self._get_autoinstall_conf(),

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -25,11 +25,15 @@ class DeviceConnector(ZapperConnector):
 
     PROVISION_METHOD = "ProvisioningKVM"
 
-    def _get_autoinstall_conf(self):
+    def _get_autoinstall_conf(self) -> Dict[str, Any]:
         """Prepare autoinstall-related configuration."""
         autoinstall_conf = {
-            "storage_layout": self.job_data["provision_data"]["storage_layout"],
-            "storage_password": self.job_data["provision_data"].get("storage_password")
+            "storage_layout": self.job_data["provision_data"][
+                "storage_layout"
+            ],
+            "storage_password": self.job_data["provision_data"].get(
+                "storage_password"
+            ),
         }
 
         if "base_user_data" in self.job_data["provision_data"]:
@@ -44,7 +48,7 @@ class DeviceConnector(ZapperConnector):
 
     def _validate_configuration(
         self,
-    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+    ) -> Tuple[Tuple, Dict[str, Any]]:
         """
         Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.
@@ -52,12 +56,16 @@ class DeviceConnector(ZapperConnector):
 
         provisioning_data = {
             "url": self.job_data["provision_data"]["url"],
-            "username": self.job_data.get("test_data", {}).get("test_username", "ubuntu"),
-            "password": self.job_data.get("test_password", {}).get("test_password", "ubuntu"),
+            "username": self.job_data.get("test_data", {}).get(
+                "test_username", "ubuntu"
+            ),
+            "password": self.job_data.get("test_password", {}).get(
+                "test_password", "ubuntu"
+            ),
             "autoinstall_conf": self._get_autoinstall_conf(),
             "reboot_script": self.config["reboot_script"],
             "device_ip": self.config["device_ip"],
-            "robot_tasks": self.job_data["provision_data"]["robot_tasks"]
+            "robot_tasks": self.job_data["provision_data"]["robot_tasks"],
         }
 
         return ((), provisioning_data)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Zapper Connector for KVM provisioning."""
+
+import os
+from typing import Any, Dict, Tuple
+
+from testflinger_device_connectors.devices.zapper import ZapperConnector
+
+
+class DeviceConnector(ZapperConnector):
+    """Tool for provisioning baremetal with a given image."""
+
+    PROVISION_METHOD = "zapper_kvm"
+
+    def _get_autoinstall_conf(self, config, job_data):
+        """Prepare autoinstall-related configuration."""
+        autoinstall_conf = {}
+
+        autoinstall_conf["storage_layout"] = job_data["provision_data"][
+            "storage_layout"
+        ]
+        autoinstall_conf["storage_password"] = job_data["provision_data"].get(
+            "storage_password"
+        )
+
+        if "base_user_data" in job_data["provision_data"]:
+            autoinstall_conf["base_user_data"] = job_data["provision_data"][
+                "base_user_data"
+            ]
+
+        with open(os.path.expanduser("~/.ssh/id_rsa.pub")) as pub:
+            autoinstall_conf["authorized_keys"] = [pub.read()]
+
+        return autoinstall_conf
+
+    def _validate_configuration(
+        self, config, job_data
+    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        """
+        Validate the job config and data and prepare the arguments
+        for the Zapper `provision` API.
+
+        Strictly required arguments are:
+        - url
+        - device_ip
+        - storage_layout
+        - robot_tasks
+        - reboot_script
+        """
+        provisioning_data = {}
+        provisioning_data["url"] = job_data["provision_data"]["url"]
+        provisioning_data["robot_tasks"] = job_data["provision_data"][
+            "robot_tasks"
+        ]
+        provisioning_data["reboot_script"] = config["reboot_script"]
+        provisioning_data["device_ip"] = config["device_ip"]
+        provisioning_data["username"] = job_data.get("test_data", {}).get(
+            "test_username", "ubuntu"
+        )
+        provisioning_data["password"] = job_data.get("test_password", {}).get(
+            "test_password", "ubuntu"
+        )
+
+        provisioning_data["autoinstall_conf"] = self._get_autoinstall_conf(
+            config, job_data
+        )
+
+        return ((), provisioning_data)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -27,15 +27,10 @@ class DeviceConnector(ZapperConnector):
 
     def _get_autoinstall_conf(self):
         """Prepare autoinstall-related configuration."""
-        autoinstall_conf = {}
-
-        autoinstall_conf["storage_layout"] = self.job_data["provision_data"][
-            "storage_layout"
-        ]
-
-        autoinstall_conf["storage_password"] = self.job_data[
-            "provision_data"
-        ].get("storage_password")
+        autoinstall_conf = {
+            "storage_layout": self.job_data["provision_data"]["storage_layout"],
+            "storage_password": self.job_data["provision_data"].get("storage_password")
+        }
 
         if "base_user_data" in self.job_data["provision_data"]:
             autoinstall_conf["base_user_data"] = self.job_data[

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for Zapper KVM device connector."""
+
+import unittest
+from unittest.mock import Mock, patch
+from testflinger_device_connectors.devices.zapper_kvm import DeviceConnector
+
+
+class ZapperKVMConnectorTests(unittest.TestCase):
+    """Unit tests for ZapperConnector KVM class."""
+
+    def test_validate_configuration(self):
+        """
+        Test whether the validate_configuration function returns
+        the expected data merging the relevant bits from conf and job
+        data.
+        """
+
+        connector = DeviceConnector()
+        connector.config = {
+            "device_ip": "1.1.1.1",
+            "control_host": "1.1.1.2",
+            "reboot_script": ["cmd1", "cmd2"],
+        }
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "robot_tasks": [
+                    "job.robot",
+                    "another.robot",
+                ],
+                "storage_layout": "lvm",
+            },
+            "test_data": {
+                "test_username": "username",
+                "test_password": "password",
+            },
+        }
+
+        connector._get_autoinstall_conf = Mock()
+        args, kwargs = connector._validate_configuration()
+        self.assertEqual(args, ())
+        self.assertEqual(kwargs["url"], "http://example.com/image.iso")
+        self.assertEqual(kwargs["username"], "username")
+        self.assertEqual(kwargs["password"], "password")
+        self.assertEqual(
+            kwargs["autoinstall_conf"],
+            connector._get_autoinstall_conf.return_value,
+        )
+        self.assertEqual(kwargs["reboot_script"], ["cmd1", "cmd2"])
+        self.assertEqual(kwargs["device_ip"], "1.1.1.1")
+        self.assertEqual(kwargs["robot_tasks"], ["job.robot", "another.robot"])
+
+    def test_get_autoinstall_conf(self):
+        """
+        Test whether the get_autoinstall_conf function returns
+        the expected data merging the relevant bits from conf and job
+        data when password and base_user_data are not given.
+        """
+
+        connector = DeviceConnector()
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "robot_tasks": [
+                    "job.robot",
+                    "another.robot",
+                ],
+                "storage_layout": "lvm",
+            },
+            "test_data": {
+                "test_username": "username",
+                "test_password": "password",
+            },
+        }
+
+        with patch("builtins.open") as mock_open:
+            conf = connector._get_autoinstall_conf()
+        self.assertEqual(conf["storage_layout"], "lvm")
+        self.assertIsNone(conf["storage_password"])
+        self.assertNotIn("base_user_data", conf.keys())
+        self.assertIn(
+            mock_open.return_value.__enter__.return_value.read.return_value,
+            conf["authorized_keys"],
+        )
+
+    def test_get_autoinstall_conf_full(self):
+        """
+        Test whether the get_autoinstall_conf function returns
+        the expected data merging the relevant bits from conf and job
+        data when password and user_data_base are given.
+        """
+
+        connector = DeviceConnector()
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "robot_tasks": [
+                    "job.robot",
+                    "another.robot",
+                ],
+                "storage_layout": "lvm",
+                "storage_password": "luks",
+                "base_user_data": "base data content",
+            },
+            "test_data": {
+                "test_username": "username",
+                "test_password": "password",
+            },
+        }
+
+        with patch("builtins.open") as mock_open:
+            conf = connector._get_autoinstall_conf()
+        self.assertEqual(conf["storage_layout"], "lvm")
+        self.assertEqual(conf["storage_password"], "luks")
+        self.assertEqual(conf["base_user_data"], "base data content")
+        self.assertIn(
+            mock_open.return_value.__enter__.return_value.read.return_value,
+            conf["authorized_keys"],
+        )


### PR DESCRIPTION
## Description

Introduces a Zapper connector for KVM provisioning. The connector inherits from the base class and just implements the function to prepare the API arguments.

## Resolved issues

Resolves [ZAP-699](https://warthogs.atlassian.net/browse/ZAP-699)

## Documentation

Updated the README.

## Tests
Tested running `testflinger-device-connector zapper_kvm provision -c config_30464.yaml job_30464.json` where

```
# config_30464.yaml
device_ip: "10.102.163.33"
control_host: "10.102.243.33"
reboot_script: 
  - snmpset -c private -v2c 10.102.196.162 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.7 i 0
  - sleep 5
  - snmpset -c private -v2c 10.102.196.162 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.7 i 1
```

```
# job_30464.json
{
"job_queue": "test",
"provision_data": {
  "url": "http://cdimage.ubuntu.com/daily-live/current/noble-desktop-amd64.iso",
  "robot_tasks": [
    "hp/pro/sff_400_g9/boot/boot_from_usb.robot",
    "common/grub/autoinstall/http/configure_autoinstall_http.robot",
    "hp/boot/wait_reboot.robot"
    ],
  "storage_layout": "lvm"
},
"test_data": {
  "test_username": "ubuntu",
  "test_password": "insecure"
  }
}
```


[ZAP-699]: https://warthogs.atlassian.net/browse/ZAP-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ