### PR TITLE
Update cloud-init data to also work with uc24

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/muxpi/uc20/99_nocloud.cfg
+++ b/device-connectors/src/testflinger_device_connectors/data/muxpi/uc20/99_nocloud.cfg
@@ -1,14 +1,9 @@
 #cloud-config
-datasource_list: [ NoCloud, None ]
-datasource:
-  NoCloud:
-    user-data: |
-      #cloud-config
-      password: ubuntu
-      chpasswd:
-          list:
-              - ubuntu:ubuntu
-          expire: False
-      ssh_pwauth: True
-    meta-data: |
-      instance_id: cloud-image
+datasource_list: [NoCloud, None]
+users:
+  - name: ubuntu
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    lock_passwd: false
+    shell: /bin/bash
+    # this is just "ubuntu"
+    passwd: "$6$rounds=4096$PCrfo.ggdf4ubP$REjyaoY2tUWH2vjFJjvLs3rDxVTszGR9P7mhH9sHb2MsELfc53uV/v15jDDOJU/9WInfjjTKJPlD5URhX5Mix0"


### PR DESCRIPTION
## Description
In trying to get the uc24 image tests working, I was having trouble getting it to provision. I tried it locally and it seemed to install ok but it wasn't setting up the user automatically with cloud-init. This cloud init data had worked fine for uc20 and uc22 but needs updates for uc24. Fortunately, this one works for all three of those

## Tests
After testing this locally, I tried it on rpi4b1g001 with uc20, uc22, and uc24. Those are the only images that would be affected by this change. All of them provisioned fine after changing this.
