### PR TITLE
Alert the user about the nature of advertised queues

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -110,6 +110,7 @@ def _get_ssh_keys():
                 print("Please enter keys in the form lp:userid or gh:userid")
     return key_list
 
+
 def _print_queue_message():
     print(
         "ATTENTION: This only shows a curated list of queues with "


### PR DESCRIPTION
## Description
One of the frequently asked things we get from people using the cli for reservations, is "why don't I see this queue that I know exists?" In order to make that a little more obvious, it was suggested that we add a message when using list-queues or reserve from the cli

## Resolved issues
This is one of the items that was requested in CERTTF-298