### PR TITLE
timeout muxpi hdparm after 40s to workaround usb reset

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -320,7 +320,7 @@ class MuxPi:
         try:
             self._run_control(
                 "sudo hdparm -z {}".format(self.test_device),
-                timeout=30,
+                timeout=40,
             )
         except Exception as error:
             raise ProvisioningError(


### PR DESCRIPTION
On some zapper-connected devices, there's an occasional usb reset that seems to happen while running hdparm -z. When this happens, it makes the hdparm command take about 32s when it normally doesn't even take 1s. Since we aren't seeing other negative effects from this so far, let's extend the timeout a bit so that provisioning works while we debug this further

## Description


## Resolved issues
Some devices are failing to provision because the usb reset is causing hdparm to timeout prematurely.

## Documentation
N/A

## Web service API changes
N/A

## Tests
Kevin and I both reproduced the problem and found that it consistently takes 31-32s when it hits this problem. So 40s should be more than enough.
