### PR TITLE
Fixing imx6 recovery install timeout issue

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
@@ -184,9 +184,19 @@ class OemRecovery:
     def check_device_booted(self):
         """Check to see if the device is booted and reachable with ssh"""
         logger.info("Checking to see if the device is available.")
+        try:
+            boot_timeout = self.job_data.get("provision_data", {}).get(
+                "boot_timeout", 3600
+            )
+        except AttributeError:
+            boot_timeout = 3600
+        finally:
+            if boot_timeout < 600:
+                boot_timeout = 600
+
         started = time.time()
         # Wait for provisioning to complete - can take a very long time
-        while time.time() - started < 3600:
+        while time.time() - started < boot_timeout:
             try:
                 time.sleep(90)
                 if (

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -202,12 +202,16 @@ ensure that the system is reachable with ssh before proceeding to the next step.
 oemrecovery
 -----------
 
-The ``oemrecovery`` device connector does not support any ``provision_data`` keys.
-Instead, this device connector uses a preconfigured command to reset the device back
-to its original state. In order to ensure that the provision step is run, and the
-system is reset back to the original state, you can specify any key in this dictionary
-(example: ``skip: false``). If you do not want the provision step to run, you can
-simply leave out the ``provision_data`` section.
+The ``oemrecovery`` device connector supports the following ``provision_data`` keys:
+
+.. list-table:: Supported ``provision_data`` keys for ``oemrecovery``
+   :header-rows: 1
+
+   * - Key
+     - Description
+   * - ``boot_timeout``
+     - A timeout value that waiting for device recovered from reset. The default timeout is
+       3600(s) and the minimum value should be greater than 600(s).
 
 .. _dell_oemscript:
 


### PR DESCRIPTION

## Description


    Due to different platform has different install and system boot time,
    hard coding timeout to 600 is not appropriate, should support assign timeout to device system boot checking.
    howto:
        in job.yaml provide

        provision_data:
            boot_timeout: <time in second>



## Resolved issues


Fixing imx6 recovery install timeout issue

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
    submit task yaml with boot_timeout and verified boot timeout can be updated


