### PR TITLE
Nicer handling of job not found on the job details view

### DIFF
--- a/server/src/templates/job_not_found.html
+++ b/server/src/templates/job_not_found.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% set active_page = 'jobs' %}
+{% block content %}
+<div class="p-strip is-shallow">
+    <div class="row">
+        <h1 class="p-heading--3">
+            Job not found: {{ job_id }}
+        </h1>
+    </div>
+</div>
+{% endblock %}

--- a/server/src/views.py
+++ b/server/src/views.py
@@ -67,6 +67,12 @@ def jobs():
 def job_detail(job_id):
     """Job detail view"""
     job_data = mongo.db.jobs.find_one({"job_id": job_id})
+    if not job_data:
+        response = make_response(
+            render_template("job_not_found.html", job_id=job_id)
+        )
+        response.status_code = 404
+        return response
     return render_template("job_detail.html", job=job_data)
 
 

--- a/server/src/views.py
+++ b/server/src/views.py
@@ -69,9 +69,8 @@ def job_detail(job_id):
     job_data = mongo.db.jobs.find_one({"job_id": job_id})
     if not job_data:
         response = make_response(
-            render_template("job_not_found.html", job_id=job_id)
+            render_template("job_not_found.html", job_id=job_id), 404
         )
-        response.status_code = 404
         return response
     return render_template("job_detail.html", job=job_data)
 

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -19,7 +19,7 @@ Unit tests for Testflinger views
 
 import mongomock
 from mock import patch
-from src.views import queues_data, agent_detail
+from src.views import job_detail, queues_data, agent_detail
 
 
 def test_queues():
@@ -95,4 +95,18 @@ def test_agent_not_found(testapp):
             response = agent_detail("agent1")
 
     assert "Agent not found: agent1" in str(response.data)
+    assert response.status_code == 404
+
+
+def test_job_not_found(testapp):
+    """
+    Test that the job_detail fails gracefully when a job is not found
+    """
+
+    mongo = mongomock.MongoClient()
+    with patch("src.views.mongo", mongo):
+        with testapp.test_request_context():
+            response = job_detail("job1")
+
+    assert "Job not found: job1" in str(response.data)
     assert response.status_code == 404


### PR DESCRIPTION
## Description
You won't get there accidentally by clicking, but if you try to go to the job details page for an invalid job_id, you'll get a confusing error response of `Unhandled Exception: 'None' has no attribute 'job_data' ` and it'll hit the server logs as an error because we aren't handling it. This just makes a nicer 404 page for it like we did for the similar situation with agent details

## Resolved issues
N/A

## Documentation
N/A

## Web service API changes
N/A

## Tests
Added unit test and also tested locally
