### PR TITLE
Add job status endpoint to server

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -213,10 +213,15 @@ class TestflingerAgent:
                     job_data.get("job_queue"),
                     job_data.get("job_status_webhook"),
                     self.client,
+                    job.job_id,
                 )
                 job_end_reason = TestEvent.NORMAL_EXIT
 
                 logger.info("Starting job %s", job.job_id)
+                event_emitter.emit_event(
+                    TestEvent.JOB_START,
+                    f"{self.client.server}/job/{job.job_id}/events",
+                )
                 rundir = os.path.join(
                     self.client.config.get("execution_basedir"), job.job_id
                 )

--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -220,7 +220,7 @@ class TestflingerAgent:
                 logger.info("Starting job %s", job.job_id)
                 event_emitter.emit_event(
                     TestEvent.JOB_START,
-                    f"{self.client.server}/job/{job.job_id}/events",
+                    f"{self.client.server}/jobs/{job.job_id}",
                 )
                 rundir = os.path.join(
                     self.client.config.get("execution_basedir"), job.job_id

--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -264,16 +264,16 @@ class TestflingerAgent:
                     self.set_agent_state(phase)
 
                     event_emitter.emit_event(TestEvent(phase + "_start"))
-                    exitcode, exit_event, exit_reason = job.run_test_phase(
+                    exit_code, exit_event, exit_reason = job.run_test_phase(
                         phase, rundir
                     )
-                    self.client.post_influx(phase, exitcode)
+                    self.client.post_influx(phase, exit_code)
                     event_emitter.emit_event(exit_event, exit_reason)
 
-                    if exitcode:
+                    if exit_code:
                         # exit code 46 is our indication that recovery failed!
                         # In this case, we need to mark the device offline
-                        if exitcode == 46:
+                        if exit_code == 46:
                             self.mark_device_offline()
                             exit_event = TestEvent.RECOVERY_FAIL
                         else:

--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -390,7 +390,11 @@ class TestflingerClient:
             logger.warning("Unable to post provision log to server: %s", exc)
 
     def post_status_update(
-        self, job_queue: str, webhook: str, events: List[Dict[str, str]]
+        self,
+        job_queue: str,
+        webhook: str,
+        events: List[Dict[str, str]],
+        job_id: str,
     ):
         """
         Posts status updates about the running job as long as there is a
@@ -402,6 +406,8 @@ class TestflingerClient:
             String URL to post status update to
         :param events:
             List of accumulated test events
+        :param job_id:
+            id for the job on which we want to post results
 
         """
         if webhook is None:
@@ -413,7 +419,7 @@ class TestflingerClient:
             "job_status_webhook": webhook,
             "events": events,
         }
-        status_update_uri = urljoin(self.server, "/v1/agents/status")
+        status_update_uri = urljoin(self.server, f"/v1/job/{job_id}/events")
         try:
             job_request = self.session.post(
                 status_update_uri, json=status_update_request, timeout=30

--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -21,6 +21,7 @@ import shutil
 import tempfile
 import time
 
+from typing import List, Dict
 from urllib.parse import urljoin
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
@@ -387,3 +388,41 @@ class TestflingerClient:
             self.session.post(agent_data_url, json=data, timeout=30)
         except RequestException as exc:
             logger.warning("Unable to post provision log to server: %s", exc)
+
+    def post_status_update(
+        self, job_queue: str, webhook: str, events: List[Dict[str, str]]
+    ):
+        """
+        Posts status updates about the running job as long as there is a
+        webhook
+
+        :param job_queue:
+            TestFlinger queue the currently running job belongs to
+        :param webhook:
+            String URL to post status update to
+        :param events:
+            List of accumulated test events
+
+        """
+        if webhook is None:
+            return
+
+        status_update_request = {
+            "agent_id": self.config.get("agent_id"),
+            "job_queue": job_queue,
+            "job_status_webhook": webhook,
+            "events": events,
+        }
+        status_update_uri = urljoin(self.server, "/v1/agents/status")
+        try:
+            job_request = self.session.post(
+                status_update_uri, json=status_update_request, timeout=30
+            )
+        except RequestException as exc:
+            logger.error("Server Error: %s" % exc)
+            job_request = None
+        if not job_request:
+            logger.error(
+                "Unable to post status updates to: %s (error: %s)"
+                % (status_update_uri, job_request.status_code)
+            )

--- a/agent/testflinger_agent/event_emitter.py
+++ b/agent/testflinger_agent/event_emitter.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+
+from datetime import timezone, datetime
+
+from testflinger_agent.client import TestflingerClient
+from testflinger_common.enums import TestEvent
+
+
+class EventEmitter:
+    def __init__(
+        self, job_queue: str, webhook: str, client: TestflingerClient
+    ):
+        """
+        :param job_queue:
+            String representing job_queue the running job belongs to
+        :param webhook:
+            String url to send status updates to
+        :param client:
+            TestflingerClient used to post status updates to the server
+
+        """
+        self.job_queue = job_queue
+        self.webhook = webhook
+        self.events = []
+        self.client = client
+
+    def emit_event(self, test_event: TestEvent, detail: str = ""):
+        if test_event is not None:
+            new_event_json = {
+                "event_name": test_event,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "detail": detail,
+            }
+            self.events.append(new_event_json)
+            self.client.post_status_update(
+                self.job_queue, self.webhook, self.events
+            )

--- a/agent/testflinger_agent/event_emitter.py
+++ b/agent/testflinger_agent/event_emitter.py
@@ -21,7 +21,11 @@ from testflinger_common.enums import TestEvent
 
 class EventEmitter:
     def __init__(
-        self, job_queue: str, webhook: str, client: TestflingerClient
+        self,
+        job_queue: str,
+        webhook: str,
+        client: TestflingerClient,
+        job_id: str,
     ):
         """
         :param job_queue:
@@ -30,12 +34,15 @@ class EventEmitter:
             String url to send status updates to
         :param client:
             TestflingerClient used to post status updates to the server
+        :param job_id:
+            id for the job on which we want to post updates
 
         """
         self.job_queue = job_queue
         self.webhook = webhook
         self.events = []
         self.client = client
+        self.job_id = job_id
 
     def emit_event(self, test_event: TestEvent, detail: str = ""):
         if test_event is not None:
@@ -46,5 +53,5 @@ class EventEmitter:
             }
             self.events.append(new_event_json)
             self.client.post_status_update(
-                self.job_queue, self.webhook, self.events
+                self.job_queue, self.webhook, self.events, self.job_id
             )

--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -117,8 +117,10 @@ class TestflingerJob:
         ):
             runner.run(f"echo '{line}'")
         try:
+            # Set exit_event to fail for this phase in case of an exception
+            exit_event = f"{phase}_fail"
             exitcode, exit_event, exit_reason = runner.run(cmd)
-        except Exception as e:
+        except Exception as exc:
             logger.exception(exc)
             exitcode = 100
             exit_reason = str(exc)  # noqa: F841 - ignore this until it's used

--- a/agent/testflinger_agent/stop_condition_checkers.py
+++ b/agent/testflinger_agent/stop_condition_checkers.py
@@ -13,8 +13,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 import time
-from typing import Optional
-
+from typing import Optional, Tuple
+from testflinger_common.enums import JobState, TestEvent
 from .client import TestflingerClient
 
 
@@ -23,10 +23,13 @@ class JobCancelledChecker:
         self.client = client
         self.job_id = job_id
 
-    def __call__(self) -> Optional[str]:
-        if self.client.check_job_state(self.job_id) == "cancelled":
-            return "Job cancellation was requested, exiting."
-        return None
+    def __call__(self) -> Tuple[Optional[TestEvent], str]:
+        if self.client.check_job_state(self.job_id) == JobState.CANCELLED:
+            return (
+                TestEvent.CANCELLED,
+                "Job cancellation was requested, exiting.",
+            )
+        return None, ""
 
 
 class GlobalTimeoutChecker:
@@ -34,10 +37,13 @@ class GlobalTimeoutChecker:
         self.timeout = timeout
         self.start_time = time.time()
 
-    def __call__(self) -> Optional[str]:
+    def __call__(self) -> Tuple[Optional[TestEvent], str]:
         if time.time() - self.start_time > self.timeout:
-            return f"ERROR: Global timeout reached! ({self.timeout}s)"
-        return None
+            return (
+                TestEvent.GLOBAL_TIMEOUT,
+                f"ERROR: Global timeout reached! ({self.timeout}s)",
+            )
+        return None, ""
 
 
 class OutputTimeoutChecker:
@@ -45,10 +51,13 @@ class OutputTimeoutChecker:
         self.timeout = timeout
         self.last_output_time = time.time()
 
-    def __call__(self) -> Optional[str]:
+    def __call__(self) -> Tuple[Optional[TestEvent], str]:
         if time.time() - self.last_output_time > self.timeout:
-            return f"ERROR: Output timeout reached! ({self.timeout}s)"
-        return None
+            return (
+                TestEvent.OUTPUT_TIMEOUT,
+                f"ERROR: Output timeout reached! ({self.timeout}s)",
+            )
+        return None, ""
 
     def update(self):
         """Update the last output time to the current time."""

--- a/agent/testflinger_agent/tests/test_agent.py
+++ b/agent/testflinger_agent/tests/test_agent.py
@@ -403,8 +403,9 @@ class TestClient:
 
     def test_post_agent_status_update(self, agent, requests_mock):
         self.config["test_command"] = "echo test1"
+        job_id = str(uuid.uuid1())
         fake_job_data = {
-            "job_id": str(uuid.uuid1()),
+            "job_id": job_id,
             "job_queue": "test",
             "test_data": {"test_cmds": "foo"},
             "job_status_webhook": "https://mywebhook",
@@ -413,7 +414,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
         )
-        status_url = "http://127.0.0.1:8000/v1/agents/status"
+        status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
         requests_mock.post(status_url, status_code=200)
         with patch("shutil.rmtree"):
             agent.process_jobs()
@@ -431,6 +432,7 @@ class TestClient:
             for phase in TestPhase
             for postfix in ["_start", "_success"]
         ]
+        expected_event_name_list.insert(0, "job_start")
         expected_event_name_list.append("job_end")
 
         assert event_list[-1]["detail"] == "normal_exit"
@@ -449,7 +451,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
         )
-        status_url = "http://127.0.0.1:8000/v1/agents/status"
+        status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
         requests_mock.post(status_url, status_code=200)
 
         requests_mock.get(
@@ -486,7 +488,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
         )
-        status_url = "http://127.0.0.1:8000/v1/agents/status"
+        status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
         requests_mock.post(status_url, status_code=200)
 
         with patch("shutil.rmtree"):
@@ -519,7 +521,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
         )
-        status_url = "http://127.0.0.1:8000/v1/agents/status"
+        status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
         requests_mock.post(status_url, status_code=200)
 
         with patch("shutil.rmtree"):

--- a/agent/testflinger_agent/tests/test_agent.py
+++ b/agent/testflinger_agent/tests/test_agent.py
@@ -16,6 +16,7 @@ from testflinger_agent.config import ATTACHMENTS_DIR
 from testflinger_agent.errors import TFServerError
 from testflinger_agent.client import TestflingerClient as _TestflingerClient
 from testflinger_agent.agent import TestflingerAgent as _TestflingerAgent
+from testflinger_common.enums import TestPhase
 
 
 class TestClient:
@@ -399,3 +400,137 @@ class TestClient:
                     "provision_type": self.config["provision_type"],
                 }
             )
+
+    def test_post_agent_status_update(self, agent, requests_mock):
+        self.config["test_command"] = "echo test1"
+        fake_job_data = {
+            "job_id": str(uuid.uuid1()),
+            "job_queue": "test",
+            "test_data": {"test_cmds": "foo"},
+            "job_status_webhook": "https://mywebhook",
+        }
+        requests_mock.get(
+            "http://127.0.0.1:8000/v1/job?queue=test",
+            [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+        )
+        status_url = "http://127.0.0.1:8000/v1/agents/status"
+        requests_mock.post(status_url, status_code=200)
+        with patch("shutil.rmtree"):
+            agent.process_jobs()
+
+        status_update_requests = list(
+            filter(
+                lambda req: req.url == status_url,
+                requests_mock.request_history,
+            )
+        )
+        event_list = status_update_requests[-1].json()["events"]
+        event_name_list = [event["event_name"] for event in event_list]
+        expected_event_name_list = [
+            phase.value + postfix
+            for phase in TestPhase
+            for postfix in ["_start", "_success"]
+        ]
+        expected_event_name_list.append("job_end")
+
+        assert event_list[-1]["detail"] == "normal_exit"
+        assert event_name_list == expected_event_name_list
+
+    def test_post_agent_status_update_cancelled(self, agent, requests_mock):
+        self.config["test_command"] = "echo test1"
+        job_id = str(uuid.uuid1())
+        fake_job_data = {
+            "job_id": job_id,
+            "job_queue": "test",
+            "test_data": {"test_cmds": "foo"},
+            "job_status_webhook": "https://mywebhook",
+        }
+        requests_mock.get(
+            "http://127.0.0.1:8000/v1/job?queue=test",
+            [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+        )
+        status_url = "http://127.0.0.1:8000/v1/agents/status"
+        requests_mock.post(status_url, status_code=200)
+
+        requests_mock.get(
+            "http://127.0.0.1:8000/v1/result/" + job_id,
+            json={"job_state": "cancelled"},
+        )
+        with patch("shutil.rmtree"):
+            agent.process_jobs()
+
+        status_update_requests = list(
+            filter(
+                lambda req: req.url == status_url,
+                requests_mock.request_history,
+            )
+        )
+        event_list = status_update_requests[-1].json()["events"]
+        event_name_list = [event["event_name"] for event in event_list]
+
+        assert "cancelled" in event_name_list
+
+    def test_post_agent_status_update_global_timeout(
+        self, agent, requests_mock
+    ):
+        self.config["test_command"] = "sleep 12"
+        job_id = str(uuid.uuid1())
+        fake_job_data = {
+            "job_id": job_id,
+            "job_queue": "test",
+            "test_data": {"test_cmds": "foo"},
+            "job_status_webhook": "https://mywebhook",
+            "global_timeout": 1,
+        }
+        requests_mock.get(
+            "http://127.0.0.1:8000/v1/job?queue=test",
+            [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+        )
+        status_url = "http://127.0.0.1:8000/v1/agents/status"
+        requests_mock.post(status_url, status_code=200)
+
+        with patch("shutil.rmtree"):
+            agent.process_jobs()
+
+        status_update_requests = list(
+            filter(
+                lambda req: req.url == status_url,
+                requests_mock.request_history,
+            )
+        )
+        event_list = status_update_requests[-1].json()["events"]
+        event_name_list = [event["event_name"] for event in event_list]
+
+        assert "global_timeout" in event_name_list
+
+    def test_post_agent_status_update_output_timeout(
+        self, agent, requests_mock
+    ):
+        self.config["test_command"] = "sleep 12"
+        job_id = str(uuid.uuid1())
+        fake_job_data = {
+            "job_id": job_id,
+            "job_queue": "test",
+            "test_data": {"test_cmds": "foo"},
+            "job_status_webhook": "https://mywebhook",
+            "output_timeout": 1,
+        }
+        requests_mock.get(
+            "http://127.0.0.1:8000/v1/job?queue=test",
+            [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+        )
+        status_url = "http://127.0.0.1:8000/v1/agents/status"
+        requests_mock.post(status_url, status_code=200)
+
+        with patch("shutil.rmtree"):
+            agent.process_jobs()
+
+        status_update_requests = list(
+            filter(
+                lambda req: req.url == status_url,
+                requests_mock.request_history,
+            )
+        )
+        event_list = status_update_requests[-1].json()["events"]
+        event_name_list = [event["event_name"] for event in event_list]
+        assert "output_timeout" in event_name_list

--- a/agent/testflinger_agent/tests/test_client.py
+++ b/agent/testflinger_agent/tests/test_client.py
@@ -133,8 +133,9 @@ class TestClient:
         if there is a valid webhook
         """
         webhook = "http://foo"
+        job_id = job_id = str(uuid.uuid1())
         requests_mock.post(
-            "http://127.0.0.1:8000/v1/agents/status", status_code=200
+            f"http://127.0.0.1:8000/v1/job/{job_id}/events", status_code=200
         )
         events = [
             {
@@ -148,7 +149,7 @@ class TestClient:
                 "detail": "",
             },
         ]
-        client.post_status_update("myjobqueue", webhook, events)
+        client.post_status_update("myjobqueue", webhook, events, job_id)
         expected_json = {
             "agent_id": client.config.get("agent_id"),
             "job_queue": "myjobqueue",

--- a/agent/testflinger_agent/tests/test_client.py
+++ b/agent/testflinger_agent/tests/test_client.py
@@ -126,3 +126,33 @@ class TestClient:
         """
         client.transmit_job_outcome(tmp_path)
         assert "Unable to read job ID" in caplog.text
+
+    def test_post_status_update(self, client, requests_mock):
+        """
+        Test that the agent sends a status update to the status endpoint
+        if there is a valid webhook
+        """
+        webhook = "http://foo"
+        requests_mock.post(
+            "http://127.0.0.1:8000/v1/agents/status", status_code=200
+        )
+        events = [
+            {
+                "event_name": "provision_start",
+                "timestamp": "2014-12-22T03:12:58.019077+00:00",
+                "detail": "",
+            },
+            {
+                "event_name": "provision_success",
+                "timestamp": "2014-12-22T03:12:58.019077+00:00",
+                "detail": "",
+            },
+        ]
+        client.post_status_update("myjobqueue", webhook, events)
+        expected_json = {
+            "agent_id": client.config.get("agent_id"),
+            "job_queue": "myjobqueue",
+            "job_status_webhook": webhook,
+            "events": events,
+        }
+        assert requests_mock.last_request.json() == expected_json

--- a/common/testflinger_common/enums.py
+++ b/common/testflinger_common/enums.py
@@ -43,3 +43,36 @@ class TestPhase(StrEnum):
     RESERVE = "reserve"
     CLEANUP = "cleanup"
 
+
+class TestEvent(StrEnum):
+    SETUP_START = "setup_start"
+    PROVISION_START = "provision_start"
+    FIRMWARE_UPDATE_START = "firmware_update_start"
+    TEST_START = "test_start"
+    ALLOCATE_START = "allocate_start"
+    RESERVE_START = "reserve_start"
+    CLEANUP_START = "cleanup_start"
+
+    SETUP_SUCCESS = "setup_success"
+    PROVISION_SUCCESS = "provision_success"
+    FIRMWARE_UPDATE_SUCCESS = "firmware_update_success"
+    TEST_SUCCESS = "test_success"
+    ALLOCATE_SUCCESS = "allocate_success"
+    RESERVE_SUCCESS = "reserve_success"
+    CLEANUP_SUCCESS = "cleanup_success"
+
+    SETUP_FAIL = "setup_fail"
+    PROVISION_FAIL = "provision_fail"
+    FIRMWARE_UPDATE_FAIL = "firmware_update_fail"
+    TEST_FAIL = "test_fail"
+    ALLOCATE_FAIL = "allocate_fail"
+    RESERVE_FAIL = "reserve_fail"
+    CLEANUP_FAIL = "cleanup_fail"
+
+    CANCELLED = "cancelled"
+    GLOBAL_TIMEOUT = "global_timeout"
+    OUTPUT_TIMEOUT = "output_timeout"
+    RECOVERY_FAILED = "recovery_failed"
+
+    NORMAL_EXIT = "normal_exit"
+    JOB_END = "job_end"

--- a/common/testflinger_common/enums.py
+++ b/common/testflinger_common/enums.py
@@ -72,7 +72,8 @@ class TestEvent(StrEnum):
     CANCELLED = "cancelled"
     GLOBAL_TIMEOUT = "global_timeout"
     OUTPUT_TIMEOUT = "output_timeout"
-    RECOVERY_FAILED = "recovery_failed"
+    RECOVERY_FAIL = "recovery_fail"
 
     NORMAL_EXIT = "normal_exit"
+    JOB_START = "job_start"
     JOB_END = "job_end"

--- a/docs/reference/job-schema.rst
+++ b/docs/reference/job-schema.rst
@@ -47,7 +47,11 @@ The following table lists the key elements that a job definition file should con
       |   - test
       |   - allocate
       |   - reserve 
-      | For detailed information about how to define the data to include in each test phase, see :doc:`test-phases`. 
+      | For detailed information about how to define the data to include in each test phase, see :doc:`test-phases`.
+      * - ``job_status_webhook``
+    - string
+    - /
+    - | (Optional) URL to send job status updates to. These updates originate from the agent and get posted to the server which then posts the update to the webhook. If no webhook is specified, these updates will not be generated.
 
 Example jobs in YAML
 ----------------------------

--- a/server/README.rst
+++ b/server/README.rst
@@ -356,3 +356,28 @@ This will find jobs tagged with both "foo" and "bar".
          -X POST --header "Content-Type: application/json" \
          --data '{ "job_id": "00000000-0000-0000-0000-000000000000", \
                    "exit_code": 1, "detail":"foo" }'
+
+**[POST] /v1/status - Receive job status updates from an agent and posts them to the specified webhook.
+
+The job_status_webhook parameter is required for this endpoint. Other parameters included here will be forwarded to the webhook. 
+
+- Parameters:
+  - job_status_webhook: webhook URL to post status updates to
+
+- Returns:
+
+  Text response from the webhook if the server was successfully able to post.
+
+- Status Codes:
+
+  - HTTP 200 (OK)
+  - HTTP 400 (Bad request) - The arguments could not be processed by the server
+  - HTTP 504 (Gateway Timeout) - The webhook URL timed out
+
+- Example:
+
+  .. code-block:: console 
+
+    $ curl -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"agent_id": "agent-00", "job_queue": "myqueue", "job_status_webhook": "http://mywebhook", "events": [{"event_name": "started_provisioning", "timestamp": "2024-05-03T19:11:33.541130+00:00", "detail": "my_detailed_message"}]}' http://localhost:8000/v1/agents/status

--- a/server/README.rst
+++ b/server/README.rst
@@ -357,11 +357,12 @@ This will find jobs tagged with both "foo" and "bar".
          --data '{ "job_id": "00000000-0000-0000-0000-000000000000", \
                    "exit_code": 1, "detail":"foo" }'
 
-**[POST] /v1/status - Receive job status updates from an agent and posts them to the specified webhook.
+**[POST] /v1/job/<job_id>/events - Receive job status updates from an agent and posts them to the specified webhook.
 
 The job_status_webhook parameter is required for this endpoint. Other parameters included here will be forwarded to the webhook. 
 
 - Parameters:
+  - job_id: test job identifier as a UUID
   - job_status_webhook: webhook URL to post status updates to
 
 - Returns:
@@ -380,4 +381,4 @@ The job_status_webhook parameter is required for this endpoint. Other parameters
 
     $ curl -X POST \
     -H "Content-Type: application/json" \
-    -d '{"agent_id": "agent-00", "job_queue": "myqueue", "job_status_webhook": "http://mywebhook", "events": [{"event_name": "started_provisioning", "timestamp": "2024-05-03T19:11:33.541130+00:00", "detail": "my_detailed_message"}]}' http://localhost:8000/v1/agents/status
+    -d '{"agent_id": "agent-00", "job_queue": "myqueue", "job_status_webhook": "http://mywebhook", "events": [{"event_name": "started_provisioning", "timestamp": "2024-05-03T19:11:33.541130+00:00", "detail": "my_detailed_message"}]}' http://localhost:8000/v1/job/00000000-0000-0000-0000-000000000000/events

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -15,6 +15,8 @@ gevent = "^24.2.1"
 prometheus-client = "^0.20.0"
 pyyaml = "^6.0.1"
 sentry-sdk = { extras = ["flask"], version = "^2.0.1" }
+requests = "^2.31.0"
+urllib3 = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.1.2"

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -114,6 +114,7 @@ class Job(Schema):
     test_data = fields.Nested(TestData, required=False)
     allocate_data = fields.Dict(required=False)
     reserve_data = fields.Dict(required=False)
+    job_status_webhook = fields.String(required=False)
 
 
 class JobId(Schema):
@@ -168,6 +169,23 @@ class Result(Schema):
     cleanup_serial = fields.String(required=False)
     device_info = fields.Dict(required=False)
     job_state = fields.String(required=False)
+
+
+class JobEvent(Schema):
+    """Job Event schema"""
+
+    event_name = fields.String(required=True)
+    timestamp = fields.String(required=True)
+    detail = fields.String(required=False)
+
+
+class StatusUpdate(Schema):
+    """Status Update schema"""
+
+    agent_id = fields.String(required=False)
+    job_queue = fields.String(required=False)
+    job_status_webhook = fields.URL(required=True)
+    events = fields.List(fields.Nested(JobEvent), required=False)
 
 
 job_empty = {

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -531,6 +531,10 @@ def test_agents_provision_logs_post(mongo_app):
 def test_agents_status_put(mongo_app, requests_mock):
     """Test api to receive agent status requests"""
     app, _ = mongo_app
+    job_data = {"job_queue": "test"}
+    job_output = app.post("/v1/job", json=job_data)
+    job_id = job_output.json.get("job_id")
+
     webhook = "http://mywebhook.com"
     requests_mock.put(webhook, status_code=200, text="webhook requested")
     status_update_data = {
@@ -545,7 +549,7 @@ def test_agents_status_put(mongo_app, requests_mock):
             }
         ],
     }
-    output = app.post("/v1/agents/status", json=status_update_data)
+    output = app.post(f"/v1/job/{job_id}/events", json=status_update_data)
     assert 200 == output.status_code
     assert "webhook requested" == output.text
 

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -528,6 +528,28 @@ def test_agents_provision_logs_post(mongo_app):
     assert len(provision_log_records["provision_log"]) == 2
 
 
+def test_agents_status_put(mongo_app, requests_mock):
+    """Test api to receive agent status requests"""
+    app, _ = mongo_app
+    webhook = "http://mywebhook.com"
+    requests_mock.put(webhook, status_code=200, text="webhook requested")
+    status_update_data = {
+        "agent_id": "agent1",
+        "job_queue": "myjobqueue",
+        "job_status_webhook": webhook,
+        "events": [
+            {
+                "event_name": "my_event",
+                "timestamp": "2014-12-22T03:12:58.019077+00:00",
+                "detail": "mymsg",
+            }
+        ],
+    }
+    output = app.post("/v1/agents/status", json=status_update_data)
+    assert 200 == output.status_code
+    assert "webhook requested" == output.text
+
+
 def test_get_agents_data(mongo_app):
     """Test api to retrieve agent data"""
     app, _ = mongo_app

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -17,6 +17,7 @@ deps =
     pytest-mock
     pytest-cov
     requests
+    requests-mock
     # cosl needed for unit tests to pass
     cosl
     -r charm/requirements.txt


### PR DESCRIPTION
## Description

This adds an endpoint to Testflinger server that receives status updates from Testflinger agents. These updates require a webhook that the server will forward the rest of the update message to.

## Documentation

Documentation was added to job_schema.rst to reflect new job_status_webhook option in the job yaml. The server ReadMe was updated with details on the new status endpoint. 

## Web service API changes
- Interface: [POST] /v1/status
- Request Structure: 
    ```json
    {
        "agent_id": "<string>",
        "job_queue": "<string>",
        "job_status_webhook": "<URL as string>",
        "events": [
            {
  	        "event_name": "<string enum of events>",
  	        "timestamp": "<string>",
  	        "detail_msg": "<string>"
            },
            ...
         ]
    }

    ```

- Response Status Codes:
    - HTTP 200 (OK)
    - HTTP 400 (Bad request) - The arguments could not be processed by the server
    - HTTP 504 (Gateway Timeout) - The webhook URL timed out
- Rationale: This endpoint receives status updates from the agent if there is a webhook specified in the job yaml and posts the update to this webhook.

## Tests

For the server, unit tests were added to test_v1.py. For the agents, unit tests were added to both test_client.py and test_agent.py to test both webhook posting behavior and overall status updating.
