### PR TITLE
Add the jammy tag to all self-hosted runner invocations

### DIFF
--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: agent
-    runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, linux, jammy, X64]
     strategy:
       matrix:
         python: ["3.8", "3.10"]

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: cli
-    runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, linux, jammy, X64]
     strategy:
       matrix:
         python: ["3.8", "3.10"]

--- a/.github/workflows/device-tox.yml
+++ b/.github/workflows/device-tox.yml
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: device-connectors
-    runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, linux, jammy, X64]
     strategy:
       matrix:
         python: ["3.8", "3.10"]

--- a/.github/workflows/server-charm-check-libs.yml
+++ b/.github/workflows/server-charm-check-libs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Check charm libraries
-    runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, linux, jammy, X64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/server-charm-release-edge.yml
+++ b/.github/workflows/server-charm-release-edge.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-push-charm:
-    runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, linux, jammy, X64]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: server
-    runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, linux, jammy, X64]
     strategy:
       matrix:
         python: ["3.8", "3.10"]


### PR DESCRIPTION
## Description

Update all workflows using self-hosted runners to include the jammy tag. This is in preparation for the availability of noble runners