### PR TITLE
Extend oemrecovery timeout for checking boot type to 15s

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
@@ -112,7 +112,7 @@ class OemRecovery:
                     self.config["device_ip"],
                 ),
                 shell=True,
-                timeout=5,
+                timeout=15,
             )
         ).decode()
 
@@ -147,7 +147,7 @@ class OemRecovery:
                     self.config["device_ip"],
                 ),
                 shell=True,
-                timeout=5,
+                timeout=15,
             )
         ).decode()
 


### PR DESCRIPTION
## Description

Sugarland uses oemrecovery to reset the device back to the original install between runs. There's an additional step that was added because certain devices need to be booted to a certain point before continuing. This doesn't have an effect on the other devices, except that the commands that checked had a 5s timeout, and the snap commands that try to run will timeout on sugarland rather than completing, so the device never shows that it's provisioned and ready to continue the setup.

This just gives it some more time to run those commands so that we can really detect when it's done.

## Tests
This test was always failing before, but it's working now after the change: http://10.102.156.15:8080/job/cert-sugarland-pdk-network-manager-beta/32/#showFailuresLink
