### PR TITLE
Auto deploy tf-cmd-scripts in agent-host charm

### DIFF
--- a/agent/charms/testflinger-agent-charm/README.md
+++ b/agent/charms/testflinger-agent-charm/README.md
@@ -16,10 +16,6 @@ charmcraft), then run: charmcraft pack
 # Configuration
 Supported options for this charm are:
 
-  - ssh-priv-key:
-      base64 encoded ssh private keyfile
-  - ssh-pub-key:
-      base64 encoded ssh public keyfile
   - testflinger-agent-configfile:
       base64 encoded string with the config file for spi-agent
   - device-configfile:

--- a/agent/charms/testflinger-agent-host-charm/README.md
+++ b/agent/charms/testflinger-agent-host-charm/README.md
@@ -4,12 +4,12 @@ This charm provides the base system for a host system that will be used for
 testflinger device agents. It installs the base dependencies and provides a
 target for deploying the "testflinger-agent" along with
 "testflinger-device-connector" on top of. Additionally, it copies the scripts
-in `src/tf-cmd-scripts/`` to the host system. The scripts would be used by the
+in `src/tf-cmd-scripts/` to the host system. The scripts would be used by the
 testflinger-agent to trigger the testflinger-device-connector at each phase.
 
 # Building
-To build this charm, first install charmcraft (sudo snap install --classic
-charmcraft), then run: charmcraft pack
+To build this charm, first install charmcraft (`sudo snap install --classic
+charmcraft`) then run `charmcraft pack`
 
 # Configuration
 Supported options for this charm are:
@@ -18,3 +18,6 @@ Supported options for this charm are:
       base64 encoded ssh private keyfile
   - ssh-pub-key:
       base64 encoded ssh public keyfile
+
+To keep the tf-cmd-scripts files up-to-date, run `juju upgrade-charm
+{testflinger-agent-host-application}`.

--- a/agent/charms/testflinger-agent-host-charm/README.md
+++ b/agent/charms/testflinger-agent-host-charm/README.md
@@ -1,5 +1,20 @@
 # Overview
 
-This charm provides the base system for a host system that will be used
-for testflinger device agents. It installs the base dependencies and
-provides a target for deploying the testflinger-device-agent on top of.
+This charm provides the base system for a host system that will be used for
+testflinger device agents. It installs the base dependencies and provides a
+target for deploying the "testflinger-agent" along with
+"testflinger-device-connector" on top of. Additionally, it copies the scripts
+in `src/tf-cmd-scripts/`` to the host system. The scripts would be used by the
+testflinger-agent to trigger the testflinger-device-connector at each phase.
+
+# Building
+To build this charm, first install charmcraft (sudo snap install --classic
+charmcraft), then run: charmcraft pack
+
+# Configuration
+Supported options for this charm are:
+
+  - ssh-priv-key:
+      base64 encoded ssh private keyfile
+  - ssh-pub-key:
+      base64 encoded ssh public keyfile

--- a/agent/charms/testflinger-agent-host-charm/run_tests
+++ b/agent/charms/testflinger-agent-host-charm/run_tests
@@ -12,6 +12,6 @@ else
     export PYTHONPATH="lib:src:$PYTHONPATH"
 fi
 
-flake8
+flake8 --exclude=lib
 coverage run --branch --source=src -m unittest -v "$@"
 coverage report -m

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -86,9 +86,6 @@ class TestflingerAgentHostCharm(CharmBase):
         """Update tf_cmd_scfipts"""
         tf_cmd_dir = "src/tf-cmd-scripts/"
         usr_local_bin = "/usr/local/bin/"
-        for file in os.listdir(usr_local_bin):
-            if "tf" in file:
-                os.remove(os.path.join(usr_local_bin, file))
         for tf_cmd_file in os.listdir(tf_cmd_dir):
             shutil.copy(os.path.join(tf_cmd_dir, tf_cmd_file), usr_local_bin)
             os.chmod(os.path.join(usr_local_bin, tf_cmd_file), 0o775)

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -7,6 +7,8 @@
 
 import logging
 import subprocess
+import shutil
+import os
 from pathlib import Path, PosixPath
 
 from charms.operator_libs_linux.v0 import apt, systemd
@@ -47,6 +49,7 @@ class TestflingerAgentHostCharm(CharmBase):
         # maas cli comes from maas snap now
         self.run_with_logged_errors(["snap", "install", "maas"])
         self.setup_docker()
+        self.copy_tf_cmd_scripts()
 
     def setup_docker(self):
         self.run_with_logged_errors(["groupadd", "docker"])
@@ -77,6 +80,13 @@ class TestflingerAgentHostCharm(CharmBase):
         if self._stored.ssh_pub != pub_key:
             self._stored.ssh_pub = pub_key
             self.write_file("/home/ubuntu/.ssh/id_rsa.pub", pub_key)
+
+    def copy_tf_cmd_scripts(self):
+        tf_cmd_dir = "src/tf-cmd-scripts/"
+        for tf_cmd_file in os.listdir(tf_cmd_dir):
+            shutil.copy(
+                os.path.join(tf_cmd_dir, tf_cmd_file), "/usr/local/bin/"
+            )
 
     def on_start(self, _):
         """Start the service"""

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -83,7 +83,7 @@ class TestflingerAgentHostCharm(CharmBase):
             self.write_file("/home/ubuntu/.ssh/id_rsa.pub", pub_key)
 
     def update_tf_cmd_scripts(self):
-        """Update tf_cmd_scfipts"""
+        """Update tf-cmd-scripts"""
         tf_cmd_dir = "src/tf-cmd-scripts/"
         usr_local_bin = "/usr/local/bin/"
         for tf_cmd_file in os.listdir(tf_cmd_dir):

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -9,9 +9,9 @@ import logging
 import subprocess
 import shutil
 import os
-from pathlib import Path, PosixPath
+from pathlib import PosixPath
 
-from charms.operator_libs_linux.v0 import apt, systemd
+from charms.operator_libs_linux.v0 import apt
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -90,9 +90,8 @@ class TestflingerAgentHostCharm(CharmBase):
             if "tf" in file:
                 os.remove(os.path.join(usr_local_bin, file))
         for tf_cmd_file in os.listdir(tf_cmd_dir):
-            shutil.copy(
-                os.path.join(tf_cmd_dir, tf_cmd_file), "/usr/local/bin/"
-            )
+            shutil.copy(os.path.join(tf_cmd_dir, tf_cmd_file), usr_local_bin)
+            os.chmod(os.path.join(usr_local_bin, tf_cmd_file), 0o775)
 
     def on_upgrade_charm(self, _):
         """Upgrade hook"""

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-allocate
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-allocate
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
+PROVISION_TYPE="$provision_type"
+
+if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
+        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE allocate -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+else
+        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE allocate -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json
+fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-allocate
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-allocate
@@ -3,8 +3,4 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
-        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE allocate -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
-else
-        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE allocate -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json
-fi
+. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE allocate -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
+PROVISION_TYPE="$provision_type"
+
+echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-firmware-update
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-firmware-update
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
+PROVISION_TYPE="$provision_type"
+
+if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
+        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE firmware_update -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+else
+        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE firmware_update -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json
+fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-firmware-update
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-firmware-update
@@ -3,8 +3,4 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
-        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE firmware_update -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
-else
-        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE firmware_update -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json
-fi
+. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE firmware_update -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-provision
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-provision
@@ -3,8 +3,4 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
-        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE provision -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
-else
-        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE provision -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json
-fi
+. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE provision -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-provision
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-provision
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
+PROVISION_TYPE="$provision_type"
+
+if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
+        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE provision -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+else
+        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE provision -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json
+fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-reserve
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-reserve
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
+PROVISION_TYPE="$provision_type"
+
+if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
+        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE reserve -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+else
+        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE reserve -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json
+fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-reserve
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-reserve
@@ -3,8 +3,4 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
-        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE reserve -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
-else
-        . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE reserve -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json
-fi
+. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE reserve -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-setup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
+PROVISION_TYPE="$provision_type"
+
+echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
+PROVISION_TYPE="$provision_type"
+
+if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
+        docker run -t --name $AGENT -v $PWD:/home/ubuntu -v ~/.ssh:/home/ubuntu/.ssh:ro -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT plars/testflinger-testenv-focal bash -c "(cd /srv/testflinger-agent/$AGENT/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json"
+else
+        docker run -t --name $AGENT -v $PWD:/home/ubuntu -v ~/.ssh:/home/ubuntu/.ssh:ro -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT plars/testflinger-testenv-focal bash -c "(cd /srv/testflinger-agent/$AGENT/snappy-device-agents && sudo pip install . &> /dev/null) && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json"
+fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -3,8 +3,4 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-if [ -f /srv/testflinger-agent/$AGENT/testflinger-agent.conf ]; then
-        docker run -t --name $AGENT -v $PWD:/home/ubuntu -v ~/.ssh:/home/ubuntu/.ssh:ro -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT plars/testflinger-testenv-focal bash -c "(cd /srv/testflinger-agent/$AGENT/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json"
-else
-        docker run -t --name $AGENT -v $PWD:/home/ubuntu -v ~/.ssh:/home/ubuntu/.ssh:ro -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT plars/testflinger-testenv-focal bash -c "(cd /srv/testflinger-agent/$AGENT/snappy-device-agents && sudo pip install . &> /dev/null) && PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/snappy-device-agents/default.yaml testflinger.json"
-fi
+docker run -t --name $AGENT -v $PWD:/home/ubuntu -v ~/.ssh:/home/ubuntu/.ssh:ro -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT plars/testflinger-testenv-focal bash -c "(cd /srv/testflinger-agent/$AGENT/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json"

--- a/agent/charms/testflinger-agent-host-charm/tests/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/test_charm.py
@@ -4,20 +4,75 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import unittest
-from unittest.mock import Mock
-
-from charm import TestflingerCharm
-from ops.model import ActiveStatus
+import os
+from unittest.mock import patch
+from charm import TestflingerAgentHostCharm
 from ops.testing import Harness
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.harness = Harness(TestflingerCharm)
+        self.harness = Harness(TestflingerAgentHostCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
-    def test_config_changed(self):
-        self.assertEqual(list(self.harness.charm._stored.things), [])
-        self.harness.update_config({"ssl_certificate": "foo"})
-        self.assertEqual(list(self.harness.charm._stored.ssl_certificate), ["foo"])
+    @patch("charm.TestflingerAgentHostCharm.write_file")
+    @patch("charm.TestflingerAgentHostCharm.read_resource")
+    def test_copy_ssh_keys(self, mock_read_resource, mock_write_file):
+        """Test the copy_ssh_keys method"""
+        charm = self.harness.charm
+        mock_read_resource.side_effect = [
+            "ssh_priv_key_content",
+            "ssh_pub_key_content",
+        ]
+
+        charm.copy_ssh_keys()
+
+        mock_read_resource.assert_any_call("ssh_priv_key")
+        mock_read_resource.assert_any_call("ssh_pub_key")
+        self.assertEqual(mock_read_resource.call_count, 2)
+
+        mock_write_file.assert_any_call(
+            "/home/ubuntu/.ssh/id_rsa", "ssh_priv_key_content"
+        )
+        mock_write_file.assert_any_call(
+            "/home/ubuntu/.ssh/id_rsa.pub", "ssh_pub_key_content"
+        )
+        self.assertEqual(mock_write_file.call_count, 2)
+
+    @patch("os.listdir")
+    @patch("os.remove")
+    @patch("shutil.copy")
+    @patch("os.chmod")
+    def test_update_tf_cmd_scripts(
+        self, mock_chmod, mock_copy, mock_remove, mock_listdir
+    ):
+        """Test the update_tf_cmd_scripts method"""
+        charm = self.harness.charm
+        usr_local_bin_files = ["tf-script1", "tf-script2", "other-file"]
+        tf_cmd_scripts_files = ["tf-script3", "tf-script4"]
+
+        mock_listdir.side_effect = [usr_local_bin_files, tf_cmd_scripts_files]
+
+        charm.update_tf_cmd_scripts()
+        tf_cmd_dir = "src/tf-cmd-scripts/"
+        usr_local_bin = "/usr/local/bin/"
+        mock_remove.assert_any_call(os.path.join(usr_local_bin, "tf-script1"))
+        mock_remove.assert_any_call(os.path.join(usr_local_bin, "tf-script2"))
+        self.assertEqual(mock_remove.call_count, 2)
+        mock_copy.assert_any_call(
+            os.path.join(tf_cmd_dir, "tf-script3"),
+            usr_local_bin,
+        )
+        mock_copy.assert_any_call(
+            os.path.join(tf_cmd_dir, "tf-script4"),
+            usr_local_bin,
+        )
+        self.assertEqual(mock_copy.call_count, 2)
+        mock_chmod.assert_any_call(
+            os.path.join(usr_local_bin, "tf-script3"), 0o775
+        )
+        mock_chmod.assert_any_call(
+            os.path.join(usr_local_bin, "tf-script4"), 0o775
+        )
+        self.assertEqual(mock_chmod.call_count, 2)


### PR DESCRIPTION
## Description
The [tf-cmd-scripts](https://git.launchpad.net/~canonical-hw-cert/hwcert-jenkins-tools/+git/tf-cmd-scripts/tree/) are a set of scripts deployed on agent hosts in HWCert labs. These scripts are used by the `testflinger-agent` to trigger the `testflinger-device-connector` at each phase. Previously, whenever the scripts were updated, a manual pull from the Launchpad Git repository to each agent host was required. This process has become inefficient as the number of labs has increased.

This PR aims to integrate tf-cmd-scripts into the mono repository and automate their deployment in the agent host environment.

## Resolved issues

https://warthogs.atlassian.net/browse/LM-1616?atlOrigin=eyJpIjoiNGE5YTkxMzY5MjkzNDllZTkzZTUyNzYyZmNkZTc4MDgiLCJwIjoiaiJ9

## Documentation

Update README for testflinger-agent-host-charm to introduce tf-cmd-scripts. Also, add a description for Building and Configuration.
Update README for testflinger-agent-charm to reflect the current Configuration.


## Tests

`charmcraft pack` to build the testfligner-agent-host charm. Juju deploy the charm on my laptop and validate all scripts are copied and executable. Also tested the `upgrade-charm` with another local charm packed with modified tf-cmd-scripts and verified the changes were landed in the application.