### PR TITLE
[CERTTF-344] Return job ID as output from `submit` composite action

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -83,7 +83,6 @@ runs:
       run: |
         JOB_ID=$(testflinger --server $SERVER submit --quiet "$JOB")
         echo "job id: $JOB_ID"
-        echo "JOB_ID=$JOB_ID" >> $GITHUB_ENV
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
 
     - name: Track the status of the job and mirror its exit status
@@ -91,6 +90,7 @@ runs:
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
+        JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: The Testflinger server to use
     required: false
     default: testflinger.canonical.com
+outputs:
+  id:
+    description: 'The ID of the submitted job'
+    value: ${{ steps.submit.outputs.id }}
 runs:
   using: composite
   steps:
@@ -80,6 +84,7 @@ runs:
         JOB_ID=$(testflinger --server $SERVER submit --quiet "$JOB")
         echo "job id: $JOB_ID"
         echo "JOB_ID=$JOB_ID" >> $GITHUB_ENV
+        echo "id=$JOB_ID" >> $GITHUB_OUTPUT
 
     - name: Track the status of the job and mirror its exit status
       if: inputs.poll == 'true' && inputs.dry-run != 'true'

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If you need to submit a job to a testflinger server through a Github action (ins
 The corresponding step in the workflow would look like this:
 ```
     - name: Submit job
+      id: submit-job
       uses: canonical/testflinger/.github/actions/submit@v1
       with:
         poll: true
@@ -54,6 +55,7 @@ This assumes that there is a previous `create-job` step in the workflow that cre
 Alternatively, you can use the `job` argument (instead of `job-path`) to provide the contents of the job inline:
 ```
     - name: Submit job
+      id: submit-job
       uses: canonical/testflinger/.github/actions/submit@v1
       with:
         poll: true
@@ -61,3 +63,13 @@ Alternatively, you can use the `job` argument (instead of `job-path`) to provide
             ...  # inline YAML for Testflinger job
 ```
 In the latter case, do remember to use escapes for environment variables in the inline text, e.g. `\$DEVICE_IP`.
+
+The `id` of the submitted job is returned as an output of the `submit` action, so you can use it (if you need it)
+in any of the subsequent steps of the workflow:
+
+```
+    - name: Display results
+      run: |
+        testflinger results ${{ steps.submit-job.outputs.id }}"
+```
+In this example, `submit-job` is the step where the `submit` action is used.


### PR DESCRIPTION
## Description

From [CERTTF-344](https://warthogs.atlassian.net/browse/CERTTF-344):

> The [Testflinger “submit” action](https://github.com/canonical/testflinger/blob/main/.github/actions/submit/action.yaml) retrieves the ID of the submitted job and uses it internally across its steps but it does not "return" this ID as an output. However, this job ID might be necessary in subsequent steps of a workflow that uses the “submit” action, e.g. in order to retrieve artifacts or notify Test Observer.

This PR adds the job ID as an output of the `submit` action.

## Resolved issues

Resolves [CERTTF-344](https://warthogs.atlassian.net/browse/CERTTF-344).

## Documentation

A paragraph about the new output of the `submit` action is documented in the corresponding section of the README file. 

## Tests

A [successful run of a test workflow](https://github.com/canonical/hwcert-jenkins-tools/actions/runs/9953784216/job/27500024351) (on the `hwcert-jenkins-tools-repo`) that uses this branch for the `submit` action and then, in a subsequent step, retrieves the ID of the submitted job from the output of the action and displays it.

[CERTTF-344]: https://warthogs.atlassian.net/browse/CERTTF-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CERTTF-344]: https://warthogs.atlassian.net/browse/CERTTF-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ