### PR TITLE
Fix an unlikely corner-case where an agent has no queues declared

### DIFF
--- a/server/src/views.py
+++ b/server/src/views.py
@@ -91,8 +91,9 @@ def queues_data():
     # Get all the queues the agents say they are listening to from agent data
     agent_data = mongo.db.agents.find({}, {"_id": 0, "queues": 1})
     agent_queues_set = set(
-        queue for agent in agent_data for queue in agent["queues"]
+        queue for agent in agent_data for queue in agent.get("queues", [])
     )
+    #    queue for agent in agent_data for queue in agent["queues"]
     advertised_queues_set = set(queue["name"] for queue in queue_data)
 
     # Only keep the ones that weren't also in the advertised queues

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -45,6 +45,10 @@ def test_queues():
                 "name": "agent2",
                 "queues": ["queue2", "queue4", "advertised_queue2"],
             },
+            # There's an unlikely chance that an agent has no queues
+            {
+                "name": "agent2",
+            },
         ]
     )
     mongo.db.jobs.insert_many(


### PR DESCRIPTION
## Description
Strange thing I hit when pushing this to staging. For some reason, there was an agent that had no queues associated with it there! That's unlikely, and wouldn't be very useful, but it's obviously possible and we apparently had one there that fit this profile.
This accounts for that possibility and skips it appropriately, while also adding a test for this corner-case

## Tests
Updated the unit tests with something that triggered this corner case
