### PR TITLE
[CERTTF-303] Introduce support for file attachments

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -123,12 +123,13 @@ class TestflingerAgent:
         """Download and unpack the attachments associated with a job"""
 
         # download attachment archive to a unique temporary folder
+        job_id = job_data["job_id"]
         archive_dir = tmp_dir()
-        archive_path = self.client.get_attachments(
-            job_id=job_data["job_id"], path=archive_dir
-        )
+        archive_path = self.client.get_attachments(job_id, path=archive_dir)
         if archive_path is None:
-            raise FileNotFoundError
+            raise FileNotFoundError(
+                f"Unable to retrieve attachments for job {job_id}"
+            )
         # extract archive data to a unique temporary folder and clean up
         extracted_dir = tmp_dir()
         with tarfile.open(archive_path, "r:gz") as tar:

--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -144,7 +144,7 @@ class TestflingerAgent:
         attachment_dir = cwd / "attachments"
 
         # move/rename extracted archive files to their specified destinations
-        for phase in ["provision", "firmware_update", "test"]:
+        for phase in ("provision", "firmware_update", "test"):
             try:
                 attachments = job_data[f"{phase}_data"]["attachments"]
             except KeyError:
@@ -159,11 +159,10 @@ class TestflingerAgent:
                 destination_path = (
                     attachment_dir / phase / attachment.get("agent", original)
                 )
-                try:
-                    # create intermediate path to destination, if required
-                    destination_path.resolve().parent.mkdir(parents=True)
-                except FileExistsError:
-                    pass
+                # create intermediate path to destination, if required
+                destination_path.resolve().parent.mkdir(
+                    parents=True, exist_ok=True
+                )
                 # move file
                 source_path = extracted_dir / phase / original
                 shutil.move(source_path, destination_path)

--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -22,6 +22,7 @@ import tempfile
 
 from testflinger_agent.job import TestflingerJob
 from testflinger_agent.errors import TFServerError
+from testflinger_agent.config import ATTACHMENTS_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -136,8 +137,7 @@ class TestflingerAgent:
             tar.extractall(extracted_dir, filter="data")
         shutil.rmtree(archive_dir)
 
-        # [TODO] clarify if this is an appropriate destination for extraction
-        attachment_dir = cwd / "attachments"
+        attachment_dir = cwd / ATTACHMENTS_DIR
 
         # move/rename extracted archive files to their specified destinations
         for phase in ("provision", "firmware_update", "test"):

--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -31,11 +31,6 @@ def tmp_dir() -> Path:
     return Path(tempfile.mkdtemp())
 
 
-def secure_filter(member, path):
-    """Combine the `data` and `tar` filter from `tarfile`"""
-    return tarfile.tar_filter(tarfile.data_filter(member, path), path)
-
-
 class TestflingerAgent:
     def __init__(self, client):
         self.client = client
@@ -137,7 +132,7 @@ class TestflingerAgent:
         # extract archive data to a unique temporary folder and clean up
         extracted_dir = tmp_dir()
         with tarfile.open(archive_path, "r:gz") as tar:
-            tar.extractall(extracted_dir, filter=secure_filter)
+            tar.extractall(extracted_dir, filter="data")
         shutil.rmtree(archive_dir)
 
         # [TODO] clarify if this is an appropriate destination for extraction

--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -188,7 +188,7 @@ class TestflingerAgent:
                 # handle job attachments, if any
                 # (always after creating "testflinger.json", for reporting
                 # in case of an unpacking error)
-                if job_data.get("attachments", "none") == "complete":
+                if job_data.get("attachments_status") == "complete":
                     self.unpack_attachments(job_data, cwd=Path(rundir))
 
                 for phase in TEST_PHASES:

--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -124,8 +124,7 @@ class TestflingerClient:
                 raise TFServerError(response.status_code)
             with open(path, "wb") as attachments:
                 for chunk in response.iter_content(chunk_size=4096):
-                    if chunk:
-                        attachments.write(chunk)
+                    attachments.write(chunk)
         return path
 
     def check_job_state(self, job_id):

--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -115,7 +115,7 @@ class TestflingerClient:
             Where to save the attachment archive. If it is a folder,
             the default filename `attachments.tar.gz` is used.
         :returns path or None:
-            Where the attachment archive was saved or `None` id nothing
+            Where the attachment archive was saved or `None` if nothing
             was retrieved
         """
         uri = urljoin(self.server, f"/v1/job/{job_id}/attachments")

--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -15,6 +15,7 @@
 import logging
 import json
 import os
+from pathlib import Path
 import requests
 import shutil
 import tempfile
@@ -104,6 +105,30 @@ class TestflingerClient:
             logger.error(exc)
             # Wait a little extra before trying again
             time.sleep(60)
+
+    def get_attachments(self, job_id: int, path: Path):
+        """Download the attachment archive associated with a job
+
+        :param job_id:
+            Id for the job
+        :param path:
+            Where to save the attachment archive. If it is a folder,
+            the default filename `attachments.tar.gz` is used.
+        :returns path or None:
+            Where the attachment archive was saved or `None` id nothing
+            was retrieved
+        """
+        uri = urljoin(self.server, f"/v1/job/{job_id}/attachments")
+        if path.is_dir():
+            path = path / "attachments.tar.gz"
+        with requests.get(uri, stream=True, timeout=600) as response:
+            if response.status_code != 200:
+                return None
+            with open(path, "wb") as attachments:
+                for chunk in response.iter_content(chunk_size=4096):
+                    if chunk:
+                        attachments.write(chunk)
+        return path
 
     def check_job_state(self, job_id):
         job_data = self.get_result(job_id)

--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -106,24 +106,22 @@ class TestflingerClient:
             # Wait a little extra before trying again
             time.sleep(60)
 
-    def get_attachments(self, job_id: int, path: Path):
+    def get_attachments(self, job_id: str, path: Path):
         """Download the attachment archive associated with a job
 
         :param job_id:
             Id for the job
         :param path:
-            Where to save the attachment archive. If it is a folder,
-            the default filename `attachments.tar.gz` is used.
-        :returns path or None:
-            Where the attachment archive was saved or `None` if nothing
-            was retrieved
+            Where to save the attachment archive.
         """
         uri = urljoin(self.server, f"/v1/job/{job_id}/attachments")
-        if path.is_dir():
-            path = path / "attachments.tar.gz"
         with requests.get(uri, stream=True, timeout=600) as response:
             if response.status_code != 200:
-                return None
+                logger.error(
+                    f"Unable to retrieve attachments for job {job_id} "
+                    f"(error: {response.status_code})"
+                )
+                raise TFServerError(response.status_code)
             with open(path, "wb") as attachments:
                 for chunk in response.iter_content(chunk_size=4096):
                     if chunk:

--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -112,7 +112,7 @@ class TestflingerClient:
         :param job_id:
             Id for the job
         :param path:
-            Where to save the attachment archive.
+            Where to save the attachment archive
         """
         uri = urljoin(self.server, f"/v1/job/{job_id}/attachments")
         with requests.get(uri, stream=True, timeout=600) as response:
@@ -125,7 +125,6 @@ class TestflingerClient:
             with open(path, "wb") as attachments:
                 for chunk in response.iter_content(chunk_size=4096):
                     attachments.write(chunk)
-        return path
 
     def check_job_state(self, job_id):
         job_data = self.get_result(job_id)

--- a/agent/testflinger_agent/config.py
+++ b/agent/testflinger_agent/config.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Configuration constants for the Testflinger agent"""
+
+ATTACHMENTS_DIR = "attachments"

--- a/agent/testflinger_agent/tests/test_agent.py
+++ b/agent/testflinger_agent/tests/test_agent.py
@@ -103,7 +103,7 @@ class TestClient:
         # create gzipped archive containing attachment
         archive = tmp_path / "attachments.tar.gz"
         with tarfile.open(archive, "w:gz") as attachments:
-            attachments.add(attachment, arcname=f"test/{attachment}")
+            attachments.add(attachment, arcname="test/random.bin")
         # job data specifies how the attachment will be handled
         fake_job_data = {
             "job_id": str(uuid.uuid1()),
@@ -142,6 +142,54 @@ class TestClient:
             basepath = Path(self.tmpdir) / fake_job_data["job_id"]
             attachment = basepath / ATTACHMENTS_DIR / "test" / attachment.name
             assert attachment.exists()
+
+    def test_attachments_insecure(self, agent, tmp_path):
+        # create file to be used as attachment
+        attachment = tmp_path / "random.bin"
+        attachment.write_bytes(os.urandom(128))
+        # create gzipped archive containing attachment
+        archive = tmp_path / "attachments.tar.gz"
+        with tarfile.open(archive, "w:gz") as attachments:
+            # note: archive name should start with a phase folder
+            attachments.add(attachment, arcname="random.bin")
+        # job data specifies how the attachment will be handled
+        fake_job_data = {
+            "job_id": str(uuid.uuid1()),
+            "job_queue": "test",
+            "test_data": {
+                "attachments": [
+                    {
+                        "local": str(attachment),
+                        "agent": str(attachment.name),
+                    }
+                ]
+            },
+            "attachments": "complete",
+        }
+
+        with rmock.Mocker() as mocker:
+            mocker.post(rmock.ANY, status_code=200)
+            # mock response to requesting jobs
+            mocker.get(
+                re.compile(r"/v1/job\?queue=\w+"),
+                [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+            )
+            # mock response to requesting job attachments
+            mocker.get(
+                re.compile(r"/v1/job/[-a-z0-9]+/attachments"),
+                content=archive.read_bytes(),
+            )
+            # mock response to results request
+            mocker.get(re.compile(r"/v1/result/"))
+
+            # request and process the job (should unpack the archive)
+            with patch("shutil.rmtree"):
+                agent.process_jobs()
+
+            # check that the attachment is *not* where it's supposed to be
+            basepath = Path(self.tmpdir) / fake_job_data["job_id"]
+            attachment = basepath / ATTACHMENTS_DIR / "test" / attachment.name
+            assert not attachment.exists()
 
     def test_config_vars_in_env(self, agent, requests_mock):
         self.config["test_command"] = (

--- a/agent/testflinger_agent/tests/test_agent.py
+++ b/agent/testflinger_agent/tests/test_agent.py
@@ -12,6 +12,7 @@ import pytest
 from mock import patch
 
 import testflinger_agent
+from testflinger_agent.config import ATTACHMENTS_DIR
 from testflinger_agent.errors import TFServerError
 from testflinger_agent.client import TestflingerClient as _TestflingerClient
 from testflinger_agent.agent import TestflingerAgent as _TestflingerAgent
@@ -139,7 +140,8 @@ class TestClient:
 
             # check that the attachment is where it's supposed to be
             basepath = Path(self.tmpdir) / fake_job_data["job_id"]
-            assert (basepath / "attachments/test" / attachment.name).exists()
+            attachment = basepath / ATTACHMENTS_DIR / "test" / attachment.name
+            assert attachment.exists()
 
     def test_config_vars_in_env(self, agent, requests_mock):
         self.config["test_command"] = (

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -330,7 +330,7 @@ class TestflingerCli:
                 attachment_data[phase] = job_data[phase_str]["attachments"]
             except KeyError:
                 pass
-        return attachment_data if attachment_data else None
+        return attachment_data or None
 
     @staticmethod
     def pack_attachments(archive: str, attachment_data: dict):

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -316,7 +316,7 @@ class TestflingerCli:
     def pack_attachments(job_data: dict) -> Optional[Path]:
         """Return the path to a compressed tarball of attachments"""
 
-        # pull together the attachement data per phase
+        # pull together the attachment data per phase
         phases = ["provision", "firmware_update", "test"]
         attachment_data = {}
         for phase in phases:

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -368,10 +368,8 @@ class TestflingerCli:
                     self.args.filename, encoding="utf-8", errors="ignore"
                 ) as job_file:
                     data = job_file.read()
-            except FileNotFoundError as exc:
-                raise SystemExit(
-                    "File not found: {}".format(self.args.filename)
-                ) from exc
+            except FileNotFoundError:
+                sys.exit("File not found: {self.args.filename}")
         job_dict = yaml.safe_load(data)
 
         attachments_data = self.extract_attachment_data(job_dict)
@@ -410,21 +408,21 @@ class TestflingerCli:
             job_id = self.client.submit_job(data)
         except client.HTTPError as exc:
             if exc.status == 400:
-                raise SystemExit(
+                sys.exit(
                     "The job you submitted contained bad data or "
                     "bad formatting, or did not specify a "
                     "job_queue."
-                ) from exc
+                )
             if exc.status == 404:
-                raise SystemExit(
+                sys.exit(
                     "Received 404 error from server. Are you "
                     "sure this is a testflinger server?"
-                ) from exc
+                )
             # This shouldn't happen, so let's get more information
-            raise SystemExit(
+            sys.exit(
                 "Unexpected error status from testflinger "
                 f"server: {exc.status}"
-            ) from exc
+            )
         return job_id
 
     def submit_job_attachments(self, job_id: str, path: Path):

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -317,9 +317,8 @@ class TestflingerCli:
         """Return the path to a compressed tarball of attachments"""
 
         # pull together the attachment data per phase
-        phases = ["provision", "firmware_update", "test"]
         attachment_data = {}
-        for phase in phases:
+        for phase in ("provision", "firmware_update", "test"):
             phase_str = f"{phase}_data"
             try:
                 attachment_data[phase] = job_data[phase_str]["attachments"]
@@ -392,10 +391,10 @@ class TestflingerCli:
         if self.args.poll:
             self.do_poll(job_id)
 
-    def submit_job_data(self, data_dict):
+    def submit_job_data(self, data: dict):
         """Submit data that was generated or read from a file as a test job"""
         try:
-            job_id = self.client.submit_job(data_dict)
+            job_id = self.client.submit_job(data)
         except client.HTTPError as exc:
             if exc.status == 400:
                 raise SystemExit(
@@ -411,7 +410,7 @@ class TestflingerCli:
             # This shouldn't happen, so let's get more information
             raise SystemExit(
                 "Unexpected error status from testflinger "
-                "server: {}".format(exc.status)
+                f"server: {exc.status}"
             ) from exc
         return job_id
 
@@ -438,7 +437,7 @@ class TestflingerCli:
             # This shouldn't happen, so let's get more information
             raise SystemExit(
                 "Unexpected error status from testflinger "
-                "server: {}".format(exc.status)
+                f"server: {exc.status}"
             ) from exc
 
     def show(self):

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -432,7 +432,8 @@ class TestflingerCli:
             if exc.status == 404:
                 raise SystemExit(
                     "Received 404 error from server. Are you "
-                    "sure this is a testflinger server?"
+                    "sure this is a testflinger server and "
+                    "that it supports attachments?"
                 ) from exc
             # This shouldn't happen, so let's get more information
             raise SystemExit(

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import tarfile
 import tempfile
 import time
+from typing import Optional
 from argparse import ArgumentParser
 from datetime import datetime
 import yaml
@@ -312,7 +313,7 @@ class TestflingerCli:
         print()
 
     @staticmethod
-    def pack_attachments(job_data: dict) -> Path | None:
+    def pack_attachments(job_data: dict) -> Optional[Path]:
         """Return the path to a compressed tarball of attachments"""
 
         # pull together the attachement data per phase

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -434,9 +434,9 @@ class TestflingerCli:
             The path to the attachment archive
         """
         # defaults for retries
-        wait = self.config.get("attachments_retry_wait") or 10
-        timeout = self.config.get("attachments_timeout") or 600
-        tries = self.config.get("attachments_tries") or 3
+        wait = self.config.get("attachments_retry_wait", 10)
+        timeout = self.config.get("attachments_timeout", 600)
+        tries = self.config.get("attachments_tries", 3)
 
         for _ in range(tries):
             try:
@@ -462,7 +462,7 @@ class TestflingerCli:
             except (requests.Timeout, requests.ConnectionError):
                 # recoverable errors, try again
                 time.sleep(wait)
-                wait *= 0.3
+                wait *= 1.3
             else:
                 # success
                 return

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -126,10 +126,12 @@ def _print_queue_message():
 
 
 def make_relative(path: Path) -> Path:
-    """Return `path` stripped of its leading `/`, if there is one"""
+    """Return resolved relative `path`"""
     if path.is_absolute():
-        return path.relative_to(path.root)
-    return path
+        # strip leading '/' from absolute path
+        path = path.relative_to(path.root)
+    # resolve the path and make relative again
+    return path.resolve().relative_to(Path.cwd())
 
 
 class AttachmentError(Exception):

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -106,14 +106,17 @@ class Client:
                 response = requests.post(uri, files=files, timeout=timeout)
             except requests.exceptions.ConnectTimeout:
                 logger.error(
-                    "Timeout while trying to communicate with the server."
+                    "Timeout while trying to connect to the remote server"
                 )
                 raise
             except requests.exceptions.ReadTimeout:
-                logger.error("Timeout while communicating with the server.")
+                logger.error(
+                    "Connection established but the server did not send data "
+                    "in the alloted amount of time"
+                )
                 raise
             except requests.exceptions.ConnectionError:
-                logger.error("Unable to communicate with specified server.")
+                logger.error("A connection error occured")
                 raise
             response.raise_for_status()
 

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -147,7 +147,7 @@ class Client:
         """Submit a test job to the testflinger server
 
         :param job_data:
-            Dictionary containing json or yaml data for the job to submit
+            Dictionary containing data for the job to submit
         :return:
             ID for the test job
         """

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -20,10 +20,11 @@ Testflinger client module
 
 import json
 import logging
+from pathlib import Path
 import sys
 import urllib.parse
+
 import requests
-import yaml
 
 
 logger = logging.getLogger(__name__)
@@ -86,6 +87,30 @@ class Client:
             raise HTTPError(req.status_code)
         return req.text
 
+    def put_file(self, uri_frag: str, path: Path, timeout: float) -> str:
+        """Stream a file to the server using a POST request
+        :param uri_frag:
+            endpoint for the POST request
+        :return:
+            String containing the response from the server
+        """
+        uri = urllib.parse.urljoin(self.server, uri_frag)
+        with open(path, "rb") as file:
+            try:
+                files = {"file": (path.name, file)}
+                response = requests.post(uri, files=files, timeout=timeout)
+            except requests.exceptions.ConnectTimeout:
+                logger.error(
+                    "Timout while trying to communicate with the server."
+                )
+                sys.exit(1)
+            except requests.exceptions.ConnectionError:
+                logger.error("Unable to communicate with specified server.")
+                sys.exit(1)
+            if response.status_code != 200:
+                raise HTTPError(response.status_code)
+            return response.text
+
     def get_status(self, job_id):
         """Get the status of a test job
 
@@ -112,18 +137,31 @@ class Client:
         data = {"job_state": state}
         self.put(endpoint, data)
 
-    def submit_job(self, job_data):
+    def submit_job(self, data: dict) -> str:
         """Submit a test job to the testflinger server
 
         :param job_data:
-            String containing json or yaml data for the job to submit
+            Dictionary containing json or yaml data for the job to submit
         :return:
             ID for the test job
         """
         endpoint = "/v1/job"
-        data = yaml.safe_load(job_data)
         response = self.put(endpoint, data)
         return json.loads(response).get("job_id")
+
+    def post_attachment(self, job_id: str, path: Path) -> str:
+        """Send a test job attachment to the testflinger server
+
+        :param job_id:
+            ID for the test job
+        :param path:
+            The path to the attachment to be sent to the server
+        :return:
+            ID for the test job
+        """
+        endpoint = f"/v1/job/{job_id}/attachments"
+        response = self.put_file(endpoint, path, timeout=600)
+        return response
 
     def show_job(self, job_id):
         """Show the JSON job definition for the specified ID

--- a/cli/testflinger_cli/config.py
+++ b/cli/testflinger_cli/config.py
@@ -41,9 +41,9 @@ class TestflingerCliConfig:
             self.data = OrderedDict(config["testflinger-cli"])
         self.configfile = configfile
 
-    def get(self, key):
+    def get(self, key, default=None):
         """Get config item"""
-        return self.data.get(key)
+        return self.data.get(key, default)
 
     def set(self, key, value):
         """Set config item"""

--- a/cli/testflinger_cli/tests/test_cli.py
+++ b/cli/testflinger_cli/tests/test_cli.py
@@ -25,6 +25,7 @@ import tarfile
 import uuid
 
 import pytest
+import requests
 from requests_mock import Mocker
 
 import testflinger_cli
@@ -125,8 +126,8 @@ def test_submit_with_attachments(tmp_path):
         # - there a request to the attachment submission endpoint
         history = mocker.request_history
         assert len(history) == 2
-        assert history[-2].path == "/v1/job"
-        assert history[-1].path == f"/v1/job/{job_id}/attachments"
+        assert history[0].path == "/v1/job"
+        assert history[1].path == f"/v1/job/{job_id}/attachments"
 
         # extract the binary file data from the request
         # (`requests_mock` only provides access to the `PreparedRequest`)
@@ -142,6 +143,160 @@ def test_submit_with_attachments(tmp_path):
             attachments.extract(filenames[0], filter="data")
         with open(filenames[0], "r", encoding="utf-8") as attachment:
             assert json.load(attachment) == job_data
+
+
+def test_submit_attachments_retries(tmp_path):
+    """Check retries after unsuccessful attachment submissions"""
+
+    job_id = str(uuid.uuid1())
+    job_file = tmp_path / "test.json"
+    job_data = {
+        "queue": "fake",
+        "test_data": {
+            "attachments": [
+                {
+                    # include the submission JSON itself as a test attachment
+                    "local": str(job_file)
+                }
+            ]
+        },
+    }
+    job_file.write_text(json.dumps(job_data))
+
+    sys.argv = ["", "submit", str(job_file)]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.config.data["attachments_retry_wait"] = 1
+    tfcli.config.data["attachments_timeout"] = 2
+    tfcli.config.data["attachments_tries"] = 4
+
+    with Mocker() as mocker:
+
+        # register responses for job and attachment submission endpoints
+        mock_response = {"job_id": job_id}
+        mocker.post(f"{URL}/v1/job", json=mock_response)
+        mocker.post(
+            f"{URL}/v1/job/{job_id}/attachments",
+            [
+                {"exc": requests.exceptions.ConnectionError},
+                {"exc": requests.exceptions.ConnectTimeout},
+                {"exc": requests.exceptions.ReadTimeout},
+                {"status_code": 200},
+            ],
+        )
+
+        # use cli to submit the job (processes `sys.argv` for arguments)
+        tfcli.submit()
+
+        # check the request history to confirm that:
+        # - there is a request to the job submission endpoint
+        # - there are repeated requests to the attachment submission endpoint
+        history = mocker.request_history
+        assert len(history) == 5
+        assert history[0].path == "/v1/job"
+        for entry in history[1:]:
+            assert entry.path == f"/v1/job/{job_id}/attachments"
+
+
+def test_submit_attachments_no_retries(tmp_path):
+    """Check no retries after attachment submission fails unrecoverably"""
+
+    job_id = str(uuid.uuid1())
+    job_file = tmp_path / "test.json"
+    job_data = {
+        "queue": "fake",
+        "test_data": {
+            "attachments": [
+                {
+                    # include the submission JSON itself as a test attachment
+                    "local": str(job_file)
+                }
+            ]
+        },
+    }
+    job_file.write_text(json.dumps(job_data))
+
+    sys.argv = ["", "submit", str(job_file)]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.config.data["attachments_tries"] = 2
+
+    with Mocker() as mocker:
+
+        # register responses for job and attachment submission endpoints
+        mocker.post(f"{URL}/v1/job", json={"job_id": job_id})
+        mocker.post(
+            f"{URL}/v1/job/{job_id}/attachments", [{"status_code": 400}]
+        )
+        mocker.post(f"{URL}/v1/job/{job_id}/action", [{"status_code": 200}])
+
+        with pytest.raises(SystemExit) as exc_info:
+            # use cli to submit the job (processes `sys.argv` for arguments)
+            tfcli.submit()
+            assert "failed to submit attachments" in exc_info.value
+
+        # check the request history to confirm that:
+        # - there is a request to the job submission endpoint
+        # - there is a single request to the attachment submission endpoint:
+        #   no retries
+        # - there is a final request to cancel the action
+        history = mocker.request_history
+        assert len(history) == 3
+        assert history[0].path == "/v1/job"
+        assert history[1].path == f"/v1/job/{job_id}/attachments"
+        assert history[2].path == f"/v1/job/{job_id}/action"
+
+
+def test_submit_attachments_timeout(tmp_path):
+    """Make timeout after repeated attachment submission timeouts"""
+
+    job_id = str(uuid.uuid1())
+    job_file = tmp_path / "test.json"
+    job_data = {
+        "queue": "fake",
+        "test_data": {
+            "attachments": [
+                {
+                    # include the submission JSON itself as a test attachment
+                    "local": str(job_file)
+                }
+            ]
+        },
+    }
+    job_file.write_text(json.dumps(job_data))
+
+    sys.argv = ["", "submit", str(job_file)]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.config.data["attachments_retry_wait"] = 1
+    tfcli.config.data["attachments_timeout"] = 2
+    tfcli.config.data["attachments_tries"] = 2
+
+    with Mocker() as mocker:
+
+        # register responses for job and attachment submission endpoints
+        mock_response = {"job_id": job_id}
+        mocker.post(f"{URL}/v1/job", json=mock_response)
+        mocker.post(
+            f"{URL}/v1/job/{job_id}/attachments",
+            [
+                {"exc": requests.exceptions.ReadTimeout},
+                {"exc": requests.exceptions.ReadTimeout},
+            ],
+        )
+        mocker.post(f"{URL}/v1/job/{job_id}/action", [{"status_code": 200}])
+
+        with pytest.raises(SystemExit) as exc_info:
+            # use cli to submit the job (processes `sys.argv` for arguments)
+            tfcli.submit()
+            assert "failed to submit attachments" in exc_info.value
+
+        # check the request history to confirm that:
+        # - there is a request to the job submission endpoint
+        # - there a request to the attachment submission endpoint
+        history = mocker.request_history
+        assert len(history) == 4
+        assert history[0].path == "/v1/job"
+        assert history[1].path == f"/v1/job/{job_id}/attachments"
+        assert history[2].path == f"/v1/job/{job_id}/attachments"
+        assert history[3].path == f"/v1/job/{job_id}/action"
 
 
 def test_show(capsys, requests_mock):

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -187,6 +187,7 @@ If either ``reserve_command`` is missing from the agent configuration, or the th
   .. code-block:: yaml
 
     reserve_command: testflinger-device-connector muxpi reserve -c /path/to/default.yaml testflinger.json  
+
 * Example job definition:
 
   .. code-block:: yaml
@@ -209,6 +210,59 @@ Example agent configuration:
 
   cleanup_command: echo Consider removing containers or other necessary cleanup steps here
 
+
+Attachments
+------------
+In the `provisioning`, `firmware_update` and `test` phases, it is also possible to specify attachments, i.e. local files that are to be copied over to the Testflinger agent host.
+
+* Example job definition:
+
+  .. code-block:: yaml
+
+    job_queue: example-queue
+    provision_data:
+      attachments:
+        - local: "ubuntu-22.04.4-preinstalled-desktop-arm64+raspi.img.xz"
+    test_data:
+      attachments:
+        - local: "config.json"
+          agent: "data/config/config.json"
+        - local: "images/ubuntu-logo.png"
+        - local: "scripts/my_test_script.sh"
+          agent: "script.sh"
+      test_cmds: |
+        ls -alR
+        cat attachments/test/data/config/config.json
+        chmod u+x attachments/test/script.sh
+        attachments/test/script.sh
+
+  The `local` fields specify where the attachments are to be found locally, e.g. on the machine where the CLI is executed. For this particular example, this sort of file tree is expected:
+
+  .. code-block:: bash
+
+    .
+    ├── config.json
+    ├── images
+    │   └── ubuntu-logo.png
+    ├── scripts
+    │   └── my_test_script.sh
+    └── ubuntu-22.04.4-preinstalled-desktop-arm64+raspi.img.xz
+
+  On the agent host, the attachments are placed under the `attachments` folder and distributed in separate sub-folders according to phase. If an `agent` field is provided, the attachments are also moved or renamed accordingly. For the example above, the file tree on the agent host would look like this:
+
+  .. code-block:: bash
+
+    .
+    └── attachments
+        ├── provision
+        │   └── ubuntu-22.04.4-preinstalled-desktop-arm64+raspi.img.xz
+        └── test
+            ├── data
+            │   └── config
+            │       └── config.json
+            ├── images
+            │   └── ubuntu-logo.png
+            └── script.sh
 
 Output 
 ------------

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -64,6 +64,30 @@ class ActionIn(Schema):
     action = fields.String(required=True, validate=OneOf(["cancel"]))
 
 
+class Attachment(Schema):
+    """Attachment pathnames schema
+
+    - `local`: path to attachment on the runner
+    - `agent`: path to copy the attachment in the testflinger agent (optional)
+    - `device`: path to copy the attachment in the device under test (optional)
+    """
+
+    local = fields.String(required=True)
+    agent = fields.String(required=False)
+    device = fields.String(required=False)
+
+
+class TestData(Schema):
+    """Schema for the `test_data` section of a testflinger job"""
+
+    test_cmds = fields.String(required=False)
+    attachments = fields.List(fields.Nested(Attachment), required=False)
+    # [TODO] Suggest removing these: introduce an `environment` field
+    # that specifies values for environment variables
+    test_username = fields.String(required=False)
+    test_password = fields.String(required=False)
+
+
 class Job(Schema):
     """Job schema"""
 
@@ -75,9 +99,13 @@ class Job(Schema):
     global_timeout = fields.Integer(required=False)
     output_timeout = fields.Integer(required=False)
     allocation_timeout = fields.Integer(required=False)
+    # [TODO] specify Nested schema to improve validation,
+    # i.e. expected fields within `provision_data`
     provision_data = fields.Dict(required=False)
+    # [TODO] specify Nested schema to improve validation,
+    # i.e. expected fields within `firmware_update_data`
     firmware_update_data = fields.Dict(required=False)
-    test_data = fields.Dict(required=False)
+    test_data = fields.Nested(TestData, required=False)
     allocate_data = fields.Dict(required=False)
     reserve_data = fields.Dict(required=False)
 

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -67,13 +67,11 @@ class ActionIn(Schema):
 class Attachment(Schema):
     """Attachment pathnames schema
 
-    - `local`: path to attachment on the runner
     - `agent`: path to copy the attachment in the testflinger agent (optional)
     - `device`: path to copy the attachment in the device under test (optional)
     """
 
-    local = fields.String(required=True)
-    agent = fields.String(required=False)
+    agent = fields.String(required=True)
     device = fields.String(required=False)
 
 

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -112,7 +112,9 @@ def job_builder(data):
         job_id = str(uuid.uuid4())
 
     # side effect: modify the job dict
-    data["attachments"] = "waiting" if has_attachments(data) else "none"
+    if has_attachments(data):
+        data["attachments_status"] = "waiting"
+
     job["job_id"] = job_id
     job["job_data"] = data
     return job
@@ -182,10 +184,11 @@ def attachments_post(job_id):
     """
     if not check_valid_uuid(job_id):
         return "Invalid job id\n", 400
-    attachments_status = database.get_attachments_status(job_id)
-    if attachments_status is None:
+    try:
+        attachments_status = database.get_attachments_status(job_id)
+    except ValueError:
         return f"Job {job_id} is not valid\n", 422
-    if attachments_status == "none":
+    if attachments_status is None:
         return f"Job {job_id} not awaiting attachments\n", 422
     if attachments_status == "complete":
         # attachments already submitted: successful, could be due to a retry

--- a/server/src/database.py
+++ b/server/src/database.py
@@ -122,16 +122,23 @@ def retrieve_file(filename):
         raise FileNotFoundError from error
 
 
-def awaits_attachments(job_id: str) -> bool:
-    """Check if a job with `job_id` is expecting attachments"""
+def get_attachments_status(job_id: str) -> str:
+    """Return the attachments status of a job with `job_id`
+
+    :returns:
+        - None if no such job exists
+        - "none" if the job is not awaiting attachments
+        - "waiting" if the job is awaiting attachments
+        - "complete" if the job has already received attachments
+    """
     response = mongo.db.jobs.find_one(
         {
             "job_id": job_id,
             "result_data.job_state": "waiting",
-            "job_data.attachments": "waiting",
-        }
+        },
+        projection={"_id": False, "job_data": True},
     )
-    return response is not None
+    return None if response is None else response["job_data"]["attachments"]
 
 
 def attachments_received(job_id):

--- a/server/src/database.py
+++ b/server/src/database.py
@@ -169,7 +169,7 @@ def pop_job(queue_list):
     if not response:
         return None
     # Flatten the job_data and include the job_id
-    job = response.get("job_data")
+    job = response["job_data"]
     job_id = response["job_id"]
     job["job_id"] = job_id
     return job

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -21,8 +21,8 @@ from dataclasses import dataclass
 import pytest
 import mongomock
 from mongomock.gridfs import enable_gridfs_integration
-import src
-from src.api import v1
+
+from src import database, application
 
 
 @dataclass
@@ -48,14 +48,13 @@ class MongoClientMock(mongomock.MongoClient):
 def mongo_app():
     """Create a pytest fixture for the app"""
     mock_mongo = MongoClientMock()
-
-    app = src.application.create_flask_app(TestingConfig)
-    v1.mongo = mock_mongo
+    database.mongo = mock_mongo
+    app = application.create_flask_app(TestingConfig)
     yield app.test_client(), mock_mongo.db
 
 
 @pytest.fixture
 def testing_app():
     """Create an app for testing without using test_client"""
-    app = src.application.create_flask_app(TestingConfig)
+    app = application.create_flask_app(TestingConfig)
     yield app

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -53,7 +53,7 @@ def test_add_job_good_with_attachments(mongo_app, tmp_path):
     """Test that adding a new job with attachments works"""
     job_data = {
         "job_queue": "test",
-        "test_data": {"attachments": [{"local": "filename"}]},
+        "test_data": {"attachments": [{"agent": "filename"}]},
     }
     # place a job on the queue
     app, _ = mongo_app

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -17,10 +17,11 @@
 Unit tests for Testflinger v1 API
 """
 
-import json
-
-from io import BytesIO
 from datetime import datetime
+from io import BytesIO
+import json
+import os
+
 from src.api import v1
 
 
@@ -46,6 +47,99 @@ def test_add_job_good(mongo_app):
     expected_data = set(job_data)
     actual_data = set(output.json)
     assert expected_data.issubset(actual_data)
+
+
+def test_add_job_good_with_attachments(mongo_app, tmp_path):
+    """Test that adding a new job with attachments works"""
+    job_data = {
+        "job_queue": "test",
+        "test_data": {"attachments": [{"local": "filename"}]},
+    }
+    # place a job on the queue
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    job_id = output.json.get("job_id")
+    assert v1.check_valid_uuid(job_id)
+
+    # confirm that the job cannot be processed yet (attachments pending)
+    output = app.get("/v1/job?queue=test")
+    assert 204 == output.status_code
+
+    # create a mock attachments archive containing random data
+    # (for the purpose of testing the server endpoints, the archive doesn't
+    # need to match the attachments specified in the job)
+    filename = tmp_path / "attachments.tar.gz"
+    with open(filename, "wb") as attachments:
+        attachments.write(os.urandom(8000))
+
+    # submit the attachments archive for the job
+    attachments_endpoint = f"/v1/job/{job_id}/attachments"
+    with open(filename, "rb") as attachments:
+        file_data = {"file": (attachments, filename.name)}
+        output = app.post(
+            attachments_endpoint,
+            data=file_data,
+            content_type="multipart/form-data",
+        )
+    assert 200 == output.status_code
+    # check that the submitted attachments can be retrieved and
+    # that they match the original data
+    output = app.get(attachments_endpoint)
+    with open(filename, "rb") as attachments:
+        assert output.data == attachments.read()
+
+    # ask for a job from the queue and confirm the match
+    recovered_data = app.get("/v1/job?queue=test").json
+    assert recovered_data["job_id"] == job_id
+    assert set(job_data).issubset(recovered_data)
+
+
+def test_submit_attachment_without_job(mongo_app, tmp_path):
+    """Test for error when submitting attachments for a non-job"""
+    app, _ = mongo_app
+    nonexistent_id = "77777777-7777-7777-7777-777777777777"
+
+    # create a mock attachments archive containing random data
+    filename = tmp_path / "attachments.tar.gz"
+    with open(filename, "wb") as attachments:
+        attachments.write(os.urandom(8000))
+
+    # submit the attachments archive for the job
+    attachments_endpoint = f"/v1/job/{nonexistent_id}/attachments"
+    with open(filename, "rb") as attachments:
+        file_data = {"file": (attachments, filename.name)}
+        output = app.post(
+            attachments_endpoint,
+            data=file_data,
+            content_type="multipart/form-data",
+        )
+    assert 422 == output.status_code
+
+
+def test_retrieve_attachments_nonexistent_job(mongo_app):
+    """Test for error when requesting non-existent attachments"""
+    app, _ = mongo_app
+    nonexistent_id = "77777777-7777-7777-7777-777777777777"
+
+    # request the attachments archive for the job
+    attachments_endpoint = f"/v1/job/{nonexistent_id}/attachments"
+    output = app.get(attachments_endpoint)
+    assert 204 == output.status_code
+
+
+def test_retrieve_attachments_nonexistent_attachment(mongo_app):
+    """Test for error when requesting non-existent attachments"""
+    job_data = {"job_queue": "test", "tags": ["foo", "bar"]}
+    # place a job on the queue
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    job_id = output.json.get("job_id")
+    assert v1.check_valid_uuid(job_id)
+
+    # request the attachments archive for the job
+    attachments_endpoint = f"/v1/job/{job_id}/attachments"
+    output = app.get(attachments_endpoint)
+    assert 204 == output.status_code
 
 
 def test_add_job_good_with_jobid(mongo_app):


### PR DESCRIPTION
## Description

This PR introduces functionality that allows a testflinger client (e.g. the testflinger CLI) to submit a job that includes attachments, with these attachments eventually finding their way into the testflinger agent.

## Resolved issues

[CERTTF-303](https://warthogs.atlassian.net/browse/CERTTF-303)

- Removes the need to create configuration files as [here documents](https://tldp.org/LDP/abs/html/here-docs.html) within the `test_cmds` field; the configuration files can be attached instead.
- Bash scripts can be attached and used in the `test_cmds` field
- Attached files can also be useful in the `provisioning` or `firmware_update` phases
- Will serve as a step for addressing [RTW-282](https://warthogs.atlassian.net/browse/RTW-282)

## Changes

### Server

- Extend the `Job` submission schema so that `attachments` fields are allowed under `test_data`, specifying which local files should be packed into an archive and submitted along with a job. For example:
```
test_data:
  attachments:
    - local: "/var/log/syslog"
      agent: "logs/syslog"
    - local: "data/config.json"
    - local: "data/scripts/script.sh"
      agent: "test.sh"
```
- Such fields are also allowed under the provisioning and firmware update data but the current schema doesn't validate against them because too many arbitrary fields are used in these phases, depending on the use case. This validation issue is not relevant to this PR.

- In the implementation of the endpoint for submitting a job, a new _derived_ `attachments` status field is stored in the job data, taking the values:

  - `none` when there are no attachments to the job
  - `waiting` when there are attachments but the corresponding archive file hasn't been submitted yet and
  - `complete` when there are attachments and the corresponding archive file has been submitted

  Only the values `none` or `complete` allow a job to be removed from a queue.

- Introduce two endpoints for submitting and retrieving an archive file that contains the attachments for a specific job. The submission of an attachments archive sets the value of the `attachments` status field for the job to `complete`.

- Move database-related code into a separate `database` module, so that the API implementation is database-agnostic. This has been partly realised: the database interactions _that are relevant to this PR_ have been moved into reusable functions of the `database` module. If approved, this change can also be applied to the implementation of all API endpoints, eventually removing all references to MongoDB from the API implementation _and_ making the database an injectable dependency into the app.

### CLI

The CLI checks if the job submission includes references to attachments in the provisioning, firmware and test phases and, if so, packs the attachments into an archive and follows the job submission with an additional attachments archive submission to the server (using the new endpoint described above)

### Agent

The agent checks if the job submission is associated with attachments and, if so, retrieves the attachments archive from the server, unpacks it and optionally moves/renames the attachments. Note that all attachments are placed under an `attachments` folder in the agents "rundir". They are additionally separated into phase-related folders, e.g. `attachments/test` for the attachments provided under `test_data`.

## Points for discussion
- The intention is that the current functionality will be later extended to attaching files that are intended to end up in the device (rather than the host).
- Efficiency concerns: how will the server behave when large files are submitted and retrieved? This is the main reason that the job submission still only includes the JSON, without the attachments archive (as a multipart-encoded request). If the job submission was bundled with a large attachments archive then it would take much longer to complete. Attachment archives are submitted and retrieved separately. In the future, this might also allow for asynchronous transfers.
- There is an evident need for tooling modules that are common among the CLI, the server and the agent. There is code that would be (re)usable and is currently isolated and repeated.
- How to test in a non-local staging environment

## Documentation

Currently only inline documentation is provided. If the approach is approved the documentation will be extended under a separate issue/PR.

## Tests

- The test suite has been extended on the CLI, server and agent sides to provide new unit tests for the new functionality. Some additional tests should be added to test for negative scenarios, i.e. behaviour under unexpected circumstances.
- Manual tests have been performed in a local testflinger deployment, using this job YAML, to verify that the specified files do indeed find their way to the agent, under the specified names.

```
job_queue: myqueue
provision_data:
  attachments:
    - local: "README.md"
firmware_update_data:
  attachments:
    - local: "CONTRIBUTING.md"
test_data:
  attachments:
    - local: "/var/log/syslog"
      agent: "logs/syslog"
    - local: "data/config.json"
    - local: "data/scripts/script.sh"
      agent: "test.sh"
  test_cmds: |
    ls -alR
    echo "*** These are the contents of the script file"
    cat attachments/test/test.sh
    echo "*** Running the script file"
    echo "(it's supposed to print the contents of the config file)"
    chmod u+x attachments/test/test.sh
    attachments/test/test.sh attachments/test/data/config.json
```

[CERTTF-303]: https://warthogs.atlassian.net/browse/CERTTF-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RTW-282]: https://warthogs.atlassian.net/browse/RTW-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ