### PR TITLE
Set timeout for flashing on muxpi back to 30 min.

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -296,7 +296,7 @@ class MuxPi:
             logger.info(
                 f"Flashing Test image {source.name} on {self.test_device}"
             )
-            self.transfer_test_image(local=source, timeout=1200)
+            self.transfer_test_image(local=source, timeout=1800)
         else:
             # the source is a URL
             with tempfile.NamedTemporaryFile(delete=True) as source_file:


### PR DESCRIPTION
## Description

This sets the timeout for flashing images back to 30min. as there are reports of some larger images timing out on some devices.

## Resolved issues

Issue #297 

## Documentation
N/A

## Web service API changes
N/A

## Tests
N/A
