### PR TITLE
Fix riverside errors on muxpi

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -309,7 +309,7 @@ class MuxPi:
                 logger.info(
                     f"Flashing Test image {url_name} on {self.test_device}"
                 )
-                self.transfer_test_image(local=source_file.name, timeout=1200)
+                self.transfer_test_image(local=source_file.name, timeout=1800)
 
         try:
             self._run_control("sync")

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -195,12 +195,15 @@ class MuxPi:
             self._run_control(cmd)
         else:
             media = self.job_data["provision_data"]["media"]
+            # If media option is provided, then DUT is probably capable of
+            # booting from different media, we should switch both of them
+            # to TS side regardless of which one was previously used
             try:
-                # If media option is provided, then DUT is probably capable of
-                # booting from different media, we should switch both of them
-                # to TS side regardless of which one was previously used
                 cmd = "zapper sdwire plug_to_self"
                 sd_node = self._run_control(cmd)
+            except Exception:
+                pass
+            try:
                 cmd = "zapper typecmux plug_to_self"
                 usb_node = self._run_control(cmd)
             except Exception:


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
* #296 
* #297 
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
