### PR TITLE
fix incorrect formatting for file not found error in submit

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -371,7 +371,7 @@ class TestflingerCli:
                 ) as job_file:
                     data = job_file.read()
             except FileNotFoundError:
-                sys.exit("File not found: {self.args.filename}")
+                sys.exit(f"File not found: {self.args.filename}")
         job_dict = yaml.safe_load(data)
 
         attachments_data = self.extract_attachment_data(job_dict)


### PR DESCRIPTION
I noticed this when doing some testing with testflinger. It seems what is meant to be an fstring isn't actually formatted. Not sure if this is intended but I thought I'd submit a PR anyway.

This is the current behaviour:
```
File not found: {self.args.filename}
```

## Description
Changes what is seemingly meant to be an fstring, into an fstring

## Resolved issues
None

## Documentation
None necessary

## Web service API changes
Nope!
