### PR TITLE
Ensure self.process is None in CommandRunner in case it's reused

### DIFF
--- a/agent/testflinger_agent/runner.py
+++ b/agent/testflinger_agent/runner.py
@@ -87,6 +87,8 @@ class CommandRunner:
             self.process.kill()
 
     def run(self, cmd: str) -> int:
+        # Ensure that the process is None before starting
+        self.process = None
 
         signal.signal(signal.SIGTERM, lambda signum, frame: self.cleanup())
 


### PR DESCRIPTION
## Description
Tiny fix, for something I noticed after deploying the latest agent code.
We reuse the CommandRunner throughout the duration of a single job phase. We currently send the banner output for the top of the test phase as commands so that it goes to all the right logs, output buffer, etc. But there's a chance that the old process can be left over when we restart a new on, and this can result in the output not streaming properly from the command. Fortunately, the fix is pretty easy - just ensure that we reset self.process back to None before starting a command each time.

## Tests
I tested this both locally after reproducing it, and with a real agent in the lab and was able to see the output streaming properly after I pushed the fix.
