### PR TITLE
Add a help-icon link to the relevant docs for agents/queues

### DIFF
--- a/server/src/templates/agents.html
+++ b/server/src/templates/agents.html
@@ -5,6 +5,9 @@
     <div class="row">
         <h1 class="p-heading--3">
             Agents
+            <a href="https://testflinger.readthedocs.io/en/latest/explanation/agents/" target="_blank">
+                <i class="p-icon--help"></i>
+            </a>
         </h1>
     </div>
 </div>

--- a/server/src/templates/queues.html
+++ b/server/src/templates/queues.html
@@ -5,6 +5,9 @@
     <div class="row">
         <h1 class="p-heading--3">
             Queues
+            <a href="https://testflinger.readthedocs.io/en/latest/explanation/queues/" target="_blank">
+                <i class="p-icon--help"></i>
+            </a>
         </h1>
     </div>
 </div>


### PR DESCRIPTION
## Description

Now that the documentation additions describing the concept of agents and queues is live on readthedocs, we can link to them with a little help icon from the ui. It looks something like this, and when you click it, it opens a new tab to the appropriate documentation page.
![image](https://github.com/canonical/testflinger/assets/1255513/143159e9-d562-4b16-88aa-af0fe5c816af)


## Resolved issues
CERTTF-298

## Documentation
No new documentation in this branch, but it links to the live version of the documentation on readthedocs now

## Tests
Tested locally
