### PR TITLE
Don't use the reboot control host workaround on zapper devices

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -148,7 +148,9 @@ class MuxPi:
         return output
 
     def provision(self):
-        self.reboot_control_host()
+        # If this is not a zapper, reboot before provisioning
+        if "zapper" not in self.config.get("control_switch_local_cmd", ""):
+            self.reboot_control_host()
         try:
             url = self.job_data["provision_data"]["url"]
         except KeyError:


### PR DESCRIPTION
## Description
We recently implemented a workaround for the network issues on nanopi controller devices to reboot them before starting the provisioning phase. This seems to work fine, but it shouldn't be necessary for the ones that run zappers - which are based on rpi4 not nanopi.
Furthermore, rebooting the zappers and then trying to use them too quickly can result in provisioning failure because the addons aren't ready yet.
Until there's a completely separate device connector for zapper, let's avoid rebooting those for now.

## Tests
There are quite a few devices in the lab failing from this right now. I tested this on one of those and confirmed it works now.
