### PR TITLE
[CERTTF-316] Use attachments for provisioning (muxpi)

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -240,25 +240,26 @@ class MuxPi:
             f'"zstdcat | sudo dd of={self.test_device} bs=16M"'
         )
         try:
-            result = subprocess.run(
+            subprocess.run(
                 cmd,
                 capture_output=True,
+                check=True,
                 text=True,
                 shell=True,
                 executable="/bin/bash",
                 timeout=timeout,
             )
+        except subprocess.CalledProcessError as error:
+            raise ProvisioningError(
+                f"Error while piping the test image to {self.test_device} "
+                f"through {control_user}@{control_host}: {error}"
+            ) from error
         except subprocess.TimeoutExpired as error:
             raise ProvisioningError(
                 f"Timeout while piping the test image to {self.test_device} "
                 f"through {control_user}@{control_host} "
                 f"using a timeout of {timeout}: {error}"
             ) from error
-        if result.returncode != 0:
-            raise ProvisioningError(
-                f"Error while piping the test image to {self.test_device} "
-                f"through {control_user}@{control_host}: {result.stderr}"
-            )
 
     def flash_test_image(self, url):
         """

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -245,6 +245,7 @@ class MuxPi:
                 capture_output=True,
                 text=True,
                 shell=True,
+                executable="/bin/bash",
                 timeout=timeout,
             )
         except subprocess.TimeoutExpired as error:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -287,8 +287,7 @@ class MuxPi:
             provisioning_attachments = [item for item in attachments_dir.iterdir() if item.is_file()]
             test_image = provisioning_attachments[0] if len(provisioning_attachments) == 1 else None
             logger.info(f"Flashing Test image {test_image.name} on {self.test_device}")
-            self.transfer_test_image(local=test_image.name, timeout=1200)
-
+            self.transfer_test_image(local=test_image, timeout=1200)
         try:
             self._run_control("sync")
         except Exception:

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -95,6 +95,7 @@ TPM
 txt
 Ubuntu
 ubuntu
+url
 UI
 URI
 USB

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -222,7 +222,8 @@ In the `provisioning`, `firmware_update` and `test` phases, it is also possible 
     job_queue: example-queue
     provision_data:
       attachments:
-        - local: "ubuntu-22.04.4-preinstalled-desktop-arm64+raspi.img.xz"
+        - local: ubuntu-22.04.4-preinstalled-desktop-arm64+raspi.img.xz
+      use_attachment: ubuntu-22.04.4-preinstalled-desktop-arm64+raspi.img.xz
     test_data:
       attachments:
         - local: "config.json"
@@ -263,6 +264,12 @@ In the `provisioning`, `firmware_update` and `test` phases, it is also possible 
             ├── images
             │   └── ubuntu-logo.png
             └── script.sh
+
+In this example, there is no `url` field under the `provision_data` to specify where to download the provisioning image from.
+Instead, there is a `use_attachment` field that indicates which attachment should be used as a provisioning image.
+The presence of *either* `url` or `use_attachment` is required.
+
+At the moment, only the `muxpi` device connector supports provisioning using an attached image.
 
 Output 
 ------------


### PR DESCRIPTION
## Description

Build on Testflinger support for file attachments ([CERTTF-303](https://warthogs.atlassian.net/browse/CERTTF-303)) to introduce provisioning using a file attachment instead of downloading an image from a URL. In the scope of this PR this only applies to the `muxpi` device connector.

The file attachment to be used is specified in the new `use_attachment` field, provided as an alternative to the `url` field. Previously, `url` was required, now one of `url` or `use_attachment` are required.

Significant refactoring/reimplementation has taken place in this context: previously, downloading the image from the url, decompressing and flashing on the device media was entirely performed _on the device connector_ using a series of pipes, roughly like this:
```
# device connector
curl -sf {url} | zstdcat | sudo dd of={test_device}" 
```
This was efficient and avoided saving the downloaded image file on the device connector (where storage is generally constrained). However, it also made logging and debugging difficult, as the whole process was consolidated, making it hard to distinguish which part failed.

In this PR, the process is initiated _on the agent_ and is roughly performed like this:
```
# agent    | # device connector
cat {path} | ssh {ssh_options} {control_user}@{control_host} "zstdcat | sudo dd of={test_device}"
```
The `path` here is the provisioning image, which has either been previously downloaded _on the agent_ from a URL or is an attachment.

This unifies the process of transferring the image on the device connector and flashing it, regardless of the source of the image, and also allows for more fine-grained logging and debugging.

## Resolved issues

Linked to [CERTTF-316](https://warthogs.atlassian.net/browse/CERTTF-316).

## Documentation

The section regarding attachments in the Testflinger reference has been updated.

## Tests

All tests performed on the `rpi4b1g001` agent on [`testflinger-staging`](https://testflinger-staging.canonical.com), with the `muxpi` device connector installed from this branch.

### Provisioning from a URL

```
job_queue: rpi4b1g-001
provision_data:
  url: http://cdimage.ubuntu.com/ubuntu-core/22/dangerous-stable/current/ubuntu-core-22-arm64+raspi.img.xz
```
See [result](https://testflinger-staging.canonical.com/jobs/dca39e54-fa34-4966-8351-78e920e60170).

### Provisioning from an attachment

```
job_queue: rpi4b1g-001
provision_data:
  attachments:
    - local: /home/boukeas/Downloads/busybox-gadget_1.0_dx-series.kernos.zst
      agent: busybox-gadget_1.0_dx-series.kernos.zst
  use_attachment: busybox-gadget_1.0_dx-series.kernos.zst
  create_user: false
  boot_check_url: http://$DEVICE_IP:8888/v1/health
```
See [result](https://testflinger-staging.canonical.com/jobs/16d618d8-5261-4f51-8082-e8a66818f784).

### Error cases: Provisioning without a URL or from a non-existent attachment

```
job_queue: rpi4b1g-001
provision_data:
  attachments:
    - local: /home/boukeas/Downloads/busybox-gadget_1.0_dx-series.kernos.zst
      agent: busybox-gadget_1.0_dx-series.kernos.zst
  create_user: false
  boot_check_url: http://$DEVICE_IP:8888/v1/health
```
See [result](https://testflinger-staging.canonical.com/jobs/c43792d0-768c-4f8a-bf4a-473ea1077b37).

```
job_queue: rpi4b1g-001
provision_data:
  attachments:
    - local: /home/boukeas/Downloads/busybox-gadget_1.0_dx-series.kernos.zst
      agent: busybox-gadget_1.0_dx-series.kernos.zst
  use_attachment: busybox-gadget_1.0_dx-series.kernos
  create_user: false
  boot_check_url: http://$DEVICE_IP:8888/v1/health
```
See [result](https://testflinger-staging.canonical.com/jobs/246775e9-f214-4f86-9337-d886c54ce889).

[CERTTF-303]: https://warthogs.atlassian.net/browse/CERTTF-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CERTTF-316]: https://warthogs.atlassian.net/browse/CERTTF-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ