### PR TITLE
Create Ubuntu Core Reinstall device connector

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/ubuntu_core_reinstall/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/ubuntu_core_reinstall/__init__.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Ubuntu Core Re-Install Provisioning
+For machines running Ubuntu Core, it is possible to get to a clean system
+using the same image 
+"""
+
+import logging
+
+from testflinger_device_connectors.devices import (
+    DefaultDevice,
+    RecoveryError,
+    catch,
+)
+from .ubuntu_core_reinstall import UbuntuCoreReinstall
+
+logger = logging.getLogger(__name__)
+
+
+class DeviceConnector(DefaultDevice):
+    """Tool for performing a re-install on an Ubuntu Core machine"""
+
+    @catch(RecoveryError, 46)
+    def provision(self, args):
+        """Method called when the command is invoked."""
+        device = UbuntuCoreReinstall(args.config, args.job_data)
+        logger.info("BEGIN provision")
+        logger.info("Provisioning device")
+        device.provision()
+        logger.info("END provision")

--- a/device-connectors/src/testflinger_device_connectors/devices/ubuntu_core_reinstall/ubuntu_core_reinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/ubuntu_core_reinstall/ubuntu_core_reinstall.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Ubuntu Core Re-Install Provisioning
+For machines running Ubuntu Core, it is possible to get to a clean system
+using the same image by calling the "command snap reboot --install"
+"""
+
+import logging
+import subprocess
+from testflinger_device_connectors.devices.oemrecovery.oemrecovery import (
+    OemRecovery,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class UbuntuCoreReinstall(OemRecovery):
+    """Device Agent for Ubuntu Core machines"""
+
+    def provision(self):
+        """Provision the device"""
+
+        # First, ensure the device is online and reachable
+        try:
+            self.copy_ssh_id()
+        except subprocess.CalledProcessError:
+            self.hardreset()
+            self.check_device_booted()
+
+        logger.info("Running Ubuntu Core Re-install")
+        recovery_cmds = ["sudo snap reboot --install"]
+        self._run_cmd_list(recovery_cmds)
+        self.check_device_booted()


### PR DESCRIPTION
## Description

This a frequently used speciialistion of the OemRecovery device connector. To reduce the need to frequently configure the same recovery commands create a device connector for this purpose.

## Resolved issues

None

## Documentation


## Web service API changes

None

## Tests


## Testing

