### PR TITLE
Temporarily disable output timeout checking until we have a better fix

### DIFF
--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -24,7 +24,6 @@ from .handlers import LiveOutputHandler, LogUpdateHandler
 from .stop_condition_checkers import (
     JobCancelledChecker,
     GlobalTimeoutChecker,
-    OutputTimeoutChecker,
 )
 
 logger = logging.getLogger(__name__)
@@ -94,13 +93,6 @@ class TestflingerJob:
                 self.get_global_timeout()
             )
             runner.register_stop_condition_checker(global_timeout_checker)
-
-        # We only need to check for output timeouts during the test phase
-        if phase == "test":
-            output_timeout_checker = OutputTimeoutChecker(
-                self.get_output_timeout()
-            )
-            runner.register_stop_condition_checker(output_timeout_checker)
 
         # Do not allow cancellation during provision for safety reasons
         if phase != "provision":


### PR DESCRIPTION
This to work around an issue with how we do output timeout checking for now, until we have a better way.

When I originally refactored this, the output timeout checking was on another thread, but it was a bit hairy. That was one of the pieces I was trying to clean up, so I ended up consolidating it as a "stop_condition_checker" that we could register, but I missed the part where it needs to have awareness of the latest time new output was seen.
Will look into whether output timeout checking makes sense really, or at least providing a better fix.
But for now, it's very likely this could cause things to fail prematurely, so we need to address that immediately
