### PR TITLE
Muxpi improvement

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -131,8 +131,8 @@ class MuxPi:
             media = self.job_data["provision_data"]["media"]
             try:
                 # If media option is provided, then DUT is probably capable of
-                # booting from different media, we should switch both of them to TS
-                # side regardless of which one was previously used
+                # booting from different media, we should switch both of them
+                # to TS side regardless of which one was previously used
                 cmd = "zapper sdwire plug_to_self"
                 sd_node = self._run_control(cmd)
                 cmd = "zapper typecmux plug_to_self"

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -129,13 +129,12 @@ class MuxPi:
             self._run_control(cmd)
         else:
             media = self.job_data["provision_data"]["media"]
-            match media:
-                case "sd":
-                    self.test_device = "/dev/sd-disk"
-                case "usb":
-                    self.test_device = "/dev/tc-disk"
-                case _:
-                    self.test_device = self.config["test_device"]
+            if media == "sd":
+                self.test_device = "/dev/sd-disk"
+            elif media == "usb":
+                self.test_device = "/dev/tc-disk"
+            else:
+                self.test_device = self.config["test_device"]
             # If media option is provided, then DUT is probably capable of
             # booting from different media, we should switch both of them to TS
             # side regardless of which one was previously used

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -122,8 +122,28 @@ class MuxPi:
                 'the "provision_data" section of '
                 "your job_data"
             )
-        cmd = self.config.get("control_switch_local_cmd", "stm -ts")
-        self._run_control(cmd)
+        if "media" not in self.job_data["provision_data"]:
+            media = None
+            self.test_device = self.config["test_device"]
+            cmd = self.config.get("control_switch_local_cmd", "stm -ts")
+            self._run_control(cmd)
+        else:
+            media = self.job_data["provision_data"]["media"]
+            match media:
+                case "sd":
+                    self.test_device = "/dev/sd-disk"
+                case "usb":
+                    self.test_device = "/dev/tc-disk"
+                case _:
+                    self.test_device = self.config["test_device"]
+            # If media option is provided, then DUT is probably capable of
+            # booting from different media, we should switch both of them to TS
+            # side regardless of which one was previously used
+            cmd = "zapper sdwire set ZAPPER; zapper typecmux set TS"
+            try:
+                self._run_control(cmd)
+            except Exception:
+                pass
         time.sleep(5)
         logger.info("Flashing Test image")
         try:
@@ -138,7 +158,12 @@ class MuxPi:
                 logger.info("Skipping test user creation (create_user=False)")
             self.run_post_provision_script()
             logger.info("Booting Test Image")
-            cmd = self.config.get("control_switch_device_cmd", "stm -dut")
+            if media == "sd":
+                cmd = "zapper sdwire set DUT"
+            elif media == "usb":
+                cmd = "zapper typecmux set DUT"
+            else:
+                cmd = self.config.get("control_switch_device_cmd", "stm -dut")
             self._run_control(cmd)
             self.hardreset()
             self.check_test_image_booted()
@@ -157,10 +182,9 @@ class MuxPi:
         # First unmount, just in case
         self.unmount_writable_partition()
 
-        test_device = self.config["test_device"]
         cmd = (
             f"(set -o pipefail; curl -sf {shlex.quote(url)} | zstdcat| "
-            f"sudo dd of={test_device} bs=16M)"
+            f"sudo dd of={self.test_device} bs=16M)"
         )
         logger.info("Running: %s", cmd)
         try:
@@ -176,7 +200,7 @@ class MuxPi:
             time.sleep(30)
         try:
             self._run_control(
-                "sudo hdparm -z {}".format(self.config["test_device"]),
+                "sudo hdparm -z {}".format(self.test_device),
                 timeout=30,
             )
         except Exception:
@@ -185,9 +209,8 @@ class MuxPi:
             )
 
     def _get_part_labels(self):
-        test_device = self.config["test_device"]
         lsblk_data = self._run_control(
-            "lsblk -o NAME,LABEL -J {}".format(test_device)
+            "lsblk -o NAME,LABEL -J {}".format(self.test_device)
         )
         lsblk_json = json.loads(lsblk_data.decode())
         # List of (name, label) pairs
@@ -293,7 +316,7 @@ class MuxPi:
     def unmount_writable_partition(self):
         try:
             self._run_control(
-                "sudo umount {}*".format(self.config["test_device"]),
+                "sudo umount {}*".format(self.test_device),
                 timeout=30,
             )
         except KeyError:

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -117,6 +117,13 @@ The ``muxpi`` device connector supports the following ``provision_data`` keys:
        ``unzstd`` (**xz** format is recommended, but any format supported by
        the ``zstd`` tool is supported) and
        flashed to the SD card, which will be used to boot up the DUT.
+   * - ``media``
+     - Optional paramer to indicate on which boot media the disk image should 
+       be programmed (using symlinks on the controller + zapper commands). 
+       Supported values are :
+
+       1. ``usb`` : symlink /dev/tc-disk
+       2. ``sd`` : symlink /dev/sd-disk
    * - ``create_user``
      - Boolean (default ``true``) specifying whether a user account should be created.
    * - ``boot_check_url``

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -118,7 +118,7 @@ The ``muxpi`` device connector supports the following ``provision_data`` keys:
        the ``zstd`` tool is supported) and
        flashed to the SD card, which will be used to boot up the DUT.
    * - ``media``
-     - Optional paramer to indicate on which boot media the disk image should 
+     - Optional parameter to indicate on which boot media the disk image should
        be programmed (using zapper commands). Supported values are ``usb`` or 
        ``sd``
    * - ``create_user``

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -119,11 +119,8 @@ The ``muxpi`` device connector supports the following ``provision_data`` keys:
        flashed to the SD card, which will be used to boot up the DUT.
    * - ``media``
      - Optional paramer to indicate on which boot media the disk image should 
-       be programmed (using symlinks on the controller + zapper commands). 
-       Supported values are :
-
-       1. ``usb`` : symlink /dev/tc-disk
-       2. ``sd`` : symlink /dev/sd-disk
+       be programmed (using zapper commands). Supported values are ``usb`` or 
+       ``sd``
    * - ``create_user``
      - Boolean (default ``true``) specifying whether a user account should be created.
    * - ``boot_check_url``


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->
* Improved little bit the way we avoid rebooting zapper controllers
* Introduced a new "media" parameter in 'provision_data' section (as discussed with @mz2). This optional parameter is currently quite specific to Riverside devices, but is designed to be as generic as possible. The existing behavior is preserved if omitted. It is intended to select one of the 2 zapper tools as a boot media:
1. typecmux + usb stick (usb): the usb stick must be symlinked in zapper to /dev/tc-disk
2. sdwire + sd card (sd): sdwire must be symlinked in zapper to /dev/sd-disk

## Resolved issues
* https://warthogs.atlassian.net/browse/PERI-436
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
Tested with agents:
* nvidia-jetson-agx-orin-c31646
* nvidia-jetson-orin-nano-c33506

Tested combinations:
* no 'media' parameter
* media : usb
* media : sd
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run.
-->
