### PR TITLE
Display the number of consecutive failed provsion attempts on the agents page

### DIFF
--- a/server/devel/create_sample_data.py
+++ b/server/devel/create_sample_data.py
@@ -199,10 +199,14 @@ class TestflingerClient:
             )
 
             # Add failed provision logs with obviously fake job_id for testing
+            exit_code = random.choice((0, 1))
+            exit_detail = (
+                "provision_fail" if exit_code != 0 else "provision_pass"
+            )
             provision_log = {
                 "job_id": "00000000-0000-0000-0000-00000000000",
-                "exit_code": 1,
-                "detail": "provision_fail",
+                "exit_code": exit_code,
+                "detail": exit_detail,
             }
             self.session.post(
                 f"{self.server_url}/v1/agents/provision_logs/{agent_name}",

--- a/server/src/database.py
+++ b/server/src/database.py
@@ -19,6 +19,7 @@ This returns a db object for talking to MongoDB
 
 import os
 import urllib
+from datetime import datetime
 from typing import Any
 
 from flask_pymongo import PyMongo
@@ -186,3 +187,48 @@ def pop_job(queue_list):
     job_id = response["job_id"]
     job["job_id"] = job_id
     return job
+
+
+def get_provision_log(
+    agent_id: str, start_datetime: datetime, stop_datetime: datetime
+) -> list:
+    """Get the provision log for an agent between two dates"""
+    provision_log_entries = mongo.db.provision_logs.aggregate(
+        [
+            {"$match": {"name": agent_id}},
+            {
+                "$project": {
+                    "provision_log": {
+                        "$filter": {
+                            "input": "$provision_log",
+                            "as": "log",
+                            "cond": {
+                                "$and": [
+                                    {
+                                        "$gte": [
+                                            "$$log.timestamp",
+                                            start_datetime,
+                                        ]
+                                    },
+                                    {
+                                        "$lt": [
+                                            "$$log.timestamp",
+                                            stop_datetime,
+                                        ]
+                                    },
+                                ]
+                            },
+                        }
+                    }
+                }
+            },
+        ]
+    )
+    # Convert the aggregated result to a list of logs
+    provision_log_entries = list(provision_log_entries)
+
+    return (
+        provision_log_entries[0]["provision_log"]
+        if provision_log_entries
+        else []
+    )

--- a/server/src/static/assets/js/filter.js
+++ b/server/src/static/assets/js/filter.js
@@ -13,3 +13,98 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 });
+
+function sortTable(header, table) {
+  var SORTABLE_STATES = {
+    none: 0,
+    ascending: -1,
+    descending: 1,
+    ORDER: ['none', 'ascending', 'descending'],
+  };
+
+  // Get index of column based on position of header cell in <thead>
+  // We assume there is only one row in the table head.
+  var col = [].slice.call(table.tHead.rows[0].cells).indexOf(header);
+
+  // Based on the current aria-sort value, get the next state.
+  var newOrder = SORTABLE_STATES.ORDER.indexOf(header.getAttribute('aria-sort')) + 1;
+  newOrder = newOrder > SORTABLE_STATES.ORDER.length - 1 ? 0 : newOrder;
+  newOrder = SORTABLE_STATES.ORDER[newOrder];
+
+  // Reset all header sorts.
+  var headerSorts = table.querySelectorAll('[aria-sort]');
+
+  for (var i = 0, ii = headerSorts.length; i < ii; i += 1) {
+    headerSorts[i].setAttribute('aria-sort', 'none');
+  }
+
+  // Set the new header sort.
+  header.setAttribute('aria-sort', newOrder);
+
+  // Get the direction of the sort and assume only one tbody.
+  // For this example only assume one tbody.
+  var direction = SORTABLE_STATES[newOrder];
+  var body = table.tBodies[0];
+
+  // Convert the HTML element list to an array.
+  var newRows = [].slice.call(body.rows, 0);
+
+  // If the direction is 0 - aria-sort="none".
+  if (direction === 0) {
+    // Reset to the default order.
+    newRows.sort(function (a, b) {
+      return a.getAttribute('data-index') - b.getAttribute('data-index');
+    });
+  } else {
+    // Sort based on a cell contents
+    newRows.sort(function (rowA, rowB) {
+      // Trim the cell contents.
+      var contentA = rowA.cells[col].textContent.trim();
+      var contentB = rowB.cells[col].textContent.trim();
+
+      // Based on the direction, do the sort.
+      //
+      // This example only sorts based on alphabetical order, to sort based on
+      // number value a more specific implementation would be needed, to provide
+      // number parsing and comparison function between text strings and numbers.
+      return contentA < contentB ? direction : -direction;
+    });
+  }
+  // Append each row into the table, replacing the current elements.
+  for (i = 0, ii = body.rows.length; i < ii; i += 1) {
+    body.appendChild(newRows[i]);
+  }
+}
+
+function setupClickableHeader(table, header) {
+  header.addEventListener('click', function () {
+    sortTable(header, table);
+  });
+}
+
+/**
+ * Initializes a sortable table by assigning event listeners to sortable column headers.
+ * @param {HTMLTableElement} table
+ */
+function setupSortableTable(table) {
+  // For this example, assume only one tbody.
+  var rows = table.tBodies[0].rows;
+  // Set an index for the default order.
+  for (var row = 0, totalRows = rows.length; row < totalRows; row += 1) {
+    rows[row].setAttribute('data-index', row);
+  }
+
+  // Select sortable column headers.
+  var clickableHeaders = table.querySelectorAll('th[aria-sort]');
+  // Attach the click event for each header.
+  for (var i = 0, ii = clickableHeaders.length; i < ii; i += 1) {
+    setupClickableHeader(table, clickableHeaders[i]);
+  }
+}
+
+// Make all tables on the page sortable.
+var tables = document.querySelectorAll('table');
+
+for (var i = 0, ii = tables.length; i < ii; i += 1) {
+  setupSortableTable(tables[i]);
+}

--- a/server/src/templates/agent_detail.html
+++ b/server/src/templates/agent_detail.html
@@ -37,6 +37,24 @@
 </ul>
 
 <h2 class="p-muted-heading">Provision History</h2>
+<form action="" method="get" class="p-form--inline">
+    <div class="p-form__group">
+        <label for="start-date" class="p-form__label">Start Date</label>
+        <input type="date" id="start-date" name="start" class="p-form__control"
+            value="{{ request.args.get('start', agent.start) }}">
+    </div>
+    <div class="p-form__group">
+        <label for="stop-date" class="p-form__label">Stop Date</label>
+        <input type="date" id="stop-date" name="stop" class="p-form__control"
+            value="{{ request.args.get('stop', agent.stop) }}">
+    </div>
+    <button type="submit" class="p-button--positive">Refresh</button>
+</form>
+
+<div>
+    <strong>Provision success rate for this range:</strong> {{ agent.provision_success_rate }}%
+</div>
+
 <div>
     <table>
         <thead>

--- a/server/src/templates/agents.html
+++ b/server/src/templates/agents.html
@@ -32,13 +32,20 @@
         {% for agent in agents %}
         <tr class="searchable-row">
             <td class="has-overflow">
-                {% if agent.recent_failed_provisions and agent.recent_failed_provisions > 1 %}
+                {% if agent.provision_streak_type == "fail" and agent.provision_streak_count > 0 %}
                 <span class="p-tooltip--right" aria-describedby="tooltip">
                     <i class="p-icon--warning"></i>
                     <span class="p-tooltip__message" role="tooltip" id="tooltip">This agent has failed the last {{
-                        agent.recent_failed_provisions }} provision attempts</span>
+                        agent.provision_streak_count }} provision attempts</span>
                 </span>
-                {{ agent.recent_failed_provisions }}
+                {{ agent.provision_streak_count }}
+                {% elif agent.provision_streak_type == "pass" and agent.provision_streak_count > 0 %}
+                <span class="p-tooltip--right" aria-describedby="tooltip">
+                    <i class="p-icon--success"></i>
+                    <span class="p-tooltip__message" role="tooltip" id="tooltip">This agent has passed the last {{
+                        agent.provision_streak_count }} provision attempts</span>
+                </span>
+                {{ agent.provision_streak_count }}
                 {% endif %}
             </td>
             <td><a href="/agents/{{ agent.name }}">{{ agent.name }}</a></td>

--- a/server/src/templates/agents.html
+++ b/server/src/templates/agents.html
@@ -54,5 +54,6 @@
             <td class="u-align--right u-truncate"><a href="/jobs/{{ agent.job_id }}">{{ agent.job_id }}</a></td>
         </tr>
         {% endfor %}
+    </tbody>
 </table>
 {% endblock %}

--- a/server/src/templates/agents.html
+++ b/server/src/templates/agents.html
@@ -20,21 +20,32 @@
 <table aria-label="Agents table" class="p-table--mobile-card">
     <thead>
         <tr>
-            <th>Name</th>
-            <th>State</th>
-            <th>Updated At</th>
+            <th aria-sort="none" class="has-overflow" style="width: 40pt"></th>
+            <!-- Added an empty header for the warning icon column -->
+            <th aria-sort="none">Name</th>
+            <th aria-sort="none">State</th>
+            <th aria-sort="none">Updated At</th>
             <th>Job ID</th>
         </tr>
     </thead>
     <tbody>
         {% for agent in agents %}
         <tr class="searchable-row">
+            <td class="has-overflow">
+                {% if agent.recent_failed_provisions and agent.recent_failed_provisions > 1 %}
+                <span class="p-tooltip--right" aria-describedby="tooltip">
+                    <i class="p-icon--warning"></i>
+                    <span class="p-tooltip__message" role="tooltip" id="tooltip">This agent has failed the last {{
+                        agent.recent_failed_provisions }} provision attempts</span>
+                </span>
+                {{ agent.recent_failed_provisions }}
+                {% endif %}
+            </td>
             <td><a href="/agents/{{ agent.name }}">{{ agent.name }}</a></td>
             <td>{{ agent.state }}</td>
             <td>{{ agent.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
             <td class="u-align--right u-truncate"><a href="/jobs/{{ agent.job_id }}">{{ agent.job_id }}</a></td>
         </tr>
         {% endfor %}
-    </tbody>
 </table>
 {% endblock %}

--- a/server/src/templates/base.html
+++ b/server/src/templates/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %} {% endblock %} - Testflinger</title>
     <!-- Site CSS Files -->
     <link href="/static/assets/css/testflinger.css" rel="stylesheet" />
-    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.5.0.min.css" />
+    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.13.0.min.css" />
     <!-- Don't request favicon -->
     <link rel="icon" href="data:,">
     <!-- Page specific CSS Files -->

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -58,10 +58,3 @@ def testapp():
     """pytest fixture for just the app"""
     app = application.create_flask_app(TestingConfig)
     yield app
-
-
-@pytest.fixture
-def testing_app():
-    """Create an app for testing without using test_client"""
-    app = application.create_flask_app(TestingConfig)
-    yield app

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -21,9 +21,9 @@ import pytest
 from src.application import create_flask_app
 
 
-def test_default_config(testing_app):
+def test_default_config(testapp):
     """Test default config settings"""
-    app = testing_app
+    app = testapp
     assert app.config.get("PROPAGATE_EXCEPTIONS") is True
 
 

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -522,10 +522,19 @@ def test_agents_provision_logs_post(mongo_app):
         <= provision_log_records["provision_log"][0].items()
     )
 
+    # Test recent_failed_provisions is 1 on the agent
+    agent_data = mongo.agents.find_one({"name": agent_name})
+    assert agent_data["recent_failed_provisions"] == 1
+
     # Now we should have two provision log entries
+    provision_log["exit_code"] = 0
     app.post(f"/v1/agents/provision_logs/{agent_name}", json=provision_log)
     provision_log_records = mongo.provision_logs.find_one({"name": agent_name})
     assert len(provision_log_records["provision_log"]) == 2
+
+    # Test that recent_failed_provisions is cleared on the agent
+    agent_data = mongo.agents.find_one({"name": agent_name})
+    assert agent_data["recent_failed_provisions"] == 0
 
 
 def test_get_agents_data(mongo_app):

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -17,6 +17,8 @@
 Unit tests for Testflinger views
 """
 
+from datetime import datetime
+import re
 import mongomock
 from mock import patch
 from src.views import queues_data, agent_detail
@@ -82,6 +84,23 @@ def test_queues():
     assert len(advertised_queue2) == 1
     assert advertised_queue2[0]["description"] == "desc2"
     assert advertised_queue2[0]["numjobs"] == 2
+
+
+def test_agent_detail_no_provision_log(testapp):
+    """
+    Test that the agent detail page doesn't break when there's no provision log
+    """
+
+    mongo = mongomock.MongoClient()
+    mongo.db.agents.insert_one(
+        {"name": "agent1", "updated_at": datetime.now()}
+    )
+    with patch("src.views.mongo", mongo):
+        with testapp.test_request_context():
+            response = agent_detail("agent1")
+
+    pattern = r"Provision success rate for this range:</strong>\s*0%"
+    assert re.search(pattern, response)
 
 
 def test_agent_not_found(testapp):


### PR DESCRIPTION
## Description

Display a warning icon, count, and tooltip for the icon with details if the agent has failed more than 1 consecutive provision attempt for the most recent runs.

Also, columns are sortable now, including the one for the failure counts.

![image](https://github.com/canonical/testflinger/assets/1255513/8d4037f6-0896-458e-9de1-8d327ef1f56e)

## Resolved issues

CERTTF-354

## Documentation
N/A

## Web service API changes
N/A

## Tests
Tested locally (see screenshot) and also added unit tests
