### PR TITLE
Send provision log data to the server to display on agent-details page

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -259,10 +259,11 @@ class TestflingerAgent:
                         if phase == "provision":
                             detail = ""
                             # Replace with TestEvent enum values once it lands
-                            if exit_code == 46:
-                                detail = "recovery_fail"
-                            if exit_code != 0:
-                                detail = "provision_fail"
+                            detail = (
+                                "recovery_fail"
+                                if exit_code == 46
+                                else "provision_fail"
+                            )
                             self.client.post_provision_log(
                                 job.job_id, exit_code, detail
                             )

--- a/agent/testflinger_agent/client.py
+++ b/agent/testflinger_agent/client.py
@@ -365,3 +365,25 @@ class TestflingerClient:
             )
         except InfluxDBClientError as exc:
             logger.error(exc)
+
+    def post_provision_log(self, job_id: str, exit_code: int, detail: str):
+        """Post the outcome of provisioning to the server
+
+        :param job_id:
+            job_id of the job that was running
+        :param exitcode:
+            exit code from the provision phase
+        :param detail:
+            string with any known details of the failure
+        """
+        data = {
+            "job_id": job_id,
+            "exit_code": exit_code,
+            "detail": detail,
+        }
+        agent_data_uri = urljoin(self.server, "/v1/agents/provision_logs/")
+        agent_data_url = urljoin(agent_data_uri, self.config.get("agent_id"))
+        try:
+            self.session.post(agent_data_url, json=data, timeout=30)
+        except RequestException as exc:
+            logger.warning("Unable to post provision log to server: %s", exc)

--- a/agent/testflinger_agent/tests/test_client.py
+++ b/agent/testflinger_agent/tests/test_client.py
@@ -25,6 +25,7 @@ class TestClient:
     @pytest.fixture
     def client(self):
         config = {
+            "agent_id": "test_agent",
             "server_address": "127.0.0.1:8000",
             "advertised_queues": {"test_queue": "test_queue"},
             "advertised_images": {
@@ -68,6 +69,22 @@ class TestClient:
         assert requests_mock.last_request.json() == {
             "test_queue": {"test_image": "url: http://foo"}
         }
+
+    def test_post_provision_logs(self, client, requests_mock):
+        """Test that /v1/agents/provision_logs is called with the right data"""
+        job_id = "00000000-0000-0000-0000-00000000000"
+        exit_code = 1
+        detail = "provision_failed"
+        requests_mock.post(
+            "http://127.0.0.1:8000/v1/agents/provision_logs/"
+            f"{client.config['agent_id']}",
+            status_code=200,
+        )
+        client.post_provision_log(job_id, exit_code, detail)
+        last_request = requests_mock.last_request.json()
+        assert last_request["job_id"] == job_id
+        assert last_request["exit_code"] == exit_code
+        assert last_request["detail"] == detail
 
     def test_transmit_job_outcome(self, client, requests_mock, tmp_path):
         """

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -117,6 +117,7 @@ class RealSerialLogger:
         with open(self.filename, "a+") as f:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.connect((self.host, self.port))
+                logger.info("Successfully connected to serial logging server")
                 while True:
                     read_sockets, _, _ = select.select([s], [], [])
                     for sock in read_sockets:
@@ -127,7 +128,10 @@ class RealSerialLogger:
                             )
                             f.flush()
                         else:
-                            logger.error("Serial Log connection closed")
+                            logger.error(
+                                "Serial log connection closed - attempts to "
+                                "reconnect will be made in the background"
+                            )
                             return
 
     def stop(self):

--- a/server/README.rst
+++ b/server/README.rst
@@ -341,3 +341,18 @@ This will find jobs tagged with both "foo" and "bar".
   .. code-block:: console
 
     $ curl -X GET http://localhost:8000/v1/agents/data
+
+**[POST] /v1/agents/provision_logs/<agent_name>** - post provision log data for the specified agent
+
+- Status Codes:
+  
+    - HTTP 200 (OK)
+
+- Example:
+
+  .. code-block:: console
+
+    $ curl http://localhost:8000/v1/agents/provision_logs/myagent \
+         -X POST --header "Content-Type: application/json" \
+         --data '{ "job_id": "00000000-0000-0000-0000-000000000000", \
+                   "exit_code": 1, "detail":"foo" }'

--- a/server/devel/create_sample_data.py
+++ b/server/devel/create_sample_data.py
@@ -22,6 +22,7 @@ import logging
 import random
 import sys
 from argparse import ArgumentParser, Namespace
+from datetime import datetime, timezone
 from typing import Iterator, Optional, Tuple
 
 import requests
@@ -195,6 +196,17 @@ class TestflingerClient:
             self.session.post(
                 f"{self.server_url}/v1/agents/data/{agent_name}",
                 json=agent_data,
+            )
+
+            # Add failed provision logs with obviously fake job_id for testing
+            provision_log = {
+                "job_id": "00000000-0000-0000-0000-00000000000",
+                "exit_code": 1,
+                "detail": "provision_fail",
+            }
+            self.session.post(
+                f"{self.server_url}/v1/agents/provision_logs/{agent_name}",
+                json=provision_log,
             )
 
     def post_job_data(self, jobs: Iterator):

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -41,7 +41,7 @@ class ProvisionLogsIn(Schema):
 
     job_id = fields.String(required=True)
     exit_code = fields.Integer(required=True)
-    detail = fields.String(required=True)
+    detail = fields.String(required=False)
 
 
 class AgentIn(Schema):

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -36,6 +36,14 @@ ValidJobStates = (
 )
 
 
+class ProvisionLogsIn(Schema):
+    """Provision logs input schema"""
+
+    job_id = fields.String(required=True)
+    exit_code = fields.Integer(required=True)
+    detail = fields.String(required=True)
+
+
 class AgentIn(Schema):
     """Agent data input schema"""
 

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -18,7 +18,7 @@ Testflinger v1 API
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pkg_resources
 from apiflask import APIBlueprint, abort
@@ -484,6 +484,30 @@ def agents_post(agent_name, json_data):
     database.mongo.db.agents.update_one(
         {"name": agent_name},
         {"$set": json_data, "$push": {"log": {"$each": log, "$slice": -100}}},
+        upsert=True,
+    )
+    return "OK"
+
+
+@v1.post("/agents/provision_logs/<agent_name>")
+@v1.input(schemas.ProvisionLogsIn, location="json")
+def agents_provision_logs_post(agent_name, json_data):
+    """Post provision logs for the agent to the server"""
+    agent_record = {}
+
+    # timestamp this agent record and provision log entry
+    timestamp = datetime.now(timezone.utc)
+    agent_record["updated_at"] = json_data["timestamp"] = timestamp
+
+    update_operation = {
+        "$set": json_data,
+        "$push": {
+            "provision_log": {"$each": [json_data], "$slice": -100},
+        },
+    }
+    database.mongo.db.provision_logs.update_one(
+        {"name": agent_name},
+        update_operation,
         upsert=True,
     )
     return "OK"

--- a/server/src/templates/agent_detail.html
+++ b/server/src/templates/agent_detail.html
@@ -36,6 +36,31 @@
     {% endfor %}
 </ul>
 
+<h2 class="p-muted-heading">Provision History</h2>
+<div>
+    <table>
+        <thead>
+            <tr>
+                <th style="width: 150pt">Timestamp</th>
+                <th style="width: 300pt">Job ID</th>
+                <th class="p-table__cell--icon-placeholder" style="width: 75pt">Status</th>
+                <th>Detail</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for log in agent.provision_log|reverse %}
+            <tr>
+                <td>{{ log.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                <td><a href="/jobs/{{ log.job_id }}">{{ log.job_id }}</a></td>
+                <td class="u-align--right p-table__cell--icon-placeholder"><i class={{ 'p-icon--success' if
+                        log.exit_code==0 else 'p-icon--error' }}></i>{{ log.exit_code }}</td>
+                <td>{{ log.detail }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
 <h2 class="p-muted-heading">Agent Log</h2>
 <div class="p-code-snippet">
     <div class="scrollable">

--- a/server/src/templates/agent_detail.html
+++ b/server/src/templates/agent_detail.html
@@ -41,7 +41,7 @@
     <table>
         <thead>
             <tr>
-                <th style="width: 150pt">Timestamp</th>
+                <th style="width: 150pt">Finished At</th>
                 <th style="width: 300pt">Job ID</th>
                 <th class="p-table__cell--icon-placeholder" style="width: 75pt">Status</th>
                 <th>Detail</th>

--- a/server/src/views.py
+++ b/server/src/views.py
@@ -53,6 +53,13 @@ def agent_detail(agent_id):
         )
         response.status_code = 404
         return response
+    provision_log_entry = mongo.db.provision_logs.find_one(
+        {"name": agent_id}, {"provision_log": 1}
+    )
+    agent_info["provision_log"] = (
+        provision_log_entry["provision_log"] if provision_log_entry else []
+    )
+
     return render_template("agent_detail.html", agent=agent_info)
 
 

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -36,4 +36,4 @@ commands =
 
 [testenv:unit]
 commands =
-    {envbindir}/python -m pytest --doctest-modules --ignore testflinger.py --cov=.
+    {envbindir}/python -m pytest --ignore testflinger.py --cov=.


### PR DESCRIPTION
## Description

This adds some additional logging for the previous provision attempts in the agent-details page. When provisioning on an agent passes, or fails, we log this so that you can browse to the agent-details page and find out if it has typically been provisioning successfully or unsuccessfully lately. This can provide valuable insight if you are wondering if a failure to provision a particular device is a fluke, or if it has been failing all of the recent attempts.

![image](https://github.com/canonical/testflinger/assets/1255513/ffd81d1b-8390-4a32-b54b-14410d566b87)


## Resolved issues

CERTTF-326

## Documentation
It's used internally through the agent, nothing extra needed from a user standpoint. However the API documentation has been updated through the schema so that swagger-docs are updated. README.rst for server was also updated with the new API.

## Web service API changes

- Are there new endpoints introduced? Please detail for each of them...

Yes, `[POST] /v1/agents/provision_logs/<agent_name>` was added for posting a json event log for the provision phase.
I considered reusing the existing `[POST] /v1/agents/data/<agent_name>` API, but decided against it for two reasons:
1. That one is for pushing general agent data such as name, queues it knows about, etc. This isn't likely to change and typically only gets updated when the agent comes online. Pushing provision logs will happen every time it attempts to provision the device, and these events do not coincide
2. With a nosql db, the typical pattern is to store all related data together, but in this case, it made more sense to create a new collection for the provision_logs. Mostly, because from an API side, we would have had a mixture of things like the name and list of queues that simply get replaced. However with the provision_log, you will be adding to an array of log messages (capped at 100 latest entries), or creating it if it doesn't exist. So if we used the previous API, we would have to handle the data differently depending on what type of data we received

I used POST for this, which is somewhat generic. We didn't get too picky with post vs patch vs put in v1 of the API, perhaps something to re-examine in v2 someday. In this case, I think a good argument could be made for patch also, but I felt like post was better since we're not really "patching" (or updating" some subset of the values, instead we're adding new data to an array/list.

If we do ever choose to modify or deprecate this API, it should be pretty straightforward. It's only expected to be used by the agents, not the end user or cli. 

## Tests

Unit tests were added, as well as local testing. I made some changes to the `create_sample_data.py`  script to also inject some failed provision events. You can call this script with a local server setup. It will use the API on the server you point it at to create fake data and inject those provision_log events so that you can see that they show up in the db and ui.
