### PR TITLE
Allow setting nginx max-body-size in terraform module

### DIFF
--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -29,6 +29,7 @@ resource "juju_application" "ingress" {
   config = {
     tls-secret-name = var.tls_secret_name
     whitelist-source-range = var.nginx_ingress_integrator_charm_whitelist_source_range
+    max-body-size = var.nginx_ingress_integrator_charm_max_body_size
   }
 }
 

--- a/server/terraform/variables.tf
+++ b/server/terraform/variables.tf
@@ -23,6 +23,13 @@ variable "nginx_ingress_integrator_charm_whitelist_source_range" {
   default     = ""
 }
 
+variable "nginx_ingress_integrator_charm_max_body_size" {
+  description = "Max allowed body-size (for file uploads) in megabytes, set to 0 to disable limits."
+  type        = number
+  default     = 20
+}
+
+
 variable "application_units" {
   description = "Number of units (pods) to start"
   type        = number


### PR DESCRIPTION
## Description
This is part of the changes needed so that we can configure the max-body-size on the ingress from the testflinger terraform module. The other half is setting it to whatever we want in the certification-ops branch. I just kept the default at 20MB for this part of it though, since we don't know exactly what we want to set it to yet, and 20MB is the current default for the ingress also, so least surprising default

## Tests
I've set this through juju on our staging instance and @boukeas was able to get past the 413 error with the ingress rejecting it because the body-size was too big. There's still a timeout issue to address, but I suspect that's going to be somewheree else.