### PR TITLE
Charm building needs rust in some cases now

### DIFF
--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -6,3 +6,6 @@ bases:
     run-on:
     - name: ubuntu
       channel: "22.04"
+parts:
+  charm:
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]


### PR DESCRIPTION
## Description
Just had a successful build a few days ago and everything was fine, but now it looks like charm building has some dependencies that need rust installed to build them while it's packing the charm. It's described further in https://github.com/canonical/bundle-kubeflow/issues/989 and seems to be fixed for charmcraft 3.x in the future, but for now, it looks like the recommended fix is to add these build-packages to force the installation of them while it builds your charm.

## Resolved issues
See above

## Documentation
N/A

## Web service API changes
N/A

## Tests
Reproduced the problem locally in a container, then confirmed that I can build the charm after applying this fix.
