### PR TITLE
Fix: add missing logger name.

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
@@ -28,7 +28,7 @@ from testflinger_device_connectors.devices import (
     RecoveryError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class CM3:

--- a/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/dell_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/dell_oemscript.py
@@ -21,7 +21,7 @@ for provisioning, but require the --ubr flag in order to use the
 import logging
 from testflinger_device_connectors.devices.oemscript.oemscript import OemScript
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class DellOemScript(OemScript):

--- a/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
@@ -29,7 +29,7 @@ from testflinger_device_connectors.devices import (
     RecoveryError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class Dragonboard:

--- a/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/hp_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/hp_oemscript.py
@@ -21,7 +21,7 @@ for provisioning, but require the --ubr flag in order to use the
 import logging
 from testflinger_device_connectors.devices.oemscript.oemscript import OemScript
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class HPOemScript(OemScript):

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
@@ -28,7 +28,7 @@ from testflinger_device_connectors.devices import (
 )
 from .lenovo_oemscript import LenovoOemScript
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class DeviceConnector(DefaultDevice):

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/lenovo_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/lenovo_oemscript.py
@@ -21,7 +21,7 @@ for provisioning, but require the --ubr flag in order to use the
 import logging
 from testflinger_device_connectors.devices.oemscript.oemscript import OemScript
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class LenovoOemScript(OemScript):

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -33,7 +33,7 @@ from testflinger_device_connectors.devices.maas2.maas_storage import (
 )
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class Maas2:

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
@@ -22,7 +22,7 @@ import math
 from testflinger_device_connectors.devices import ProvisioningError
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class MaasStorageError(ProvisioningError):

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
@@ -21,7 +21,7 @@ import time
 
 from testflinger_device_connectors.devices import ProvisioningError
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class Multi:

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/tfclient.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/tfclient.py
@@ -19,7 +19,7 @@ import logging
 import urllib.parse
 import requests
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class TFClient:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -30,7 +30,7 @@ from testflinger_device_connectors.devices import (
     RecoveryError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class MuxPi:

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
@@ -27,7 +27,7 @@ from testflinger_device_connectors.devices import (
     RecoveryError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class Netboot:

--- a/device-connectors/src/testflinger_device_connectors/devices/noprovision/noprovision.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/noprovision/noprovision.py
@@ -25,7 +25,7 @@ from testflinger_device_connectors.devices import (
     RecoveryError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class Noprovision:

--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
@@ -26,7 +26,7 @@ from testflinger_device_connectors.devices import (
     RecoveryError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class OemRecovery:

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
@@ -28,7 +28,7 @@ from testflinger_device_connectors.devices import (
     RecoveryError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class OemScript:


### PR DESCRIPTION
## Description

After this [PR](https://github.com/canonical/testflinger/pull/197) has been merged, I found that during the provisoning phase, some info level messages were gone, some scripts didn't pass the module name when calling getLogger().

## Resolved issues
None

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
Use a local build device_connectors for testing this change.
### Before 
```
23:00:54 ***********************************************************
23:00:54 
23:00:54 * Starting testflinger provision phase on capilano-qed001 *
23:00:54 
23:00:54 ***********************************************************
23:01:06 2024-03-13 15:00:52,767 capilano-qed001 INFO: DEVICE CONNECTOR: BEGIN provision
23:01:06 2024-03-13 15:00:52,767 capilano-qed001 INFO: DEVICE CONNECTOR: Provisioning device
```
### After
```
10:26:46 ***********************************************************
10:26:46 
10:26:46 * Starting testflinger provision phase on capilano-qed001 *
10:26:46 
10:26:46 ***********************************************************
10:26:59 2024-03-15 02:26:46,139 capilano-qed001 INFO: DEVICE CONNECTOR: BEGIN provision
10:26:59 2024-03-15 02:26:46,139 capilano-qed001 INFO: DEVICE CONNECTOR: Provisioning device
10:26:59 2024-03-15 02:26:47,407 capilano-qed001 INFO: DEVICE CONNECTOR: Recovering OEM image
10:26:59 2024-03-15 02:26:47,407 capilano-qed001 INFO: DEVICE CONNECTOR: Running sudo snap reboot --install
10:26:59 2024-03-15 02:26:49,993 capilano-qed001 INFO: DEVICE CONNECTOR: b'Reboot into "install" mode.\n'
10:26:59 2024-03-15 02:26:49,994 capilano-qed001 INFO: DEVICE CONNECTOR: Checking to see if the device is available.
```

