### PR TITLE
Documentation Link in Dashboard Header

### DIFF
--- a/server/src/templates/base.html
+++ b/server/src/templates/base.html
@@ -18,6 +18,7 @@
     {'name': 'Agents', 'url': '/agents'},
     {'name': 'Jobs', 'url': '/jobs'},
     {'name': 'Queues', 'url': '/queues'},
+    {'name': 'Documentation', 'url': 'https://canonical-testflinger.readthedocs-hosted.com'},
     ] -%}
     {%- set active_page = active_page|default('agents') %}
 


### PR DESCRIPTION
## Description
For CERTTF-334. This change adds a link to the testflinger documentation([https://canonical-testflinger.readthedocs-hosted.com](https://canonical-testflinger.canonical.com/)) in the dashboard.