### PR TITLE
Add: support for live ISOs to zapper_kvm connector

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -56,5 +56,5 @@ Support for live ISOs is simply performed booting from an external storage devic
 ### Job parameters
 
 - __boot_from_ext_media__: Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions defined by the specified `robot_tasks`, without needing to unplug the external media.
-- __wait_until_ssh__: If set to "true", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.
+- __wait_until_ssh__: If set to "false", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -55,6 +55,6 @@ Support for live ISOs is simply performed booting from an external storage devic
 
 ### Job parameters
 
-- __boot_from_ext_media__: Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions defined by the specified `robot_tasks`, without needing to unplug the external media.
+- __live_image__: Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions defined by the specified `robot_tasks`, without needing to unplug the external media.
 - __wait_until_ssh__: If set to "false", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -2,10 +2,12 @@
 
 Zapper-driven provisioning method that makes use of KVM assertions and actions.
 
-## Ubuntu Desktop / Server
+
+## Autoinstall based
 
 Support for vanilla Ubuntu is provided by [autoinstall](https://canonical-subiquity.readthedocs-hosted.com/en/latest/intro-to-autoinstall.html). Supported Ubuntu versions are:
 
+- Core24
 - Desktop >= 23.04
 - Server >= 20.04
 
@@ -16,7 +18,7 @@ Unless specified via _autoinstall_ storage filter, the tool will select the larg
 - __url__: URL to the image to install
 - __username__: username to configure
 - __password__: password to configure
-- **storage_layout**: can be either `lvm`, `direct`, `zfs` or `hybrid` (Desktop 23.10+)
+- **storage_layout**: can be either `lvm`, `direct`, `zfs` or `hybrid` (Core, Desktop 23.10+)
 - **robot_tasks**: list of Zapper Robot tasks to run after a hard reset in order to follow the `autoinstall` installation
 - **cmdline_append** (optional): kernel parameters to append at the end of GRUB entry cmdline
 - **base_user_data** (optional): a custom base user-data file, it should be validated against [this schema](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-schema.html)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -7,7 +7,7 @@ Zapper-driven provisioning method that makes use of KVM assertions and actions.
 
 Support for vanilla Ubuntu is provided by [autoinstall](https://canonical-subiquity.readthedocs-hosted.com/en/latest/intro-to-autoinstall.html). Supported Ubuntu versions are:
 
-- Core24
+- Core24 (experimental)
 - Desktop >= 23.04
 - Server >= 20.04
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -55,6 +55,6 @@ Support for live ISOs is simply performed booting from an external storage devic
 
 ### Job parameters
 
-- __boot_from_ext_media__: Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions, without needing to unplug the external media.
+- __boot_from_ext_media__: Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions defined by the specified `robot_tasks`, without needing to unplug the external media.
 - __wait_until_ssh__: If set to "true", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -48,3 +48,13 @@ The tool will select the storage device with the following priority:
 ### Noble
 
 Ubuntu OEM 24.04 uses `autoinstall`. The procedure and the arguments are the same as _vanilla_ Ubuntu.
+
+## Live ISO
+
+Support for live ISOs is simply performed booting from an external storage device and returning.
+
+### Job parameters
+
+- __boot_from_ext_media__: should be set to "true"
+- __wait_until_ssh__: SSH assertion at the end of provisioning can be skipped, in case the live ISO does not include an SSH server
+

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -51,10 +51,10 @@ Ubuntu OEM 24.04 uses `autoinstall`. The procedure and the arguments are the sam
 
 ## Live ISO
 
-Support for live ISOs is simply performed booting from an external storage device and returning.
+Support for live ISOs is simply performed booting from an external storage device and returning right after KVM interactions.
 
 ### Job parameters
 
-- __boot_from_ext_media__: should be set to "true"
-- __wait_until_ssh__: SSH assertion at the end of provisioning can be skipped, in case the live ISO does not include an SSH server
+- __boot_from_ext_media__: Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions, without needing to unplug the external media.
+- __wait_until_ssh__: If set to "true", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -94,7 +94,7 @@ class DeviceConnector(ZapperConnector):
             "cmdline_append",
             "skip_download",
             "wait_until_ssh",
-            "boot_from_ext_media",
+            "live_image",
         ]
         provisioning_data.update(
             {

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -81,18 +81,28 @@ class DeviceConnector(ZapperConnector):
             "url": url,
             "username": username,
             "password": password,
+            "robot_retries": retries,
             "autoinstall_conf": self._get_autoinstall_conf(),
             "reboot_script": self.config["reboot_script"],
             "device_ip": self.config["device_ip"],
             "robot_tasks": self.job_data["provision_data"]["robot_tasks"],
-            "robot_retries": retries,
-            "cmdline_append": self.job_data["provision_data"].get(
-                "cmdline_append", ""
-            ),
-            "skip_download": self.job_data["provision_data"].get(
-                "skip_download", False
-            ),
         }
+
+        # Let's handle defaults on the Zapper side adding only the explicitely
+        # specified keys to the `provision_data` dict.
+        optionals = [
+            "cmdline_append",
+            "skip_download",
+            "wait_until_ssh",
+            "boot_from_ext_media",
+        ]
+        provisioning_data.update(
+            {
+                opt: self.job_data["provision_data"][opt]
+                for opt in optionals
+                if opt in self.job_data["provision_data"]
+            }
+        )
 
         return ((), provisioning_data)
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -17,7 +17,7 @@
 import logging
 import os
 import subprocess
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.zapper import ZapperConnector
@@ -36,14 +36,14 @@ class DeviceConnector(ZapperConnector):
 
     PROVISION_METHOD = "ProvisioningKVM"
 
-    def _get_autoinstall_conf(self) -> Dict[str, Any]:
+    def _get_autoinstall_conf(self) -> Optional[Dict[str, Any]]:
         """Prepare autoinstall-related configuration."""
         provision = self.job_data["provision_data"]
 
-        autoinstall_conf = {
-            "storage_layout": provision.get("storage_layout", "lvm"),
-        }
+        if "storage_layout" not in provision:
+            return None
 
+        autoinstall_conf = {"storage_layout": provision["storage_layout"]}
         if "base_user_data" in provision:
             autoinstall_conf["base_user_data"] = provision["base_user_data"]
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -88,7 +88,7 @@ class DeviceConnector(ZapperConnector):
             "robot_tasks": self.job_data["provision_data"]["robot_tasks"],
         }
 
-        # Let's handle defaults on the Zapper side adding only the explicitely
+        # Let's handle defaults on the Zapper side adding only the explicitly
         # specified keys to the `provision_data` dict.
         optionals = [
             "cmdline_append",

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -89,7 +89,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                 "cmdline_append": "more arguments",
                 "skip_download": True,
                 "wait_until_ssh": True,
-                "boot_from_ext_media": False,
+                "live_image": False,
             },
             "test_data": {
                 "test_username": "username",
@@ -112,7 +112,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "cmdline_append": "more arguments",
             "skip_download": True,
             "wait_until_ssh": True,
-            "boot_from_ext_media": False,
+            "live_image": False,
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -59,8 +59,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "device_ip": "1.1.1.1",
             "robot_tasks": ["job.robot", "another.robot"],
             "robot_retries": 1,
-            "cmdline_append": "",
-            "skip_download": False,
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
@@ -90,6 +88,8 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                 "robot_retries": 3,
                 "cmdline_append": "more arguments",
                 "skip_download": True,
+                "wait_until_ssh": True,
+                "boot_from_ext_media": False,
             },
             "test_data": {
                 "test_username": "username",
@@ -111,6 +111,8 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "robot_retries": 3,
             "cmdline_append": "more arguments",
             "skip_download": True,
+            "wait_until_ssh": True,
+            "boot_from_ext_media": False,
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
@@ -159,8 +161,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "device_ip": "1.1.1.1",
             "robot_tasks": ["job.robot", "another.robot"],
             "robot_retries": 2,
-            "cmdline_append": "",
-            "skip_download": False,
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -165,6 +165,33 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
+    def test_get_autoinstall_none(self):
+        """
+        Test whether the get_autoinstall_conf function returns
+        None in case the storage_layout is not specified.
+        """
+
+        connector = DeviceConnector()
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "robot_tasks": [
+                    "job.robot",
+                    "another.robot",
+                ],
+            },
+            "test_data": {
+                "test_username": "username",
+                "test_password": "password",
+            },
+        }
+
+        with patch("builtins.open", mock_open(read_data="mykey")):
+            conf = connector._get_autoinstall_conf()
+
+        self.assertIsNone(conf)
+
     def test_get_autoinstall_conf(self):
         """
         Test whether the get_autoinstall_conf function returns

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -26,6 +26,7 @@ Git
 GitHub
 Grafana
 IAM
+ISOs
 init
 installable
 Instantiation

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -314,3 +314,20 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
     * - ``oem``
       - Optional value to select the ``oemscript`` to run when specifying a ``url``, possible values
         are ``dell``, ``hp`` and ``lenovo``.
+
+.. list-table:: Supported ``provision_data`` keys for ``zapper_kvm`` with target any generic live ISOs
+    :header-rows: 1
+
+    * - Key
+      - Description
+    * - ``url``
+      - URL to a disk image that is downloaded and flashed to a USB storage device,
+        which will be used to boot up the DUT.
+    * - ``robot_tasks``
+      - List of Zapper/Robot snippets to run in sequence after the USB storage device
+        is plugged into the DUT and the system restarted. The snippet ID is the relative
+        path from the ``robot/snippets`` path in the Zapper repository.
+    * - ``boot_from_ext_media``
+      - keeps the external storage device connected, booting from there. It should be flagged as `true` for live ISOs.
+    * - ``wait_until_ssh``
+      - if `true`, skip the attempt to connect via SSH at the end of provisionig, useful in case the live ISO does not include a SSH server

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -322,12 +322,12 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
       - Description
     * - ``url``
       - URL to a disk image that is downloaded and flashed to a USB storage device,
-        which will be used to boot up the DUT.
+        which the DUT will then boot from.
     * - ``robot_tasks``
-      - List of Zapper/Robot snippets to run in sequence after the USB storage device
+      - List of Robot snippets to run in sequence after the USB storage device
         is plugged into the DUT and the system restarted. The snippet ID is the relative
         path from the ``robot/snippets`` path in the Zapper repository.
     * - ``boot_from_ext_media``
-      - Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions, without needing to unplug the external media.
+      - Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions defined by the specified `robot_tasks`, without needing to unplug the external media.
     * - ``wait_until_ssh``
       - If set to "true", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -330,4 +330,4 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
     * - ``boot_from_ext_media``
       - keeps the external storage device connected, booting from there. It should be flagged as `true` for live ISOs.
     * - ``wait_until_ssh``
-      - if `true`, skip the attempt to connect via SSH at the end of provisionig, useful in case the live ISO does not include a SSH server
+      - if `true`, skip the attempt to connect via SSH at the end of provisioning, useful in case the live ISO does not include a SSH server

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -284,7 +284,7 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
         path from the ``robot/snippets`` path in the Zapper repository.
     * - ``storage_layout``
       - When provisioning an image supporting *autoinstall*, the storage_layout can
-        be either ``lvm`` (default), ``direct``, ``zfs`` or ``hybrid`` (Desktop 23.10+)
+        be either ``lvm`` (default), ``direct``, ``zfs`` or ``hybrid`` (Core, Desktop 23.10+)
     * - ``cmdline_append``
       - When provisioning an image supporting *autoinstall*, the cmdline_append can
         be used to append Kernel parameters to the standard GRUB entry.

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -328,6 +328,6 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
         is plugged into the DUT and the system restarted. The snippet ID is the relative
         path from the ``robot/snippets`` path in the Zapper repository.
     * - ``boot_from_ext_media``
-      - keeps the external storage device connected, booting from there. It should be flagged as `true` for live ISOs.
+      - Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions, without needing to unplug the external media.
     * - ``wait_until_ssh``
-      - if `true`, skip the attempt to connect via SSH at the end of provisioning, useful in case the live ISO does not include a SSH server
+      - If set to "true", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -327,7 +327,7 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
       - List of Robot snippets to run in sequence after the USB storage device
         is plugged into the DUT and the system restarted. The snippet ID is the relative
         path from the ``robot/snippets`` path in the Zapper repository.
-    * - ``boot_from_ext_media``
+    * - ``live_image``
       - Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions defined by the specified `robot_tasks`, without needing to unplug the external media.
     * - ``wait_until_ssh``
       - If set to "false", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -330,4 +330,4 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
     * - ``boot_from_ext_media``
       - Set to "true" to ensure that the Zapper considers the provision process complete at the end of KVM interactions defined by the specified `robot_tasks`, without needing to unplug the external media.
     * - ``wait_until_ssh``
-      - If set to "true", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.
+      - If set to "false", the Zapper will skip the SSH connection attempt, which is normally performed at the end of provisioning as a form of boot assertion. This is primarily useful in cases where the live ISO does not include an SSH server.


### PR DESCRIPTION
~~Pending review of [the Zapper counterpart](https://github.com/canonical/zapper/pull/294).~~

## Description

This PR updates the zapper_kvm connector with support for provisioning a live ISO. Two new arguments make that possible:
1. `boot_from_ext_media`: which should be true, so that the USB stick is kept connected to the DUT side
2. `wait_until_ssh`: which defaults to true, but it might me useful if the live ISO does not have a SSH server available at boot

## Resolved issues

Part of [ZAP-840](https://warthogs.atlassian.net/browse/ZAP-840)

## Documentation

Updated adding a section for the "live ISO" specific parameters

## Web service API changes

N/A

## Tests

Tested with Zapper by running the corresponding API. An example job using TF would be:

```
job_queue: 202207-30464
global_timeout: 18000
output_timeout: 1800

provision_data:
  url: https://releases.ubuntu.com/noble/ubuntu-24.04-desktop-amd64.iso
  robot_tasks:
    - hp/pro/sff_400_g9/boot/boot_from_usb.robot
    - common/grub/stop/stop_at_grub.robot
  boot_from_ext_media: true
  wait_until_ssh: false
  skip_download: true  # USB stick already flashed for testing
```


[ZAP-840]: https://warthogs.atlassian.net/browse/ZAP-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ