### PR TITLE
Add: reboot control host from poe switch for muxpi devices

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -113,7 +113,6 @@ class MuxPi:
             raise ProvisioningError(e.output)
         return output
 
-
     def check_control_alive(self):
         """Check if the control host is alive"""
         try:
@@ -150,7 +149,6 @@ class MuxPi:
             time.sleep(10)
         # One final check to ensure the control host is alive, or fail
         self.check_control_alive()
-
 
     def provision(self):
         # If this is not a zapper, reboot before provisioning

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -130,6 +130,12 @@ class MuxPi:
         be using the control host, check and power cycle it if needed before
         provisioning to ensure it's in a known good state.
         """
+        if not self.config.get("control_host_reboot_script"):
+            logger.warning(
+                "control_host_reboot_script not defined, "
+                "skip rebooting control host"
+            )
+            return
         logger.info("Rebooting control host")
         for cmd in self.config["control_host_reboot_script"]:
             logger.info("Running %s", cmd)

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -113,7 +113,54 @@ class MuxPi:
             raise ProvisioningError(e.output)
         return output
 
+
+    def check_control_alive(self):
+        """Check if the control host is alive"""
+        try:
+            self._run_control("true")
+        except (ProvisioningError, subprocess.SubprocessError):
+            raise ProvisioningError(
+                "Control host is not responding, provisioning can't proceed!"
+            )
+
+    def reboot_control_host(self):
+        """
+        Reboot the control host
+        Sometimes the control host can end up in an unstable condition which
+        isn't easy to detect until it's too late. Since nothing else should
+        be using the control host, check and power cycle it if needed before
+        provisioning to ensure it's in a known good state.
+        """
+        try:
+            self.check_control_alive()
+        except:
+            logger.info("Rebooting control host")
+            # disable/enable poe switch port power
+            for cmd in self.config["control_host_reboot_script"]:
+                logger.info("Running %s", cmd)
+                try:
+                    subprocess.check_call(cmd.split(), timeout=60)
+                except Exception:
+                    raise ProvisioningError("fail to reboot control host")
+
+            time.sleep(120)
+            # It should be up after 120s, but wait up to 5min if necessary
+            for _ in range(24):
+                try:
+                    self.check_control_alive()
+                    break
+                except ProvisioningError:
+                    logger.info("Waiting for control host to become active...")
+                time.sleep(10)
+        finally:
+            # One final check to ensure the control host is alive, or fail
+            self.check_control_alive()
+
+
     def provision(self):
+        # If this is not a zapper, reboot before provisioning
+        if "zapper" not in self.config.get("control_switch_local_cmd", ""):
+            self.reboot_control_host()
         try:
             url = self.job_data["provision_data"]["url"]
         except KeyError:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -131,30 +131,25 @@ class MuxPi:
         be using the control host, check and power cycle it if needed before
         provisioning to ensure it's in a known good state.
         """
-        try:
-            self.check_control_alive()
-        except:
-            logger.info("Rebooting control host")
-            # disable/enable poe switch port power
-            for cmd in self.config["control_host_reboot_script"]:
-                logger.info("Running %s", cmd)
-                try:
-                    subprocess.check_call(cmd.split(), timeout=60)
-                except Exception:
-                    raise ProvisioningError("fail to reboot control host")
+        logger.info("Rebooting control host")
+        for cmd in self.config["control_host_reboot_script"]:
+            logger.info("Running %s", cmd)
+            try:
+                subprocess.check_call(cmd.split(), timeout=60)
+            except Exception:
+                raise ProvisioningError("fail to reboot control host")
 
-            time.sleep(120)
-            # It should be up after 120s, but wait up to 5min if necessary
-            for _ in range(24):
-                try:
-                    self.check_control_alive()
-                    break
-                except ProvisioningError:
-                    logger.info("Waiting for control host to become active...")
-                time.sleep(10)
-        finally:
-            # One final check to ensure the control host is alive, or fail
-            self.check_control_alive()
+        time.sleep(120)
+        # It should be up after 120s, but wait up to 5min if necessary
+        for _ in range(24):
+            try:
+                self.check_control_alive()
+                break
+            except ProvisioningError:
+                logger.info("Waiting for control host to become active...")
+            time.sleep(10)
+        # One final check to ensure the control host is alive, or fail
+        self.check_control_alive()
 
 
     def provision(self):


### PR DESCRIPTION
## Description

This PR is based on https://github.com/canonical/testflinger/pull/222, replacing the `shutdown` command with PoE switch snmp command for non-Zapper control hosts (NanoPi). Hoping this can improve the stability of them and ensure a smooth provisioning.

It depends on the changes on [cc-lab-manager](https://github.com/canonical/certification-lab-manager/pull/20) and [cc-tool-box](https://code.launchpad.net/~nancy-chen/cc-tool-box/+git/cc-tool-box/+merge/463194) to generate `control_host_reboot_script` in default.yaml.


## Tests

Tested on several agents for device with NanoPi. 
Manually disable the power supply for `limerick-zcu106001`'s NanoPi before sending the testflinger job. The NanoPi is back and able to continue the provisioning.
```
**************************************************************

* Starting testflinger provision phase on limerick-zcu106001 *

**************************************************************
2024-03-27 10:00:19,943 limerick-zcu106001 INFO: DEVICE CONNECTOR: BEGIN provision
2024-03-27 10:00:19,943 limerick-zcu106001 INFO: DEVICE CONNECTOR: Provisioning device
2024-03-27 10:00:23,003 limerick-zcu106001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
2024-03-27 10:00:23,003 limerick-zcu106001 INFO: DEVICE CONNECTOR: Rebooting control host
2024-03-27 10:00:23,004 limerick-zcu106001 INFO: DEVICE CONNECTOR: Running snmpset -c private -v 2c 10.102.x.x 1.3.6.1.2.1.105.1.1.1.3.1.2 i 2
iso.3.6.1.2.1.105.1.1.1.3.1.2 = INTEGER: 2
2024-03-27 10:00:23,012 limerick-zcu106001 INFO: DEVICE CONNECTOR: Running sleep 5
2024-03-27 10:00:28,045 limerick-zcu106001 INFO: DEVICE CONNECTOR: Running snmpset -c private -v 2c 10.102.x.x 1.3.6.1.2.1.105.1.1.1.3.1.2 i 1
iso.3.6.1.2.1.105.1.1.1.3.1.2 = INTEGER: 1
2024-03-27 10:00:56,091 limerick-zcu106001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
2024-03-27 10:01:26,123 limerick-zcu106001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
2024-03-27 10:01:56,155 limerick-zcu106001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
2024-03-27 10:02:36,336 limerick-zcu106001 INFO: DEVICE CONNECTOR: Flashing Test image
2024-03-27 10:02:37,413 limerick-zcu106001 INFO: DEVICE CONNECTOR: Running: (set -o pipefail; curl -sf http://10.102.196.9/limerick/focal/iot-limerick-classic-desktop-2004-x07-20210728-85.img.xz | zstdcat| sudo dd of=/dev/sda bs=16M)
2024-03-27 10:12:03,788 limerick-zcu106001 INFO: DEVICE CONNECTOR: Image type detected: ce-oem-iot
2024-03-27 10:12:03,788 limerick-zcu106001 INFO: DEVICE CONNECTOR: Creating Test User
2024-03-27 10:12:17,709 limerick-zcu106001 INFO: DEVICE CONNECTOR: Booting Test Image
2024-03-27 10:12:18,883 limerick-zcu106001 INFO: DEVICE CONNECTOR: Running snmpset -c private -v2c 10.102.x.x .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.6 i 0
iso.3.6.1.4.1.13742.6.4.1.2.1.2.1.6 = INTEGER: 0
2024-03-27 10:12:18,893 limerick-zcu106001 INFO: DEVICE CONNECTOR: Running sleep 30
2024-03-27 10:12:48,923 limerick-zcu106001 INFO: DEVICE CONNECTOR: Running snmpset -c private -v2c 10.102.x.x .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.6 i 1
iso.3.6.1.4.1.13742.6.4.1.2.1.2.1.6 = INTEGER: 1
2024-03-27 10:12:48,931 limerick-zcu106001 INFO: DEVICE CONNECTOR: Checking if test image booted.
2024-03-27 10:14:17,807 limerick-zcu106001 INFO: DEVICE CONNECTOR: END provision
```