### PR TITLE
[CERTTF-303] Handle case of file upload interrupted by the user

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -382,12 +382,12 @@ class TestflingerCli:
             with tempfile.NamedTemporaryFile(suffix="tar.gz") as archive:
                 archive_path = Path(archive.name)
                 # create attachments archive prior to job submission
-                logger.info(f"Packing attachments into {archive_path}")
+                logger.info("Packing attachments into %s", archive_path)
                 self.pack_attachments(archive_path, attachments_data)
                 # submit job, followed by the submission of the archive
                 job_id = self.submit_job_data(job_dict)
                 try:
-                    logger.info(f"Submitting attachments for {job_id}")
+                    logger.info("Submitting attachments for %s", job_id)
                     self.submit_job_attachments(job_id, path=archive_path)
                 except AttachmentError:
                     self.cancel(job_id)
@@ -445,11 +445,11 @@ class TestflingerCli:
         for _ in range(tries):
             try:
                 self.client.post_attachment(job_id, path, timeout=timeout)
-            except KeyboardInterrupt:
+            except KeyboardInterrupt as error:
                 raise AttachmentError(
                     f"Unable to submit attachment archive for {job_id}: "
                     f"attachment upload was cancelled by the user"
-                )
+                ) from error
             except requests.HTTPError as error:
                 # we can't recover from these errors, give up without retrying
                 if error.response.status_code == 400:

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -382,10 +382,12 @@ class TestflingerCli:
             with tempfile.NamedTemporaryFile(suffix="tar.gz") as archive:
                 archive_path = Path(archive.name)
                 # create attachments archive prior to job submission
+                logger.info(f"Packing attachments into {archive_path}")
                 self.pack_attachments(archive_path, attachments_data)
                 # submit job, followed by the submission of the archive
                 job_id = self.submit_job_data(job_dict)
                 try:
+                    logger.info(f"Submitting attachments for {job_id}")
                     self.submit_job_attachments(job_id, path=archive_path)
                 except AttachmentError:
                     self.cancel(job_id)
@@ -443,6 +445,11 @@ class TestflingerCli:
         for _ in range(tries):
             try:
                 self.client.post_attachment(job_id, path, timeout=timeout)
+            except KeyboardInterrupt:
+                raise AttachmentError(
+                    f"Unable to submit attachment archive for {job_id}: "
+                    f"attachment upload was cancelled by the user"
+                )
             except requests.HTTPError as error:
                 # we can't recover from these errors, give up without retrying
                 if error.response.status_code == 400:

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -115,8 +115,8 @@ class Client:
                     "in the alloted amount of time"
                 )
                 raise
-            except requests.exceptions.ConnectionError:
-                logger.error("A connection error occured")
+            except requests.exceptions.ConnectionError as error:
+                logger.error(f"A connection error occured {error}")
                 raise
             response.raise_for_status()
 

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -102,7 +102,7 @@ class Client:
         uri = urllib.parse.urljoin(self.server, uri_frag)
         with open(path, "rb") as file:
             try:
-                files = {"file": (path.name, file)}
+                files = {"file": (path.name, file, "application/x-gzip")}
                 response = requests.post(uri, files=files, timeout=timeout)
             except requests.exceptions.ConnectTimeout:
                 logger.error(

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -116,7 +116,7 @@ class Client:
                 )
                 raise
             except requests.exceptions.ConnectionError as error:
-                logger.error(f"A connection error occured {error}")
+                logger.error("A connection error occured %s", error)
                 raise
             response.raise_for_status()
 


### PR DESCRIPTION
## Description

When file upload through the CLI was interrupted by the user, then the job was not automatically cancelled, causing it to appear indefinitely as `waiting` on the server. 

Now `KeyboardInterrupt` is caught and raises an `AttachmentError`, which in turn causes the job to be cancelled.

Also included are a couple of very minor refinements, mostly relating to improved logging.

## Tests

Submitted a job that involved a larger attachment and pressed Ctrl-C during the upload:
```
testflinger-cli --server https://testflinger-staging.canonical.com submit test-job-kernos.yaml 
^CJob 1736d348-32d0-48a3-a212-234060bb201d submitted and cancelled: failed to submit attachments
```
See [result](https://testflinger-staging.canonical.com/jobs/1736d348-32d0-48a3-a212-234060bb201d), verifying the job has been cancelled.