### PR TITLE
docs(muxpi): cross-reference attachment info

### DIFF
--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -128,6 +128,9 @@ The ``muxpi`` device connector supports the following ``provision_data`` keys:
        ``unzstd`` (**xz** format is recommended, but any format supported by
        the ``zstd`` tool is supported) and
        flashed to the SD card, which will be used to boot up the DUT.
+   * - ``use_attachment``
+     - If set, overrides the ``url`` above and uses :ref:`file attachments <file_attachments>`
+       for deploying an image to the SD card.
    * - ``media``
      - Optional parameter to indicate on which boot media the disk image should
        be programmed (using zapper commands). Supported values are ``usb`` or 

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -211,6 +211,8 @@ Example agent configuration:
   cleanup_command: echo Consider removing containers or other necessary cleanup steps here
 
 
+.. _file_attachments:
+
 Attachments
 ------------
 In the `provisioning`, `firmware_update` and `test` phases, it is also possible to specify attachments, i.e. local files that are to be copied over to the Testflinger agent host.
@@ -269,7 +271,7 @@ In this example, there is no `url` field under the `provision_data` to specify w
 Instead, there is a `use_attachment` field that indicates which attachment should be used as a provisioning image.
 The presence of *either* `url` or `use_attachment` is required.
 
-At the moment, only the `muxpi` device connector supports provisioning using an attached image.
+At the moment, only the :ref:`muxpi` device connector supports provisioning using an attached image.
 
 Output 
 ------------


### PR DESCRIPTION
Cross-referencing documentation of #265 for easier discoverability.