### PR TITLE
Add: provision OEM images via Zapper KVM connector

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -62,6 +62,8 @@ class ZapperConnector(ABC, DefaultDevice):
         (api_args, api_kwargs) = self._validate_configuration()
         self._run(self.config["control_host"], *api_args, **api_kwargs)
 
+        self._post_run_actions(args)
+
         logger.info("END provision")
 
     @abstractmethod
@@ -99,3 +101,6 @@ class ZapperConnector(ABC, DefaultDevice):
             logger=logger,
             **kwargs,
         )
+
+    def _post_run_actions(self, args):
+        """Run further actions after Zapper API returns succesfully."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -103,4 +103,4 @@ class ZapperConnector(ABC, DefaultDevice):
         )
 
     def _post_run_actions(self, args):
-        """Run further actions after Zapper API returns succesfully."""
+        """Run further actions after Zapper API returns successfully."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -9,6 +9,8 @@ Support for vanilla Ubuntu is provided by [autoinstall](https://canonical-subiqu
 - Desktop >= 23.04
 - Server >= 20.04
 
+Unless specified via _autoinstall_ storage filter, the tool will select the largest storage device on the DUT. See [supported layouts](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#supported-layouts) for more information.
+
 ### Job parameters
 
 - __url__: URL to the image to install
@@ -28,6 +30,12 @@ Ubuntu OEM 22.04 is a two step process:
 
 1. Install using Zapper automations the `alloem` image which creates the reset partition on DUT and installs Ubuntu Jammy
 2. If URL is provided, run the OEM script to install an updated image on top of (1)
+
+The tool will select the storage device with the following priority:
+
+1. RAID
+2. NVME
+3. SATA
 
 #### Job parameters
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -1,0 +1,41 @@
+# Zapper KVM
+
+Zapper-driven provisioning method that makes use of KVM assertions and actions.
+
+## Ubuntu Desktop / Server
+
+Support for vanilla Ubuntu is provided by [autoinstall](https://canonical-subiquity.readthedocs-hosted.com/en/latest/intro-to-autoinstall.html). Supported Ubuntu versions are:
+
+- Desktop >= 23.04
+- Server >= 20.04
+
+### Job parameters
+
+- __url__: URL to the image to install
+- __username__: username to configure
+- __password__: password to configure
+- **storage_layout**: can be either `lvm`, `direct`, `zfs` or `hybrid` (Desktop 23.10+)
+- **storage_password** (optional): only available with *storage_layout=lvm*, it's the password for LUKS encryption
+- **robot_tasks**: list of Zapper Robot tasks to run after a hard reset in order to follow the `autoinstall` installation
+- **cmdline_append** (optional): kernel parameters to append at the end of GRUB entry cmdline
+- **base_user_data** (optional): a custom base user-data file, it should be validated against [this schema](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-schema.html)
+
+## Ubuntu Desktop OEM
+
+### Jammy
+
+Ubuntu OEM 22.04 is a two step process:
+
+1. Install using Zapper automations the `alloem` image which creates the reset partition on DUT and installs Ubuntu Jammy
+2. If URL is provided, run the OEM script to install an updated image on top of (1)
+
+#### Job parameters
+
+- __alloem_url__: URL to the `alloem` image
+- __url__ (optional): URL to the image to test, will be installed via the OEM script
+- __password__: password to configure
+- **robot_tasks**: list of Zapper Robot tasks to run after a hard reset in order to follow the `alloem` installation
+
+### Noble
+
+Ubuntu OEM 24.04 uses `autoinstall`. The procedure and the arguments are the same as _vanilla_ Ubuntu.

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -17,7 +17,6 @@ Unless specified via _autoinstall_ storage filter, the tool will select the larg
 - __username__: username to configure
 - __password__: password to configure
 - **storage_layout**: can be either `lvm`, `direct`, `zfs` or `hybrid` (Desktop 23.10+)
-- **storage_password** (optional): only available with *storage_layout=lvm*, it's the password for LUKS encryption
 - **robot_tasks**: list of Zapper Robot tasks to run after a hard reset in order to follow the `autoinstall` installation
 - **cmdline_append** (optional): kernel parameters to append at the end of GRUB entry cmdline
 - **base_user_data** (optional): a custom base user-data file, it should be validated against [this schema](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-schema.html)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -37,7 +37,7 @@ class DeviceConnector(ZapperConnector):
         provision = self.job_data["provision_data"]
 
         autoinstall_conf = {
-            "storage_layout": provision["storage_layout"],
+            "storage_layout": provision.get("storage_layout", "lvm"),
             "storage_password": provision.get("storage_password"),
         }
 
@@ -61,7 +61,7 @@ class DeviceConnector(ZapperConnector):
             url = self.job_data["provision_data"]["alloem_url"]
             username = "ubuntu"
             password = "u"
-            retries = min(
+            retries = max(
                 2, self.job_data["provision_data"].get("robot_retries", 1)
             )
         else:
@@ -90,7 +90,6 @@ class DeviceConnector(ZapperConnector):
                 "skip_dowload", False
             ),
         }
-        provisioning_data = {}
 
         return ((), provisioning_data)
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -87,7 +87,7 @@ class DeviceConnector(ZapperConnector):
                 "cmdline_append", ""
             ),
             "skip_download": self.job_data["provision_data"].get(
-                "skip_dowload", False
+                "skip_download", False
             ),
         }
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -42,7 +42,6 @@ class DeviceConnector(ZapperConnector):
 
         autoinstall_conf = {
             "storage_layout": provision.get("storage_layout", "lvm"),
-            "storage_password": provision.get("storage_password"),
         }
 
         if "base_user_data" in provision:

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -89,7 +89,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                 "storage_password": "luks",
                 "robot_retries": 3,
                 "cmdline_append": "more arguments",
-                "skip_dowload": True,
+                "skip_download": True,
             },
             "test_data": {
                 "test_username": "username",

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -355,6 +355,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         connector.job_data = {
             "provision_data": {"alloem_url": "file://image.iso"}
         }
+        connector._copy_ssh_id = Mock()
         connector._change_password = Mock()
         connector._run_oem_script = Mock()
 
@@ -362,3 +363,4 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
         connector._change_password.assert_called_with("ubuntu", "u")
         connector._run_oem_script.assert_called_with("args")
+        connector._copy_ssh_id.assert_called()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -87,7 +87,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                     "another.robot",
                 ],
                 "storage_layout": "lvm",
-                "storage_password": "luks",
                 "robot_retries": 3,
                 "cmdline_append": "more arguments",
                 "skip_download": True,
@@ -195,7 +194,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
         expected = {
             "storage_layout": "lvm",
-            "storage_password": None,
             "authorized_keys": ["mykey"],
         }
         self.assertDictEqual(conf, expected)
@@ -217,7 +215,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                     "another.robot",
                 ],
                 "storage_layout": "lvm",
-                "storage_password": "luks",
                 "base_user_data": "base data content",
             },
             "test_data": {
@@ -231,7 +228,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
         expected = {
             "storage_layout": "lvm",
-            "storage_password": "luks",
             "base_user_data": "base data content",
             "authorized_keys": ["mykey"],
         }

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -13,6 +13,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for Zapper KVM device connector."""
 
+import subprocess
 import unittest
 from unittest.mock import Mock, patch, mock_open
 from testflinger_device_connectors.devices.zapper_kvm import DeviceConnector
@@ -25,7 +26,49 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         """
         Test whether the validate_configuration function returns
         the expected data merging the relevant bits from conf and job
-        data.
+        data when passing only the required arguments
+        """
+
+        connector = DeviceConnector()
+        connector.config = {
+            "device_ip": "1.1.1.1",
+            "control_host": "1.1.1.2",
+            "reboot_script": ["cmd1", "cmd2"],
+        }
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "robot_tasks": [
+                    "job.robot",
+                    "another.robot",
+                ],
+            },
+        }
+
+        connector._get_autoinstall_conf = Mock()
+        args, kwargs = connector._validate_configuration()
+
+        expected = {
+            "url": "http://example.com/image.iso",
+            "username": "ubuntu",
+            "password": "ubuntu",
+            "autoinstall_conf": connector._get_autoinstall_conf.return_value,
+            "reboot_script": ["cmd1", "cmd2"],
+            "device_ip": "1.1.1.1",
+            "robot_tasks": ["job.robot", "another.robot"],
+            "robot_retries": 1,
+            "cmdline_append": "",
+            "skip_download": False,
+        }
+        self.assertEqual(args, ())
+        self.assertDictEqual(kwargs, expected)
+
+    def test_validate_configuration_w_opt(self):
+        """
+        Test whether the validate_configuration function returns
+        the expected data merging the relevant bits from conf and job
+        data when passing all the optional arguments.
         """
 
         connector = DeviceConnector()
@@ -43,6 +86,10 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                     "another.robot",
                 ],
                 "storage_layout": "lvm",
+                "storage_password": "luks",
+                "robot_retries": 3,
+                "cmdline_append": "more arguments",
+                "skip_dowload": True,
             },
             "test_data": {
                 "test_username": "username",
@@ -61,6 +108,59 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "reboot_script": ["cmd1", "cmd2"],
             "device_ip": "1.1.1.1",
             "robot_tasks": ["job.robot", "another.robot"],
+            "robot_retries": 3,
+            "cmdline_append": "more arguments",
+            "skip_download": True,
+        }
+        self.assertEqual(args, ())
+        self.assertDictEqual(kwargs, expected)
+
+    def test_validate_configuration_alloem(self):
+        """
+        Test whether the validate_configuration function returns
+        the expected data merging the relevant bits from conf and job
+        data when `alloem_url` is passed. In that case, username and
+        password are hardcoded and the Zapper shall try the procedures
+        at least twice because it can fail on purpose.
+        """
+
+        connector = DeviceConnector()
+        connector.config = {
+            "device_ip": "1.1.1.1",
+            "control_host": "1.1.1.2",
+            "reboot_script": ["cmd1", "cmd2"],
+        }
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "alloem_url": "http://example.com/alloem.iso",
+                "robot_tasks": [
+                    "job.robot",
+                    "another.robot",
+                ],
+                "storage_layout": "lvm",
+            },
+            "test_data": {
+                "test_username": "username",
+                "test_password": "password",
+            },
+        }
+
+        connector._get_autoinstall_conf = Mock()
+        args, kwargs = connector._validate_configuration()
+
+        expected = {
+            "url": "http://example.com/alloem.iso",
+            "username": "ubuntu",
+            "password": "u",
+            "autoinstall_conf": connector._get_autoinstall_conf.return_value,
+            "reboot_script": ["cmd1", "cmd2"],
+            "device_ip": "1.1.1.1",
+            "robot_tasks": ["job.robot", "another.robot"],
+            "robot_retries": 2,
+            "cmdline_append": "",
+            "skip_download": False,
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
@@ -135,3 +235,111 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "authorized_keys": ["mykey"],
         }
         self.assertDictEqual(conf, expected)
+
+    def test_run_oem_default(self):
+        """
+        Test the function changes the default password on DUT and
+        the runs the base OemScript.
+        """
+
+        connector = DeviceConnector()
+        connector.job_data = {}
+        connector._change_password = Mock()
+        args = Mock()
+
+        with patch(
+            "testflinger_device_connectors.devices.zapper_kvm.OemScript"
+        ) as script:
+            connector._run_oem(args)
+
+        connector._change_password.assert_called_with("ubuntu", "u")
+        script.assert_called_with(args.config, args.job_data)
+        script.return_value.provision.assert_called_once()
+
+    def test_run_oem_hp(self):
+        """
+        Test the function changes the default password on DUT and
+        the runs the HP OemScript when oem=hp.
+        """
+
+        connector = DeviceConnector()
+        connector.job_data = {}
+        connector._change_password = Mock()
+        args = Mock()
+
+        with patch(
+            "testflinger_device_connectors.devices.zapper_kvm.OemScript"
+        ) as script:
+            connector._run_oem(args)
+
+        connector._change_password.assert_called_with("ubuntu", "u")
+        script.assert_called_with(args.config, args.job_data)
+        script.return_value.provision.assert_called_once()
+
+    def test_run_oem_dell(self):
+        """
+        Test the function changes the default password on DUT and
+        the runs the Dell OemScript when oem=dell.
+        """
+
+        connector = DeviceConnector()
+        connector.job_data = {"oem": "dell"}
+        connector._change_password = Mock()
+        args = Mock()
+
+        with patch(
+            "testflinger_device_connectors.devices.zapper_kvm.DellOemScript"
+        ) as script:
+            connector._run_oem(args)
+
+        connector._change_password.assert_called_with("ubuntu", "u")
+        script.assert_called_with(args.config, args.job_data)
+        script.return_value.provision.assert_called_once()
+
+    def test_run_oem_lenovo(self):
+        """
+        Test the function changes the default password on DUT and
+        the runs the Lenovo OemScript when oem=lenovo.
+        """
+
+        connector = DeviceConnector()
+        connector.job_data = {"oem": "lenovo"}
+        connector._change_password = Mock()
+        args = Mock()
+
+        with patch(
+            "testflinger_device_connectors.devices.zapper_kvm.LenovoOemScript"
+        ) as script:
+            connector._run_oem(args)
+
+        connector._change_password.assert_called_with("ubuntu", "u")
+        script.assert_called_with(args.config, args.job_data)
+        script.return_value.provision.assert_called_once()
+
+    @patch("subprocess.check_output")
+    def test_change_password(self, mock_check_output):
+        """
+        Test the function runs a command over SSH to change the
+        original password to the one specified in test_data.
+        """
+        connector = DeviceConnector()
+        connector.job_data = {"test_data": {"test_password": "new_password"}}
+        connector.config = {"device_ip": "localhost"}
+
+        connector._change_password("ubuntu", "u")
+
+        cmd = [
+            "sshpass",
+            "-p",
+            "u",
+            "ssh",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "ubuntu@localhost",
+            "echo 'ubuntu:new_password' | sudo chpasswd",
+        ]
+        mock_check_output.assert_called_with(
+            cmd, stderr=subprocess.STDOUT, timeout=60
+        )


### PR DESCRIPTION
## Description

_Draft until https://github.com/canonical/zapper/pull/239 gets merged (only minor problems, but some argument name might change)._

This PR introduces the support for OEM images via the Zapper KVM provisioning method.

For __22.04__ the procedure is split in two:
1. Zapper installs via KVM automations the `alloem` image which restores the backup partition and install a default Ubuntu 22.04 OEM image
2. If another `url` is passed, Testflinger will run the normal OemScript to install it on top of (1).

I preferred keeping (2) on the TF side to avoid code duplication and big downloads on Zapper "internal" storage (like the OemScript is doing).

On the other hand, __24.04__ is similar to provision since it's using `autoinstall` with a custom `user-data-base` and some additional kernel arguments (hence the new `cmdline_append` parameter). I haven't had the chance to test it since our main focus for now is 22.04 and this method is still under development by the OEM team.

## Resolved issues

Part of [ZAP-722](https://warthogs.atlassian.net/browse/ZAP-722)

## Documentation

Added a README which describes the available arguments, the supported scenarios and versions.

## Tests

Test are updated accordingly. Also, one can test it manually with the following configuration:

```
# config.yaml
device_ip: "10.102.163.33"
control_host: "10.102.243.33"
reboot_script: 
  - snmpset -c private -v2c 10.102.196.162 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.7 i 0
  - sleep 5
  - snmpset -c private -v2c 10.102.196.162 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.7 i 1
```

```
#job.json
{
"job_queue": "test",
"provision_data": {
  "alloem_url": "http://10.102.196.9/somerville/Platforms/jellyfish-edge-alloem-init/dell-bto-jammy-jellyfish-edge-alloem-init-X104-20230908-19.iso",
  "robot_tasks": [
    "hp/pro/sff_400_g9/boot/boot_from_usb.robot",
    "common/oem/jammy/alloem.robot",
    "hp/boot/wait_reboot.robot"
    ],
  "skip_download": true
},
"test_data": {
  "test_username": "ubuntu",
  "test_password": "insecure"
  }
}
```


[ZAP-722]: https://warthogs.atlassian.net/browse/ZAP-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ