### PR TITLE
Disable Unattended Upgrades

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -377,6 +377,13 @@ class MuxPi:
                 )
                 self._run_control(cmd)
 
+                # Disable Unattended Upgrades
+                cmd = (
+                    'sudo sed -i \'s/"1"/"0"/g\' '
+                    f"{base}/etc/apt/apt.conf.d/20auto-upgrades"
+                )
+                self._run_control(cmd)
+
                 self._configure_sudo()
                 return
             if image_type == "pi-desktop":


### PR DESCRIPTION
This upgrade process, when triggered, can block a job for half an hour (sometimes even more). This is unecessarely annoying

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->
Disable unattended upgrade for Riverside jobs (see https://linuxhint.com/enable-disable-unattended-upgrades-ubuntu/)

## Resolved issues
* https://warthogs.atlassian.net/browse/PERI-415

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
