### PR TITLE
Avoid splitting cmd in runner.py

### DIFF
--- a/agent/testflinger_agent/runner.py
+++ b/agent/testflinger_agent/runner.py
@@ -16,7 +16,6 @@ import logging
 import os
 import fcntl
 import sys
-import shlex
 import signal
 import subprocess
 import threading
@@ -70,11 +69,12 @@ class CommandRunner:
 
     def run_command_thread(self, cmd: str):
         self.process = subprocess.Popen(
-            shlex.split(cmd),
+            cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=self.cwd,
             env=self.env,
+            shell=True,
         )
         # Ensure that the output doesn't get buffered on our end
         if self.process.stdout is not None:


### PR DESCRIPTION
## Description
Avoid splitting cmd in runner.py to support Needham lab's agent configuration.

## Resolved issues

The old runner.py will cause the error below in server lab's agent since shell variables is directly passed as a part of command to runner and not being process properly after it gets spitted.
```
[24-04-15 13:15:54]    INFO: (job.py:83)| Running firmware_update_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 firmware_update -c /data/testflinger/device-connectors/sut/doubletusk_snappy.yaml testflinger.json
Exception in thread Thread-8:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/dist-packages/testflinger_agent/runner.py", line 72, in run_command_thread
    self.process = subprocess.Popen(
  File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1704, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'PYTHONIOENCODING=utf-8
``` 

## Tests
Tested on agents in both TEL/Needham labs.
