### PR TITLE
Add docs about agents and queues to the explanation section

### DIFF
--- a/docs/explanation/agents.rst
+++ b/docs/explanation/agents.rst
@@ -1,0 +1,11 @@
+Testflinger Agents
+==================
+
+The Testflinger agent is a per-machine service that runs on an agent host
+system. The agent is configured with a set of :doc:`queues <queues>` for which
+it knows how to run jobs. When it is not running a job, the agent:
+
+   * Asks the server for a job to run from the list of configured :doc:`queues <queues>`
+   * Dispatches the device connector to execute each :doc:`phase <../reference/test-phases>` of the job
+   * Reports the results of the job back to the server
+   * Uploads artifacts (if any) saved from the job to the server

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -1,4 +1,10 @@
 Explanation
 ===========
 
+This section covers conceptual questions about Testflinger.
 
+.. toctree::
+    :maxdepth: 1
+
+    agents
+    queues

--- a/docs/explanation/queues.rst
+++ b/docs/explanation/queues.rst
@@ -1,0 +1,15 @@
+Testflinger Queues
+==================
+
+The concept of a queue in Testflinger works as a flexible way of routing test
+jobs to :doc:`agents <agents>`. It's a bit more like a system of "tags".
+
+When you define a test job in Testflinger, you give it a single `job queue`
+in the job definition. When the job is posted to the server, it waits
+for an available agent to request jobs from that queue.
+
+Trying to force the scheduling of jobs to :doc:`agents <agents>` would require
+the server to maintain state of all :doc:`agents <agents>` at all time, and be
+the arbiter of the entire process. Instead, the :doc:`agents <agents>` can
+operate autonomously, and maintain their own lifecycle. The
+:doc:`agents <agents>` ask for a job when they are available to run one.


### PR DESCRIPTION
## Description
There are certainly more things we should add here, but this gives us a start on the explanation section of the documentation (which previously didn't have anything yet). We can build on that from here.

## Resolved issues
Also, these specific sections were requested in CERTTF-298

## Documentation
Yes

## Tests
Passed make linkcheck for me locally