### PR TITLE
update: move reboot_sdwire() back to the beginning of the provision phase

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -162,6 +162,11 @@ class MuxPi:
         self._run_control("true")
 
     def provision(self):
+        # If this is not a zapper, reboot before provisioning
+        if "zapper" not in self.config.get("control_switch_local_cmd", ""):
+            self.reboot_sdwire()
+        time.sleep(5)
+
         # determine where to get the provisioning image from
         source = self.job_data["provision_data"].get("url")
         if source is None:
@@ -211,11 +216,6 @@ class MuxPi:
                     "your job_data must be either "
                     "'sd' or 'usb'"
                 )
-
-        # If this is not a zapper, reboot before provisioning
-        if "zapper" not in self.config.get("control_switch_local_cmd", ""):
-            self.reboot_sdwire()
-        time.sleep(5)
 
         self.flash_test_image(source)
 


### PR DESCRIPTION
## Description

In the original commit of this [PR](https://github.com/canonical/testflinger/pull/267), the `reboot_sdwire` function call should have been placed at the beginning of provision phase, but after this [commit](https://github.com/canonical/testflinger/pull/267/commits/9c68cad9e606ff0baf619d509e212c0995483ca1), it has been moved down. This will cause that the `reboot_sdwire` never being executed if previous section fail

## Resolved issues

@p-gentili [reported](https://chat.canonical.com/canonical/pl/tr1xka37qtdu7eg3dzfftsxqja) that rpicml couldn't find the sdwire, when I checked the output from device_connector I found that the control_host which is nanopi has never been powered cycle.



