### PR TITLE
[CERTTF-327] Introduce `submit` GitHub action

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -1,0 +1,52 @@
+name: Test-flinging
+description: Submit a job YAML file to a Testflinger server
+inputs:
+  job:
+    description: "Path to a job file (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
+    required: true
+  poll:
+    description: Specify if the submitted job should be tracked to completion
+    required: false
+    default: false
+  dry-run:
+    description: Specify if the job should really be submitted
+    required: false
+    default: false
+  server:
+    description: The Testflinger server to use
+    required: false
+    default: testflinger.canonical.com
+runs:
+  using: composite
+  steps:
+    - name: Install prerequisites
+      shell: bash
+      run: sudo snap install testflinger-cli jq
+
+    - name: Test connection to Testflinger server
+      shell: bash
+      run: nc -vz ${{ inputs.server }} 443
+
+    - name: Display contents of job file (for verification)
+      shell: bash
+      run: cat ${{ inputs.job }}
+
+    - name: Submit job to the Testflinger server
+      if: inputs.dry-run != 'true'
+      id: submit
+      shell: bash
+      run: |
+        JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
+        echo "job id: $JOB_ID"
+        echo "JOB_ID=$JOB_ID" >> $GITHUB_ENV
+
+    - name: Track the status of the job and mirror its exit status
+      if: inputs.poll == 'true' && inputs.dry-run != 'true'
+      shell: bash
+      run: |
+        # poll
+        PYTHONUNBUFFERED=1 testflinger --server https://${{ inputs.server }} poll $JOB_ID
+        # retrieve results
+        STATUS=$(testflinger --server https://${{ inputs.server }} results $JOB_ID | jq -er .test_status)
+        echo "Test exit status: $STATUS"
+        exit $STATUS

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -1,4 +1,4 @@
-name: Test-flinging
+name: submit
 description: Submit a job YAML file to a Testflinger server
 inputs:
   job:

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -1,9 +1,12 @@
-name: submit
-description: Submit a job YAML file to a Testflinger server
+name: Submit a Testflinger job
+description: Submit a job to a Testflinger server
 inputs:
   job:
+    description: "Inline contents of a job file (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
+    required: false
+  job-path:
     description: "Path to a job file (see https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/ for more info)"
-    required: true
+    required: false
   poll:
     description: Specify if the submitted job should be tracked to completion
     required: false
@@ -18,7 +21,34 @@ inputs:
     default: testflinger.canonical.com
 runs:
   using: composite
+
   steps:
+    - name: Create job file, if required
+      id: create-job-file
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.job-path }}" ]; then
+        # the `$JOB` environment variable points to the job path provided as input
+        echo "JOB=${{ inputs.job-path }}" >> $GITHUB_ENV
+        else
+        # write the inline job text to a file
+        FILE=${{ github.workspace }}/tmp_job.yaml
+        # do not ever indent these lines; the here-doc is sensitive to that
+        cat > $FILE << EOF
+        ${{ inputs.job }}
+        EOF
+        if [[ $(cat "$FILE" | wc -w) == 0 ]]; then
+          echo 'Neither of the `job` or `job-path` inputs have been specified'
+          exit 1
+        fi
+        # the `$JOB` environment variable points to the newly created job file
+        echo "JOB=$FILE" >> $GITHUB_ENV
+        fi
+
+    - name: Display contents of job file (for verification)
+      shell: bash
+      run: cat "$JOB"
+
     - name: Install prerequisites
       shell: bash
       run: sudo snap install testflinger-cli jq
@@ -27,16 +57,12 @@ runs:
       shell: bash
       run: nc -vz ${{ inputs.server }} 443
 
-    - name: Display contents of job file (for verification)
-      shell: bash
-      run: cat ${{ inputs.job }}
-
     - name: Submit job to the Testflinger server
-      if: inputs.dry-run != 'true'
       id: submit
+      if: inputs.dry-run != 'true'
       shell: bash
       run: |
-        JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet ${{ inputs.job }})
+        JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet "$JOB")
         echo "job id: $JOB_ID"
         echo "JOB_ID=$JOB_ID" >> $GITHUB_ENV
 

--- a/README.md
+++ b/README.md
@@ -47,5 +47,17 @@ The corresponding step in the workflow would look like this:
       uses: canonical/testflinger/.github/actions/submit@v1
       with:
         poll: true
-        job: ${{ steps.create-job.outputs.job }}
+        job-path: ${{ steps.create-job.outputs.job-path }}
 ```
+
+This assumes that there is a previous `create-job` step in the workflow that creates the job file and outputs the path to it, so that it can be used as input to the `submit` action.
+Alternatively, you can use the `job` argument (instead of `job-path`) to provide the contents of the job inline:
+```
+    - name: Submit job
+      uses: canonical/testflinger/.github/actions/submit@v1
+      with:
+        poll: true
+        job: |
+            ...  # inline YAML for Testflinger job
+```
+In the latter case, do remember to use escapes for environment variables in the inline text, e.g. `\$DEVICE_IP`.

--- a/README.md
+++ b/README.md
@@ -35,4 +35,17 @@ This monorepo is organized in a way that is consistant with the components descr
     ├── device-connectors
     ├── cli
     └── docs
+```
 
+# Github actions
+
+If you need to submit a job to a testflinger server through a Github action (instead, for example, of using the command-line tool), you can use the [`submit` action](https://github.com/canonical/testflinger/blob/main/.github/actions/submit/action.yaml) in a CI workflow.
+
+The corresponding step in the workflow would look like this:
+```
+    - name: Submit job
+      uses: canonical/testflinger/.github/actions/submit@v1
+      with:
+        poll: true
+        job: ${{ steps.create-job.outputs.job }}
+```


### PR DESCRIPTION
Add the `submit` action for submitting Testflinger jobs to a Testflinger server.

The main input that the action expects is the job definition for the job that will be submitted to Testflinger (see the [Testflinger documentation](https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema/) to understand how this job definition is structured).

There are two ways to provide that job definition to the `submit` action: using a file through the `job-path` input or inline through the `job` input. 
```
description: Submit a job to a Testflinger server
inputs:
  job:
    description: Inline contents of a job file
    required: false
  job-path:
    description: Path to a job file
    required: false
```
The action will fail if neither one of those inputs are provided.

There are additional (optional) inputs to the action:
```
  poll:
    description: Specify if the submitted job should be tracked to completion
    required: false
    default: false
  dry-run:
    description: Specify if the job should really be submitted
    required: false
    default: false
  server:
    description: The Testflinger server to use
    required: false
    default: testflinger.canonical.com
```
Here are some example workflows (the Checkbox "canary test") that make use of this action:
- submit a job [by creating a job file and providing its path](https://github.com/canonical/checkbox/blob/test-action-fling-test/.github/workflows/checkbox-canary-test.yaml) to the `submit` action
- submit a job [by providing it inline as an argument](https://github.com/canonical/checkbox/blob/test-action-fling-test/.github/workflows/checkbox-canary-test-inline.yaml) to the `submit` action
- submit a job [without providing a job definition](https://github.com/canonical/checkbox/blob/test-action-fling-test/.github/workflows/checkbox-canary-test-empty.yaml), either through a file or inline, resulting in an error