### PR TITLE
Update: Add timeout to subprocess call for oemrecovery

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
@@ -112,6 +112,7 @@ class OemRecovery:
                     self.config["device_ip"],
                 ),
                 shell=True,
+                timeout=5
             )
         ).decode()
 
@@ -146,6 +147,7 @@ class OemRecovery:
                     self.config["device_ip"],
                 ),
                 shell=True,
+                timeout=5
             )
         ).decode()
 

--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
@@ -112,7 +112,7 @@ class OemRecovery:
                     self.config["device_ip"],
                 ),
                 shell=True,
-                timeout=5
+                timeout=5,
             )
         ).decode()
 
@@ -147,7 +147,7 @@ class OemRecovery:
                     self.config["device_ip"],
                 ),
                 shell=True,
-                timeout=5
+                timeout=5,
             )
         ).decode()
 


### PR DESCRIPTION
## Description

Recently, I found that device-connectors for oemrecovery often get stuck at checking availability of the DUT for a long time, even the DUT is already able to ssh.
I think adding a timeout to prevent this kind of issue should be worthwhile.

https://github.com/canonical/testflinger/blob/main/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py#L104



## Resolved issues

Avoid getting stuck at here
```
15:30:03 ***********************************************************
15:30:03 
15:30:03 * Starting testflinger provision phase on capilano-qed001 *
15:30:03 
15:30:03 ***********************************************************
15:30:16 2024-03-19 07:30:03,322 capilano-qed001 INFO: DEVICE CONNECTOR: BEGIN provision
15:30:16 2024-03-19 07:30:03,322 capilano-qed001 INFO: DEVICE CONNECTOR: Provisioning device
15:30:16 2024-03-19 07:30:04,581 capilano-qed001 INFO: DEVICE CONNECTOR: Recovering OEM image
15:30:16 2024-03-19 07:30:04,581 capilano-qed001 INFO: DEVICE CONNECTOR: Running sudo snap reboot --install
15:30:16 2024-03-19 07:30:07,351 capilano-qed001 INFO: DEVICE CONNECTOR: b'Reboot into "install" mode.\n'
15:30:16 2024-03-19 07:30:07,351 capilano-qed001 INFO: DEVICE CONNECTOR: Checking to see if the device is available.
```

## Tests

Use a local build device-connector for testing this change.