### PR TITLE
Report a nicer error if the user looks for a non-existant agent

### DIFF
--- a/server/src/templates/agent_not_found.html
+++ b/server/src/templates/agent_not_found.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% set active_page = 'agents' %}
+{% block content %}
+<div class="p-strip is-shallow">
+    <div class="row">
+        <h1 class="p-heading--3">
+            Agent not found: {{ agent_id }}
+        </h1>
+    </div>
+</div>
+{% endblock %}

--- a/server/src/views.py
+++ b/server/src/views.py
@@ -47,6 +47,8 @@ def agents():
 def agent_detail(agent_id):
     """Agent detail view"""
     agent_info = mongo.db.agents.find_one({"name": agent_id})
+    if not agent_info:
+        return render_template("agent_not_found.html", agent_id=agent_id)
     return render_template("agent_detail.html", agent=agent_info)
 
 

--- a/server/src/views.py
+++ b/server/src/views.py
@@ -17,7 +17,7 @@
 Additional views not associated with the API
 """
 
-from flask import Blueprint, render_template, redirect, url_for
+from flask import Blueprint, make_response, render_template, redirect, url_for
 from prometheus_client import generate_latest
 from src.database import mongo
 
@@ -48,7 +48,11 @@ def agent_detail(agent_id):
     """Agent detail view"""
     agent_info = mongo.db.agents.find_one({"name": agent_id})
     if not agent_info:
-        return render_template("agent_not_found.html", agent_id=agent_id)
+        response = make_response(
+            render_template("agent_not_found.html", agent_id=agent_id)
+        )
+        response.status_code = 404
+        return response
     return render_template("agent_detail.html", agent=agent_info)
 
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -46,11 +46,18 @@ class MongoClientMock(mongomock.MongoClient):
 
 @pytest.fixture
 def mongo_app():
-    """Create a pytest fixture for the app"""
+    """Create a pytest fixture for database and app"""
     mock_mongo = MongoClientMock()
     database.mongo = mock_mongo
     app = application.create_flask_app(TestingConfig)
     yield app.test_client(), mock_mongo.db
+
+
+@pytest.fixture
+def testapp():
+    """pytest fixture for just the app"""
+    app = application.create_flask_app(TestingConfig)
+    yield app
 
 
 @pytest.fixture

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -92,6 +92,7 @@ def test_agent_not_found(testapp):
     mongo = mongomock.MongoClient()
     with patch("src.views.mongo", mongo):
         with testapp.test_request_context():
-            data = agent_detail("agent1")
+            response = agent_detail("agent1")
 
-    assert "Agent not found: agent1" in data
+    assert "Agent not found: agent1" in str(response.data)
+    assert response.status_code == 404

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -19,7 +19,7 @@ Unit tests for Testflinger views
 
 import mongomock
 from mock import patch
-from src.views import queues_data
+from src.views import queues_data, agent_detail
 
 
 def test_queues():
@@ -82,3 +82,16 @@ def test_queues():
     assert len(advertised_queue2) == 1
     assert advertised_queue2[0]["description"] == "desc2"
     assert advertised_queue2[0]["numjobs"] == 2
+
+
+def test_agent_not_found(testapp):
+    """
+    Test that the agent_detail fails gracefully when an agent is not found
+    """
+
+    mongo = mongomock.MongoClient()
+    with patch("src.views.mongo", mongo):
+        with testapp.test_request_context():
+            data = agent_detail("agent1")
+
+    assert "Agent not found: agent1" in data


### PR DESCRIPTION
## Description
It shouldn't come from a link but if someone tries to access an agent that doesn't exist directly through /agents/foo, for example, the will get an unhelpful error page with `Unhandled Exception: 'None' has no attribute 'updated_at'` and we'll get a similar error in the logs. Let's return something more informative that says this agent wasn't found.

## Resolved issues
N/A

## Documentation
N/A

## Web service API changes
Not an API change, just better visual feedback to the user on the rendered html

## Tests
Added a unit test

## Testing
Also tried it locally? Still not sure why we have two sections for this.