### PR TITLE
Fix agent charm on focal

### DIFF
--- a/.github/workflows/agent-charm-release-edge.yml
+++ b/.github/workflows/agent-charm-release-edge.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.0
         with:
-          charm-path: server/charm
+          charm-path: agent/charms/testflinger-agent-charm
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           channel: "latest/edge"

--- a/.github/workflows/agent-charm-release-edge.yml
+++ b/.github/workflows/agent-charm-release-edge.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - agent/charms/testflinger-agent-charm/**
+      - .github/workflows/agent-charm-release-edge.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/agent-charm-release-edge.yml
+++ b/.github/workflows/agent-charm-release-edge.yml
@@ -1,0 +1,27 @@
+name: Release testflinger-agent charm to latest/edge
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - agent/testflinger-agent-charm/**
+  workflow_dispatch:
+
+jobs:
+  agent-build-and-push-charm:
+    runs-on: [self-hosted, linux, jammy, X64]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@2.6.0
+        with:
+          charm-path: server/charm
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          channel: "latest/edge"

--- a/.github/workflows/agent-charm-release-edge.yml
+++ b/.github/workflows/agent-charm-release-edge.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - agent/testflinger-agent-charm/**
+      - agent/charms/testflinger-agent-charm/**
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/agent-host-charm-release-edge.yml
+++ b/.github/workflows/agent-host-charm-release-edge.yml
@@ -1,4 +1,4 @@
-name: Release testflinger-agent charm to latest/edge
+name: Release testflinger-agent-host charm to latest/edge
 
 on:
   push:

--- a/.github/workflows/agent-host-charm-release-edge.yml
+++ b/.github/workflows/agent-host-charm-release-edge.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - agent/testflinger-agent-charm/**
+      - agent/charms/testflinger-agent-host-charm/**
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/agent-host-charm-release-edge.yml
+++ b/.github/workflows/agent-host-charm-release-edge.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.0
         with:
-          charm-path: server/charm
+          charm-path: agent/charms/testflinger-agent-host-charm
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           channel: "latest/edge"

--- a/.github/workflows/agent-host-charm-release-edge.yml
+++ b/.github/workflows/agent-host-charm-release-edge.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - agent/charms/testflinger-agent-host-charm/**
+      - .github/workflows/agent-host-charm-release-edge.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/agent-host-charm-release-edge.yml
+++ b/.github/workflows/agent-host-charm-release-edge.yml
@@ -1,0 +1,27 @@
+name: Release testflinger-agent charm to latest/edge
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - agent/testflinger-agent-charm/**
+  workflow_dispatch:
+
+jobs:
+  agent-build-and-push-charm:
+    runs-on: [self-hosted, linux, jammy, X64]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@2.6.0
+        with:
+          charm-path: server/charm
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          channel: "latest/edge"

--- a/agent/charms/testflinger-agent-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-charm/src/charm.py
@@ -155,6 +155,16 @@ class TestflingerAgentCharm(CharmBase):
             "common",
             "device-connectors",
         )
+        # poetry needs a newer version of pip than what's in the focal repos
+        # we can drop this once we no longer have agent hosts on focal
+        self.run_with_logged_errors(
+            [
+                f"{self._stored.venv_path}/bin/pip3",
+                "install",
+                "-U",
+                "pip",
+            ]
+        )
         # Install the agent and device-connectors
         for dir in ("agent", "device-connectors"):
             self.run_with_logged_errors(


### PR DESCRIPTION
## Description
Thanks to @nancyc12 for alerting me to this last night. There were some changes that required rebuilding the agent charm recently, which is really rare. These weren't set up to autobuild because they are almost never needed, so I've added that, and requested ownership change of these charms on forums.charmhub.io. I've pushed an update for now that got her unblocked for the system she was trying to fix, but there's another issue that will happen if the agent host is on focal. Most of our agent hosts are on jammy or above now, but one of them is still on focal. This should fix that.

## Resolved issues
No issue filed that I'm aware of

## Documentation
N/A

## Web service API changes
N/A

## Tests
I've tried this update to pip in a focal container and it does what is needed, but I intend to do an end-to-end test with a built version of the charm before deploying it widely.
