### PR TITLE
Fix an issue where we might not post the provision log unless it fails

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -250,23 +250,19 @@ class TestflingerAgent:
 
                     self.client.post_influx(phase, exit_code)
 
-                    # exit code 46 is our indication that recovery failed!
-                    # In this case, we need to mark the device offline
-                    if exit_code == 46:
-                        self.mark_device_offline()
+                    if phase == "provision":
+                        # exit code 46 is our indication that recovery failed!
+                        # In this case, we need to mark the device offline
+                        if exit_code == 46:
+                            self.mark_device_offline()
+                            # Replace with TestEvent enum values once it lands
+                            detail = "recovery_fail"
+                        detail = "provision_fail" if exit_code else ""
+                        self.client.post_provision_log(
+                            job.job_id, exit_code, detail
+                        )
                     if phase != "test" and exit_code:
                         logger.debug("Phase %s failed, aborting job" % phase)
-                        if phase == "provision":
-                            detail = ""
-                            # Replace with TestEvent enum values once it lands
-                            detail = (
-                                "recovery_fail"
-                                if exit_code == 46
-                                else "provision_fail"
-                            )
-                            self.client.post_provision_log(
-                                job.job_id, exit_code, detail
-                            )
                         break
             except Exception as e:
                 logger.exception(e)


### PR DESCRIPTION
## Description
When testing on staging, I noticed that the provision log might only get updated if the provision fails. That's not quite what we want, we also want to record the successful attempts. I updated this in staging also and confirmed it was showing both successful and unsuccessful provision attempts:
![image](https://github.com/canonical/testflinger/assets/1255513/c9315f5b-4934-4bb4-8913-90caf35b2383)


## Resolved issues
see above

## Documentation
see above

## Web service API changes
None

## Tests
See above
