### PR TITLE
Ignore transmitting results if testflinger.json is missing

### DIFF
--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -200,8 +200,16 @@ class TestflingerClient:
         :param rundir:
             Execution dir where the results can be found
         """
-        with open(os.path.join(rundir, "testflinger.json")) as f:
-            job_data = json.load(f)
+        try:
+            with open(os.path.join(rundir, "testflinger.json")) as f:
+                job_data = json.load(f)
+        except OSError:
+            logger.error(
+                f"Unable to read job ID from {rundir}/testflinger.json. "
+                "This may be a job that was already transmitted, but "
+                "couldn't be removed."
+            )
+            return
         job_id = job_data.get("job_id")
         # If we find an 'artifacts' dir under rundir, archive it, and transmit
         # it to the Testflinger server


### PR DESCRIPTION
## Description
Kevin pointed out a case today where the testflinger agent had died. There's a corner case where the results have already been transmitted so we remove testflinger.json to ensure it doesn't get transmitted again. But if the dir was unable to be removed, then it might still try again. If it fails to find testflinger.json then it can't get the job id and fails, but it should do so more gracefully in this case.

## Tests
Added a unit test for this situation, and also added some other unit tests around this method that we were missing to increase coverage.
