### PR TITLE
Add api and view for queue wait time percentiles

### DIFF
--- a/server/README.rst
+++ b/server/README.rst
@@ -382,3 +382,19 @@ The job_status_webhook parameter is required for this endpoint. Other parameters
     $ curl -X POST \
     -H "Content-Type: application/json" \
     -d '{"agent_id": "agent-00", "job_queue": "myqueue", "job_status_webhook": "http://mywebhook", "events": [{"event_name": "started_provisioning", "timestamp": "2024-05-03T19:11:33.541130+00:00", "detail": "my_detailed_message"}]}' http://localhost:8000/v1/job/00000000-0000-0000-0000-000000000000/events
+
+**[GET] /v1/queues/wait_times** - get wait time metrics - optionally take a list of queues
+
+- Parameters:
+
+  - queue (array): list of queues to get wait time metrics for
+
+- Returns:
+
+  JSON mapping of queue names to wait time metrics
+
+- Example:
+
+  .. code-block:: console
+
+    $ curl http://localhost:8000/v1/queues/wait_times?queue=foo\&queue=bar

--- a/server/src/database.py
+++ b/server/src/database.py
@@ -246,21 +246,34 @@ def get_queue_wait_times(queues: list[str] | None = None) -> list[dict]:
 
 
 def calculate_percentiles(data: list) -> dict:
-    """Calculate the percentiles of the wait times for each queue"""
+    """
+    Calculate the percentiles of the wait times for each queue
+
+    This uses the nearest rank with interpolation method, which can help in
+    cases where the data is not evenly distributed, such as when we might
+    have big gaps between the best and worst case scenarios.
+    """
     if not data:
         return {}
     percentiles = [5, 10, 50, 90, 95]
     data.sort()
     percentile_results = {}
     for percentile in percentiles:
+        # Index is the position in our sorted data that goes with this
+        # percentile
         index = (len(data) - 1) * (percentile / 100.0)
+        # Lower and upper index are the indexes of two closest data points
+        # that are below and above the percentile
         lower_index = int(index)
         upper_index = lower_index + 1
         if upper_index < len(data):
+            # Interpolate the value based on how far the lower and upper
+            # data points are from the percentile
             lower_value = data[lower_index] * (upper_index - index)
             upper_value = data[upper_index] * (index - lower_index)
             percentile_results[percentile] = lower_value + upper_value
         else:
+            # If the upper index is out of bounds, just use the lower value
             percentile_results[percentile] = data[lower_index]
     return percentile_results
 

--- a/server/src/database.py
+++ b/server/src/database.py
@@ -19,7 +19,7 @@ This returns a db object for talking to MongoDB
 
 import os
 import urllib
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from flask_pymongo import PyMongo
@@ -186,7 +186,12 @@ def pop_job(queue_list):
                 ],
             },
             {"$set": {"result_data.job_state": "running"}},
-            projection={"job_id": True, "job_data": True, "_id": False},
+            projection={
+                "job_id": True,
+                "created_at": True,
+                "job_data": True,
+                "_id": False,
+            },
         )
     except TypeError:
         return None
@@ -196,7 +201,68 @@ def pop_job(queue_list):
     job = response["job_data"]
     job_id = response["job_id"]
     job["job_id"] = job_id
+    # Mark the time the job was started
+    started_at = datetime.now(timezone.utc)
+    mongo.db.jobs.update_one(
+        {"job_id": job_id},
+        {"$set": {"started_at": started_at}},
+    )
+    # Save data about the wait time in the queue
+    created_at = response["created_at"]
+    queue = job["job_queue"]
+    save_queue_wait_time(queue, started_at, created_at)
+
     return job
+
+
+def save_queue_wait_time(
+    queue: str, started_at: datetime, created_at: datetime
+):
+    """Save data about the wait time in seconds for the specified queue"""
+    # Ensure that python knows both datestamps are in UTC
+    started_at = started_at.replace(tzinfo=timezone.utc)
+    created_at = created_at.replace(tzinfo=timezone.utc)
+    wait_seconds = (started_at - created_at).seconds
+    mongo.db.queue_wait_times.update_one(
+        {"name": queue},
+        {
+            "$push": {
+                "wait_times": wait_seconds,
+            }
+        },
+        upsert=True,
+    )
+
+
+def get_queue_wait_times(queues: list[str] | None = None) -> list[dict]:
+    """Get the percentiles of wait times for specified queues or all queues"""
+    if not queues:
+        wait_times = mongo.db.queue_wait_times.find({}, {"_id": False})
+    else:
+        wait_times = mongo.db.queue_wait_times.find(
+            {"name": {"$in": queues}}, {"_id": False}
+        )
+    return list(wait_times)
+
+
+def calculate_percentiles(data: list) -> dict:
+    """Calculate the percentiles of the wait times for each queue"""
+    if not data:
+        return {}
+    percentiles = [5, 10, 50, 90, 95]
+    data.sort()
+    percentile_results = {}
+    for percentile in percentiles:
+        index = (len(data) - 1) * (percentile / 100.0)
+        lower_index = int(index)
+        upper_index = lower_index + 1
+        if upper_index < len(data):
+            lower_value = data[lower_index] * (upper_index - index)
+            upper_value = data[upper_index] * (index - lower_index)
+            percentile_results[percentile] = lower_value + upper_value
+        else:
+            percentile_results[percentile] = data[lower_index]
+    return percentile_results
 
 
 def get_provision_log(

--- a/server/src/templates/queue_detail.html
+++ b/server/src/templates/queue_detail.html
@@ -16,6 +16,11 @@
         </tr>
     </tbody>
 </table>
+<div class="p-strip is-shallow" style="margin-top: 1rem;">
+    <div class="row">
+        <h2 class="p-heading--4">Jobs</h2>
+    </div>
+</div>
 <table aria-label="Agents table" class="p-table--mobile-card">
     <thead>
         <tr>
@@ -34,5 +39,25 @@
         {% endfor %}
     </tbody>
 </table>
-
+<div class="p-strip is-shallow">
+    <div class="row">
+        <h2 class="p-heading--4">Wait Time Percentiles</h2>
+    </div>
+    <table>
+        <thead>
+            <tr>
+                <th>Percentile</th>
+                <th>Wait Time</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for percentile, wait_time in queue_percentile_data.items() %}
+            <tr>
+                <td>{{ percentile }}th</td>
+                <td>{{ wait_time }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
 {% endblock %}

--- a/server/src/views.py
+++ b/server/src/views.py
@@ -216,7 +216,7 @@ def queue_detail(queue_id):
     )
 
 
-def seconds_to_hms(seconds: int) -> str:
+def seconds_to_hms(seconds: float) -> str:
     """Convert seconds to a human-readable string"""
     seconds = int(seconds)
     hours = seconds // 3600

--- a/server/src/views.py
+++ b/server/src/views.py
@@ -196,6 +196,30 @@ def queue_detail(queue_id):
         }
     )
 
+    # Get the percentiles of wait times for this queue
+    wait_times = database.get_queue_wait_times([queue_id])
+    try:
+        wait_times = wait_times[0]["wait_times"]
+    except (IndexError, KeyError):
+        wait_times = []
+    queue_percentile_data = database.calculate_percentiles(wait_times)
+
+    # Convert the wait times to human-readable strings
+    for key, value in queue_percentile_data.items():
+        queue_percentile_data[key] = seconds_to_hms(value)
+
     return render_template(
-        "queue_detail.html", queue=queue_data, jobs=job_data
+        "queue_detail.html",
+        queue=queue_data,
+        jobs=job_data,
+        queue_percentile_data=queue_percentile_data,
     )
+
+
+def seconds_to_hms(seconds: int) -> str:
+    """Convert seconds to a human-readable string"""
+    seconds = int(seconds)
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    seconds = seconds % 60
+    return f"{hours:02d}h {minutes:02d}m {seconds:02d}s"


### PR DESCRIPTION
## Description

Store wait times for queues and add an API as well as a view on the queue_detail page that shows the percentiles for these wait times.  The API can be used to retrieve metrics on individual queue(s) or for all queues at once. For the API, the wait times are returned in seconds, but on the view, we convert this to a more human readable form (see screenshot)

![image](https://github.com/user-attachments/assets/a2f85634-9464-444a-b892-2ba02be1fee5)


## Resolved issues

CERTTF-333

## Documentation

Added README section about the new API

## Web service API changes
```
**[GET] /v1/queues/wait_times** - get wait time metrics - optionally take a list of queues

- Parameters:

  - queue (array): list of queues to get wait time metrics for

- Returns:

  JSON mapping of queue names to wait time metrics

- Example:

  .. code-block:: console

    $ curl http://localhost:8000/v1/queues/wait_times?queue=foo\&queue=bar%     
```
This adds a new database collection for queue_wait_times. For displaying a single queue, I expect this to be quite fast and have no noticeable effect on page load time for queue_details. I did some testing of the code that does the calculation of the percentiles and it was quite fast on my system - potentially it could be slower across thousands of queues if we frequently call the API with no queues specified to get all queues, but we could consider capping the number of data points per queue if this becomes a problem. The space consumed is small enough and the performance is good enough that I've left it uncapped for now.

## Tests

Tested locally and unit tests added. The wait time data doesn't exist until this is deployed on the server though (no agent changes needed), so we won't start collecting the data until then and it won't display until it has data for a given queue.
