### PR TITLE
Re-enable and fix output_timeout

### DIFF
--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -19,7 +19,7 @@ import os
 import time
 
 from testflinger_agent.errors import TFServerError
-from .runner import CommandRunner
+from .runner import CommandRunner, RunnerEvents
 from .handlers import LiveOutputHandler, LogUpdateHandler
 from .stop_condition_checkers import (
     JobCancelledChecker,
@@ -102,7 +102,7 @@ class TestflingerJob:
             )
             runner.register_stop_condition_checker(output_timeout_checker)
             runner.subscribe_event(
-                "output_received", output_timeout_checker.update
+                RunnerEvents.OUTPUT_RECEIVED, output_timeout_checker.update
             )
 
         # Do not allow cancellation during provision for safety reasons

--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -24,6 +24,7 @@ from .handlers import LiveOutputHandler, LogUpdateHandler
 from .stop_condition_checkers import (
     JobCancelledChecker,
     GlobalTimeoutChecker,
+    OutputTimeoutChecker,
 )
 
 logger = logging.getLogger(__name__)
@@ -93,6 +94,16 @@ class TestflingerJob:
                 self.get_global_timeout()
             )
             runner.register_stop_condition_checker(global_timeout_checker)
+
+        # We only need to check for output timeouts during the test phase
+        if phase == "test":
+            output_timeout_checker = OutputTimeoutChecker(
+                self.get_output_timeout()
+            )
+            runner.register_stop_condition_checker(output_timeout_checker)
+            runner.subscribe_event(
+                "output_received", output_timeout_checker.update
+            )
 
         # Do not allow cancellation during provision for safety reasons
         if phase != "provision":

--- a/agent/testflinger_agent/runner.py
+++ b/agent/testflinger_agent/runner.py
@@ -21,6 +21,7 @@ import subprocess
 import threading
 import time
 
+from collections import defaultdict
 from typing import Callable, Optional, List
 
 logger = logging.getLogger(__name__)
@@ -30,12 +31,21 @@ StopConditionType = Callable[[], Optional[str]]
 
 
 class CommandRunner:
+    """
+    Run a command and handle output and stop conditions.
+
+    There are also events that can be subscribed to for notifications. The
+    following events are available:
+    - output_received: when output is received from the command
+    """
+
     def __init__(self, cwd: Optional[str], env: Optional[dict]):
         self.output_handlers: List[OutputHandlerType] = []
         self.stop_condition_checkers: List[StopConditionType] = []
         self.process: Optional[subprocess.Popen] = None
         self.cwd = cwd
         self.env = os.environ.copy()
+        self.events = defaultdict(list)
         if env:
             self.env.update(
                 {k: str(v) for k, v in env.items() if isinstance(v, str)}
@@ -43,6 +53,15 @@ class CommandRunner:
 
     def register_output_handler(self, handler: OutputHandlerType):
         self.output_handlers.append(handler)
+
+    def subscribe_event(self, event_name: str, handler: Callable):
+        """Set a callback for an event that we want to be notified of"""
+        self.events[event_name].append(handler)
+
+    def post_event(self, event_name: str):
+        """Post an event for subscribers to be notified of"""
+        for handler in self.events[event_name]:
+            handler()
 
     def post_output(self, data: str):
         for handler in self.output_handlers:
@@ -63,6 +82,7 @@ class CommandRunner:
         raw_output = self.process.stdout.read()
         if not raw_output:
             return
+        self.post_event("output_received")
 
         output = raw_output.decode(sys.stdout.encoding, errors="replace")
         self.post_output(output)

--- a/agent/testflinger_agent/stop_condition_checkers.py
+++ b/agent/testflinger_agent/stop_condition_checkers.py
@@ -43,9 +43,13 @@ class GlobalTimeoutChecker:
 class OutputTimeoutChecker:
     def __init__(self, timeout: int):
         self.timeout = timeout
-        self.start_time = time.time()
+        self.last_output_time = time.time()
 
     def __call__(self) -> Optional[str]:
-        if time.time() - self.start_time > self.timeout:
+        if time.time() - self.last_output_time > self.timeout:
             return f"\nERROR: Output timeout reached! ({self.timeout}s)\n"
         return None
+
+    def update(self):
+        """Update the last output time to the current time."""
+        self.last_output_time = time.time()

--- a/agent/testflinger_agent/tests/test_stop_condition_checkers.py
+++ b/agent/testflinger_agent/tests/test_stop_condition_checkers.py
@@ -51,3 +51,14 @@ class TestStopConditionCheckers:
         assert checker() is None
         time.sleep(0.6)
         assert "ERROR: Output timeout reached! (0.5s)" in checker()
+
+    def test_output_timeout_update(self):
+        """
+        Test that the output timeout checker doesn't get triggered when we
+        keep updating the last output time.
+        """
+        checker = OutputTimeoutChecker(0.3)
+        for _ in range(5):
+            time.sleep(0.1)
+            checker.update()
+            assert checker() is None


### PR DESCRIPTION
## Description
When I reworked some of this a while back, I forgot to go back and add something that updates the OutputTimeoutChecker with the latest timestamp every time output occurs so that it can check to see if it's expired. I made this into an event that can be subscribed to. This is the only consumer of it for the moment but I thought it made for a nice way to organize it, and it's easy to extend in case this is useful for other things in the future.

## Resolved issues

#239 
CERTTF-301

## Documentation
N/A

## Tests
Tested on a live test run and also added a unit test
