### PR TITLE
Give more detail if job submission fails

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -425,7 +425,7 @@ class TestflingerCli:
             # This shouldn't happen, so let's get more information
             sys.exit(
                 "Unexpected error status from testflinger "
-                f"server: {exc.status}"
+                f"server: [{exc.status}] {exc.msg}"
             )
         return job_id
 

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -33,9 +33,10 @@ logger = logging.getLogger(__name__)
 class HTTPError(Exception):
     """Exception class for HTTP error codes"""
 
-    def __init__(self, status):
+    def __init__(self, status, msg=""):
         super().__init__(status)
         self.status = status
+        self.msg = msg
 
 
 class Client:
@@ -86,7 +87,7 @@ class Client:
             logger.error("Unable to communicate with specified server.")
             sys.exit(1)
         if req.status_code != 200:
-            raise HTTPError(req.status_code)
+            raise HTTPError(status=req.status_code, msg=req.text)
         return req.text
 
     def put_file(self, uri_frag: str, path: Path, timeout: float):

--- a/cli/testflinger_cli/tests/test_cli.py
+++ b/cli/testflinger_cli/tests/test_cli.py
@@ -90,6 +90,23 @@ def test_submit(capsys, tmp_path, requests_mock):
     assert jobid in std.out
 
 
+def test_submit_bad_data(tmp_path, requests_mock):
+    """Ensure a 422 response from bad data shows the returned errors"""
+    fake_data = {"badkey": "badvalue"}
+    testfile = tmp_path / "test.json"
+    testfile.write_text(json.dumps(fake_data))
+    # return 422 and "expected error"
+    requests_mock.post(URL + "/v1/job", status_code=422, text="expected error")
+    sys.argv = ["", "submit", str(testfile)]
+    tfcli = testflinger_cli.TestflingerCli()
+    with pytest.raises(SystemExit) as err:
+        tfcli.submit()
+    assert (
+        "Unexpected error status from testflinger server: [422] expected error"
+        in err.value.code
+    )
+
+
 def test_submit_with_attachments(tmp_path):
     """Make sure jobs with attachments are submitted correctly"""
 


### PR DESCRIPTION
## Description
Jeff pointed out a job he was submitting that had some invalid things in it and it got a 422 as expected. However it didn't pass along enough information to give him a hint what bit was invalid, which isn't very helpful. This should pass along the validation error that we get back from the server if that happens.
Example:
```
TESTFLINGER_SERVER=http://localhost:5000 testflinger submit bad-multi-job.yaml

Unexpected error status from testflinger server: [422] {"detail":{"json":{"test_data":{"test_cmds":["Not a valid string."]}}},"message":"Validation error"}
```

## Documentation
N/A

## Web service API changes
N/A

## Tests
Added unit test