### PR TITLE
Refine submit action check

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -38,7 +38,7 @@ runs:
           cat error.log
           exit $STATUS
         else
-          echo "Successful server ping at $SERVER, status: $status"
+          echo "Successful server ping at $SERVER, status: $STATUS"
         fi
     - name: Create job file, if required
       id: create-job-file

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -27,13 +27,15 @@ runs:
       env:
         SERVER: https://${{ inputs.server }}
       run: |
-        STATUS=$(curl -I -w "%{http_code}\n" -o /dev/null -s $SERVER/jobs)
+        STATUS=$(curl --stderr error.log -Ivw "%{http_code}\n" -o /dev/null $SERVER/jobs)
         ERROR=$?
         if [ ! $ERROR -eq 0 ]; then
           echo "Unable to ping Testflinger server at $SERVER"
+          cat error.log
           exit $ERROR
         elif [ ! $STATUS -eq 200 ]; then
           echo "Failed server ping at $SERVER, error status: $STATUS"
+          cat error.log
           exit $STATUS
         else
           echo "Successful server ping at $SERVER, status: $status"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -21,8 +21,6 @@ inputs:
     default: testflinger.canonical.com
 runs:
   using: composite
-  env:
-    SERVER: https://${{ inputs.server }}
   steps:
     - name: Create job file, if required
       id: create-job-file
@@ -56,6 +54,8 @@ runs:
 
     - name: Test connection to Testflinger server
       shell: bash {0}  # allow curl to fail
+      env:
+        SERVER: https://${{ inputs.server }}
       run: |
         STATUS=$(curl -I -w "%{http_code}\n" -o /dev/null -s $SERVER/jobs)
         ERROR=$?
@@ -72,6 +72,8 @@ runs:
       id: submit
       if: inputs.dry-run != 'true'
       shell: bash
+      env:
+        SERVER: https://${{ inputs.server }}
       run: |
         JOB_ID=$(testflinger --server $SERVER submit --quiet "$JOB")
         echo "job id: $JOB_ID"
@@ -80,6 +82,8 @@ runs:
     - name: Track the status of the job and mirror its exit status
       if: inputs.poll == 'true' && inputs.dry-run != 'true'
       shell: bash
+      env:
+        SERVER: https://${{ inputs.server }}
       run: |
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -21,7 +21,8 @@ inputs:
     default: testflinger.canonical.com
 runs:
   using: composite
-
+  env:
+    SERVER: https://${{ inputs.server }}
   steps:
     - name: Create job file, if required
       id: create-job-file
@@ -54,15 +55,25 @@ runs:
       run: sudo snap install testflinger-cli jq
 
     - name: Test connection to Testflinger server
-      shell: bash
-      run: nc -vz ${{ inputs.server }} 443
-
+      shell: bash {0}  # allow curl to fail
+      run: |
+        STATUS=$(curl -I -w "%{http_code}\n" -o /dev/null -s $SERVER/jobs)
+        ERROR=$?
+        if [ ! $ERROR -eq 0 ]; then
+          echo "Unable to ping Testflinger server at $SERVER"
+          exit $ERROR
+        elif [ ! $STATUS -eq 200 ]; then
+          echo "Failed server ping at $SERVER, error status: $STATUS"
+          exit $STATUS
+        else
+          echo "Successful server ping at $SERVER, status: $status"
+        fi
     - name: Submit job to the Testflinger server
       id: submit
       if: inputs.dry-run != 'true'
       shell: bash
       run: |
-        JOB_ID=$(testflinger --server https://${{ inputs.server }} submit --quiet "$JOB")
+        JOB_ID=$(testflinger --server $SERVER submit --quiet "$JOB")
         echo "job id: $JOB_ID"
         echo "JOB_ID=$JOB_ID" >> $GITHUB_ENV
 
@@ -71,8 +82,8 @@ runs:
       shell: bash
       run: |
         # poll
-        PYTHONUNBUFFERED=1 testflinger --server https://${{ inputs.server }} poll $JOB_ID
+        PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
         # retrieve results
-        STATUS=$(testflinger --server https://${{ inputs.server }} results $JOB_ID | jq -er .test_status)
+        STATUS=$(testflinger --server $SERVER results $JOB_ID | jq -er .test_status)
         echo "Test exit status: $STATUS"
         exit $STATUS

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -22,6 +22,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Test connection to Testflinger server
+      shell: bash {0}  # allow curl to fail
+      env:
+        SERVER: https://${{ inputs.server }}
+      run: |
+        STATUS=$(curl -I -w "%{http_code}\n" -o /dev/null -s $SERVER/jobs)
+        ERROR=$?
+        if [ ! $ERROR -eq 0 ]; then
+          echo "Unable to ping Testflinger server at $SERVER"
+          exit $ERROR
+        elif [ ! $STATUS -eq 200 ]; then
+          echo "Failed server ping at $SERVER, error status: $STATUS"
+          exit $STATUS
+        else
+          echo "Successful server ping at $SERVER, status: $status"
+        fi
     - name: Create job file, if required
       id: create-job-file
       shell: bash
@@ -52,22 +68,6 @@ runs:
       shell: bash
       run: sudo snap install testflinger-cli jq
 
-    - name: Test connection to Testflinger server
-      shell: bash {0}  # allow curl to fail
-      env:
-        SERVER: https://${{ inputs.server }}
-      run: |
-        STATUS=$(curl -I -w "%{http_code}\n" -o /dev/null -s $SERVER/jobs)
-        ERROR=$?
-        if [ ! $ERROR -eq 0 ]; then
-          echo "Unable to ping Testflinger server at $SERVER"
-          exit $ERROR
-        elif [ ! $STATUS -eq 200 ]; then
-          echo "Failed server ping at $SERVER, error status: $STATUS"
-          exit $STATUS
-        else
-          echo "Successful server ping at $SERVER, status: $status"
-        fi
     - name: Submit job to the Testflinger server
       id: submit
       if: inputs.dry-run != 'true'


### PR DESCRIPTION
## Description

The `submit` composite action used `nc` (netcat) to check if the Testflinger server was listening at the appropriate port. This was a simple test that often failed to detect connectivity issues that would later cause the `submit` action to fail (e.g. proxy problems), partly because `nc` operates at a lower protocol level (TCP) than the actual HTTPS Testflinger requests.

In this PR, the `nc` test is replaced by a more refined one that uses `curl` to check if an HTTPS connection can be established with the Testflinger server.

## Documentation

No changes to the documentation are required.

## Tests

The action was tested:
- in a workflow executing on a self-hosted Github runner with proxy-related connectivity issues ([sample run](https://github.com/canonical/hwcert-jenkins-tools/actions/runs/9600407702/job/26476886011)).
- in a workflow executing a self-hosted Github runner with no connectivity issues ([sample run](https://github.com/canonical/hwcert-jenkins-tools/actions/runs/9600407702/job/26603311087)).