### PR TITLE
Return a reason for why CommandRunner stopped execution of a phase

### DIFF
--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -117,7 +117,7 @@ class TestflingerJob:
         ):
             runner.run(f"echo '{line}'")
         try:
-            exitcode = runner.run(cmd)
+            exitcode, exit_reason = runner.run(cmd)
         except Exception as e:
             logger.exception(e)
         finally:

--- a/agent/testflinger_agent/stop_condition_checkers.py
+++ b/agent/testflinger_agent/stop_condition_checkers.py
@@ -25,7 +25,7 @@ class JobCancelledChecker:
 
     def __call__(self) -> Optional[str]:
         if self.client.check_job_state(self.job_id) == "cancelled":
-            return "\nJob cancellation was requested, exiting.\n"
+            return "Job cancellation was requested, exiting."
         return None
 
 
@@ -36,7 +36,7 @@ class GlobalTimeoutChecker:
 
     def __call__(self) -> Optional[str]:
         if time.time() - self.start_time > self.timeout:
-            return f"\nERROR: Global timeout reached! ({self.timeout}s)\n"
+            return f"ERROR: Global timeout reached! ({self.timeout}s)"
         return None
 
 
@@ -47,7 +47,7 @@ class OutputTimeoutChecker:
 
     def __call__(self) -> Optional[str]:
         if time.time() - self.last_output_time > self.timeout:
-            return f"\nERROR: Output timeout reached! ({self.timeout}s)\n"
+            return f"ERROR: Output timeout reached! ({self.timeout}s)"
         return None
 
     def update(self):

--- a/agent/testflinger_agent/tests/test_job.py
+++ b/agent/testflinger_agent/tests/test_job.py
@@ -63,17 +63,19 @@ class TestJob:
 
     def test_job_global_timeout(self, tmp_path):
         """Test that timeout from job_data is respected"""
-        timeout_str = "\nERROR: Global timeout reached! (1s)\n"
+        timeout_str = "ERROR: Global timeout reached! (1s)"
         logfile = tmp_path / "testlog"
         runner = CommandRunner(tmp_path, env={})
         log_handler = LogUpdateHandler(logfile)
         runner.register_output_handler(log_handler)
         global_timeout_checker = GlobalTimeoutChecker(1)
         runner.register_stop_condition_checker(global_timeout_checker)
-        runner.run("sleep 3")
+        exit_code, exit_reason = runner.run("sleep 12")
         with open(logfile) as log:
             log_data = log.read()
-        assert timeout_str == log_data
+        assert timeout_str in log_data
+        assert exit_reason == timeout_str
+        assert exit_code == -9
 
     def test_config_global_timeout(self, client):
         """Test that timeout from device config is preferred"""
@@ -85,7 +87,7 @@ class TestJob:
 
     def test_job_output_timeout(self, tmp_path):
         """Test that output timeout from job_data is respected"""
-        timeout_str = "\nERROR: Output timeout reached! (1s)\n"
+        timeout_str = "ERROR: Output timeout reached! (1s)"
         logfile = tmp_path / "testlog"
         runner = CommandRunner(tmp_path, env={})
         log_handler = LogUpdateHandler(logfile)
@@ -94,10 +96,12 @@ class TestJob:
         runner.register_stop_condition_checker(output_timeout_checker)
         # unfortunately, we need to sleep for longer that 10 seconds here
         # or else we fall under the polling time
-        runner.run("sleep 12")
+        exit_code, exit_reason = runner.run("sleep 12")
         with open(logfile) as log:
             log_data = log.read()
-        assert timeout_str == log_data
+        assert timeout_str in log_data
+        assert exit_reason == timeout_str
+        assert exit_code == -9
 
     def test_config_output_timeout(self, client):
         """Test that output timeout from device config is preferred"""


### PR DESCRIPTION
## Description
For now, this mainly handles normal exits, timeouts, and cancellations. Adding additional stop_condition checkers would extend this further.

I suspect we might also want to extend this in the future to gather more details about the error (if any) coming out of device connectors if they exited with some sort of error. Since those errors could come from commands or external factors, we won't know what all the possibilities are. This will require some mechanism to save that information during the device connector execution so that it can be picked up by the agent and will need to be covered later if needed.

For now, this is not used yet, but will be used by some upcoming PRs - one for exposing this data in testflinger UI and another for sending this information to test_observer.

## Resolved issues
CERTTF-325

## Documentation
N/A

## Web service API changes
None

## Tests
Unit tests extended to cover this

## Testing
...see above