### PR TITLE
Fix missing exit code if we fall through to the finally block

### DIFF
--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -118,8 +118,10 @@ class TestflingerJob:
             runner.run(f"echo '{line}'")
         try:
             exitcode, exit_reason = runner.run(cmd)
-        except Exception as e:
-            logger.exception(e)
+        except Exception as exc:
+            logger.exception(exc)
+            exitcode = 100
+            exit_reason = str(exc)  # noqa: F841 - ignore this until it's used
         finally:
             self._update_phase_results(
                 results_file, phase, exitcode, output_log, serial_log


### PR DESCRIPTION
## Description
Unlikely and hard to trigger, but if we hit an error here and then drop to the finally block, then we will be missing some data that it needs when it tries to update the phase results.

## Resolved issues

Described above. There's a small flake8 thing that I worked around for now because I think it's useful to include the exception in the details if we hit this. When the PR from @val500 lands, then we can remove the `noqa` comment.

## Documentation

N/A

## Web service API changes
N/A

## Tests
Should be obvious from inspection, but also added a unit test
