### PR TITLE
Change: additional arguments/assertions for UC24 and OEM 24.04 via Zapper KVM

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -21,7 +21,7 @@ Unless specified via _autoinstall_ storage filter, the tool will select the larg
 - **storage_layout**: can be either `lvm`, `direct`, `zfs` or `hybrid` (Core, Desktop 23.10+)
 - **robot_tasks**: list of Zapper Robot tasks to run after a hard reset in order to follow the `autoinstall` installation
 - **cmdline_append** (optional): kernel parameters to append at the end of GRUB entry cmdline
-- **base_user_data** (optional): a custom base user-data file, it should be validated against [this schema](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-schema.html)
+- **base_user_data** (optional): a string containing base64 encoded autoinstall user-data to use as base for provisioning, it should be validated against [this schema](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-schema.html)
 
 ## Ubuntu Desktop OEM
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -7,9 +7,9 @@ Zapper-driven provisioning method that makes use of KVM assertions and actions.
 
 Support for vanilla Ubuntu is provided by [autoinstall](https://canonical-subiquity.readthedocs-hosted.com/en/latest/intro-to-autoinstall.html). Supported Ubuntu versions are:
 
-- Core24 (experimental)
 - Desktop >= 23.04
 - Server >= 20.04
+- UC24 (experimental)
 
 Unless specified via _autoinstall_ storage filter, the tool will select the largest storage device on the DUT. See [supported layouts](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#supported-layouts) for more information.
 
@@ -18,11 +18,11 @@ Unless specified via _autoinstall_ storage filter, the tool will select the larg
 - __url__: URL to the image to install
 - __username__: username to configure
 - __password__: password to configure
-- **storage_layout**: can be either `lvm`, `direct`, `zfs` or `hybrid` (Core, Desktop 23.10+)
-- **robot_tasks**: list of Zapper Robot tasks to run after a hard reset in order to follow the `autoinstall` installation
-- **cmdline_append** (optional): kernel parameters to append at the end of GRUB entry cmdline
-- **base_user_data** (optional): a string containing base64 encoded autoinstall user-data to use as base for provisioning, it should be validated against [this schema](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-schema.html)
-- __autoinstall_oem__: Set to "true" to install OEM meta-packages and the reset partition (Desktop 24.04+)
+- __storage_layout__: can be either `lvm`, `direct`, `zfs` or `hybrid` (Desktop 23.10+, UC24)
+- __robot_tasks__: list of Zapper Robot tasks to run after a hard reset in order to follow the `autoinstall` installation
+- __cmdline_append__ (optional): kernel parameters to append at the end of GRUB entry cmdline
+- __base_user_data__ (optional): a string containing base64 encoded autoinstall user-data to use as base for provisioning, it should be validated against [this schema](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-schema.html)
+- __autoinstall_oem__: (optional): set to "true" to install OEM meta-packages and the reset partition (Desktop 24.04+)
 
 ## Ubuntu Desktop 22.04 OEM
 
@@ -42,7 +42,7 @@ The tool will select the storage device with the following priority:
 - __alloem_url__: URL to the `alloem` image
 - __url__ (optional): URL to the image to test, will be installed via the OEM script
 - __password__: password to configure
-- **robot_tasks**: list of Zapper Robot tasks to run after a hard reset in order to follow the `alloem` installation
+- __robot_tasks__: list of Zapper Robot tasks to run after a hard reset in order to follow the `alloem` installation
 
 ## Live ISO
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -23,6 +23,7 @@ Unless specified via _autoinstall_ storage filter, the tool will select the larg
 - __cmdline_append__ (optional): kernel parameters to append at the end of GRUB entry cmdline
 - __base_user_data__ (optional): a string containing base64 encoded autoinstall user-data to use as base for provisioning, it should be validated against [this schema](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-schema.html)
 - __autoinstall_oem__: (optional): set to "true" to install OEM meta-packages and the reset partition (Desktop 24.04+)
+- __ubuntu_sso_email__: (optional): a valid Ubuntu SSO email to which the DUT provisioned with a non-dangerous grade UC image will be linked
 
 ## Ubuntu Desktop 22.04 OEM
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/README.md
@@ -22,10 +22,9 @@ Unless specified via _autoinstall_ storage filter, the tool will select the larg
 - **robot_tasks**: list of Zapper Robot tasks to run after a hard reset in order to follow the `autoinstall` installation
 - **cmdline_append** (optional): kernel parameters to append at the end of GRUB entry cmdline
 - **base_user_data** (optional): a string containing base64 encoded autoinstall user-data to use as base for provisioning, it should be validated against [this schema](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-schema.html)
+- __autoinstall_oem__: Set to "true" to install OEM meta-packages and the reset partition (Desktop 24.04+)
 
-## Ubuntu Desktop OEM
-
-### Jammy
+## Ubuntu Desktop 22.04 OEM
 
 Ubuntu OEM 22.04 is a two step process:
 
@@ -38,16 +37,12 @@ The tool will select the storage device with the following priority:
 2. NVME
 3. SATA
 
-#### Job parameters
+### Job parameters
 
 - __alloem_url__: URL to the `alloem` image
 - __url__ (optional): URL to the image to test, will be installed via the OEM script
 - __password__: password to configure
 - **robot_tasks**: list of Zapper Robot tasks to run after a hard reset in order to follow the `alloem` installation
-
-### Noble
-
-Ubuntu OEM 24.04 uses `autoinstall`. The procedure and the arguments are the same as _vanilla_ Ubuntu.
 
 ## Live ISO
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -62,7 +62,11 @@ class DeviceConnector(ZapperConnector):
         if "storage_layout" not in provision:
             return None
 
-        autoinstall_conf = {"storage_layout": provision["storage_layout"]}
+        autoinstall_conf = {
+            "storage_layout": provision["storage_layout"],
+            "oem": provision.get("autoinstall_oem", False),
+        }
+
         if "base_user_data" in provision:
             self._validate_user_data(provision["base_user_data"])
             autoinstall_conf["base_user_data"] = provision["base_user_data"]

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -101,17 +101,6 @@ class DeviceConnector(ZapperConnector):
             )
             retries = self.job_data["provision_data"].get("robot_retries", 1)
 
-        # If a SSO email is specified, e.g. UC, username must match
-        # the local-part because that would be the only user available
-        # on the DUT after provisioning.
-        if "ubuntu_sso_email" in self.job_data["provision_data"]:
-            email = self.job_data["provision_data"]["ubuntu_sso_email"]
-            if username != email.split("@")[0]:
-                raise ProvisioningError(
-                    "Test username doesn't match the provided "
-                    "ubuntu_sso_email."
-                )
-
         provisioning_data = {
             "url": url,
             "username": username,

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -101,6 +101,17 @@ class DeviceConnector(ZapperConnector):
             )
             retries = self.job_data["provision_data"].get("robot_retries", 1)
 
+        # If a SSO email is specified, e.g. UC, username must match
+        # the local-part because that would be the only user available
+        # on the DUT after provisioning.
+        if "ubuntu_sso_email" in self.job_data["provision_data"]:
+            email = self.job_data["provision_data"]["ubuntu_sso_email"]
+            if username != email.split("@")[0]:
+                raise ProvisioningError(
+                    "Test username doesn't match the provided "
+                    "ubuntu_sso_email."
+                )
+
         provisioning_data = {
             "url": url,
             "username": username,
@@ -119,6 +130,7 @@ class DeviceConnector(ZapperConnector):
             "skip_download",
             "wait_until_ssh",
             "live_image",
+            "ubuntu_sso_email",
         ]
         provisioning_data.update(
             {

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -86,7 +86,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                     "job.robot",
                     "another.robot",
                 ],
-                "storage_layout": "lvm",
+                "autoinstall_storage_layout": "lvm",
                 "robot_retries": 3,
                 "cmdline_append": "more arguments",
                 "skip_download": True,
@@ -145,7 +145,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                     "job.robot",
                     "another.robot",
                 ],
-                "storage_layout": "lvm",
+                "autoinstall_storage_layout": "lvm",
             },
             "test_data": {
                 "test_username": "username",
@@ -172,7 +172,8 @@ class ZapperKVMConnectorTests(unittest.TestCase):
     def test_get_autoinstall_none(self):
         """
         Test whether the get_autoinstall_conf function returns
-        None in case the storage_layout is not specified.
+        None in case none of the autoinstall-related keys are
+        provided.
         """
 
         connector = DeviceConnector()
@@ -212,7 +213,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                     "job.robot",
                     "another.robot",
                 ],
-                "storage_layout": "lvm",
+                "autoinstall_storage_layout": "lvm",
             },
             "test_data": {
                 "test_username": "username",
@@ -226,7 +227,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         expected = {
             "storage_layout": "lvm",
             "authorized_keys": ["mykey"],
-            "oem": False,
         }
         self.assertDictEqual(conf, expected)
 
@@ -246,8 +246,8 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                     "job.robot",
                     "another.robot",
                 ],
-                "storage_layout": "lvm",
-                "base_user_data": "content",
+                "autoinstall_storage_layout": "lvm",
+                "autoinstall_base_user_data": "content",
                 "autoinstall_oem": True,
             },
             "test_data": {
@@ -256,11 +256,11 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             },
         }
 
-        connector._validate_user_data = Mock()
+        connector._validate_base_user_data = Mock()
         with patch("builtins.open", mock_open(read_data="mykey")):
             conf = connector._get_autoinstall_conf()
 
-        connector._validate_user_data.assert_called_once_with("content")
+        connector._validate_base_user_data.assert_called_once_with("content")
         expected = {
             "storage_layout": "lvm",
             "base_user_data": "content",
@@ -269,7 +269,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         }
         self.assertDictEqual(conf, expected)
 
-    def test_validate_user_data(self):
+    def test_validate_base_user_data(self):
         """
         Test whether the function returns without errors in case of a
         sane base64 encoded YAML.
@@ -277,18 +277,18 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         connector = DeviceConnector()
         user_data_base = yaml.safe_dump({"key1": 1, "key2": [1, 2, 3]})
         encoded = base64.b64encode(user_data_base.encode()).decode()
-        connector._validate_user_data(encoded)
+        connector._validate_base_user_data(encoded)
 
-    def test_validate_user_data_raises_decode(self):
+    def test_validate_base_user_data_raises_decode(self):
         """
         Test whether the function raises an exception if the input
         is not correctly encoded.
         """
         connector = DeviceConnector()
         with self.assertRaises(ProvisioningError):
-            connector._validate_user_data("notbase64")
+            connector._validate_base_user_data("notbase64")
 
-    def test_validate_user_data_raises_load(self):
+    def test_validate_base_user_data_raises_load(self):
         """
         Test whether the function raises an exception if the input
         is not a valid YAML.
@@ -297,7 +297,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         user_data_base = "not: a: correctly: formatted: yaml"
         encoded = base64.b64encode(user_data_base.encode()).decode()
         with self.assertRaises(ProvisioningError):
-            connector._validate_user_data(encoded)
+            connector._validate_base_user_data(encoded)
 
     def test_run_oem_no_url(self):
         """

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -224,6 +224,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         expected = {
             "storage_layout": "lvm",
             "authorized_keys": ["mykey"],
+            "oem": False,
         }
         self.assertDictEqual(conf, expected)
 
@@ -245,6 +246,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                 ],
                 "storage_layout": "lvm",
                 "base_user_data": "content",
+                "autoinstall_oem": True,
             },
             "test_data": {
                 "test_username": "username",
@@ -261,6 +263,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "storage_layout": "lvm",
             "base_user_data": "content",
             "authorized_keys": ["mykey"],
+            "oem": True,
         }
         self.assertDictEqual(conf, expected)
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -121,44 +121,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
-    def test_validate_configuration_raises_sso(self):
-        """
-        Test whether the validate_configuration raises an exception
-        if the provided test_username doesn't match with the SSO email.
-        """
-
-        connector = DeviceConnector()
-        connector.config = {
-            "device_ip": "1.1.1.1",
-            "control_host": "1.1.1.2",
-            "reboot_script": ["cmd1", "cmd2"],
-        }
-        connector.job_data = {
-            "job_queue": "queue",
-            "provision_data": {
-                "url": "http://example.com/image.iso",
-                "robot_tasks": [
-                    "job.robot",
-                    "another.robot",
-                ],
-                "storage_layout": "lvm",
-                "robot_retries": 3,
-                "cmdline_append": "more arguments",
-                "skip_download": True,
-                "wait_until_ssh": True,
-                "live_image": False,
-                "ubuntu_sso_email": "realuser@domain.com",
-            },
-            "test_data": {
-                "test_username": "username",
-                "test_password": "password",
-            },
-        }
-
-        connector._get_autoinstall_conf = Mock()
-        with self.assertRaises(ProvisioningError):
-            connector._validate_configuration()
-
     def test_validate_configuration_alloem(self):
         """
         Test whether the validate_configuration function returns

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -92,6 +92,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                 "skip_download": True,
                 "wait_until_ssh": True,
                 "live_image": False,
+                "ubuntu_sso_email": "username@domain.com",
             },
             "test_data": {
                 "test_username": "username",
@@ -115,9 +116,48 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "skip_download": True,
             "wait_until_ssh": True,
             "live_image": False,
+            "ubuntu_sso_email": "username@domain.com",
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
+
+    def test_validate_configuration_raises_sso(self):
+        """
+        Test whether the validate_configuration raises an exception
+        if the provided test_username doesn't match with the SSO email.
+        """
+
+        connector = DeviceConnector()
+        connector.config = {
+            "device_ip": "1.1.1.1",
+            "control_host": "1.1.1.2",
+            "reboot_script": ["cmd1", "cmd2"],
+        }
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "robot_tasks": [
+                    "job.robot",
+                    "another.robot",
+                ],
+                "storage_layout": "lvm",
+                "robot_retries": 3,
+                "cmdline_append": "more arguments",
+                "skip_download": True,
+                "wait_until_ssh": True,
+                "live_image": False,
+                "ubuntu_sso_email": "realuser@domain.com",
+            },
+            "test_data": {
+                "test_username": "username",
+                "test_password": "password",
+            },
+        }
+
+        connector._get_autoinstall_conf = Mock()
+        with self.assertRaises(ProvisioningError):
+            connector._validate_configuration()
 
     def test_validate_configuration_alloem(self):
         """

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -85,6 +85,7 @@ SecureBoot
 SKU
 SQA
 SSID
+SSO
 subdirectories
 subfolders
 subtree
@@ -97,6 +98,7 @@ txt
 Ubuntu
 ubuntu
 url
+UC
 UI
 URI
 USB

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -296,7 +296,7 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
     * - ``autoinstall_oem``:
       - (Optional) Set to "true" to install OEM meta-packages and the reset partition (Desktop 24.04+).
     * - ``ubuntu_sso_email``:
-      - (Optional) A valid Ubuntu SSO email to which the DUT provisioned with a non-dangerous grade UC image will be linked (UC24).
+      - (Optional) A valid Ubuntu SSO email to which the DUT provisioned with a non-dangerous grade UC image will be linked (UC24). Please make sure to provide the corresponding *username* in the *test_data.test_username* field.
 .
 
 .. list-table:: Supported ``provision_data`` keys for ``zapper_kvm`` with target Ubuntu OEM 22.04

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -289,8 +289,7 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
       - When provisioning an image supporting *autoinstall*, the cmdline_append can
         be used to append Kernel parameters to the standard GRUB entry.
     * - ``base_user_data``
-      - When provisioning an image supporting *autoinstall*, the base_user_data can
-        e used to provide a base user_data file instead of the basic one hosted by Zapper.
+      - An optional string containing base64 encoded user-data to use as base for autoinstall-driven provisioning.
         For more information, see
         `Autoinstall Reference <https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html>`_.
         on this topic

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -286,13 +286,15 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
       - When provisioning an image supporting *autoinstall*, the storage_layout can
         be either ``lvm`` (default), ``direct``, ``zfs`` or ``hybrid`` (Core, Desktop 23.10+)
     * - ``cmdline_append``
-      - When provisioning an image supporting *autoinstall*, the cmdline_append can
+      - (Optional) When provisioning an image supporting *autoinstall*, the cmdline_append can
         be used to append Kernel parameters to the standard GRUB entry.
     * - ``base_user_data``
-      - An optional string containing base64 encoded user-data to use as base for autoinstall-driven provisioning.
+      - (Optional) A string containing base64 encoded user-data to use as base for autoinstall-driven provisioning.
         For more information, see
         `Autoinstall Reference <https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html>`_.
         on this topic
+    * - ``autoinstall_oem``:
+      - (Optional) Set to "true" to install OEM meta-packages and the reset partition (Desktop 24.04+).
 
 .. list-table:: Supported ``provision_data`` keys for ``zapper_kvm`` with target Ubuntu OEM 22.04
     :header-rows: 1

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -282,13 +282,13 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
       - List of Zapper/Robot snippets to run in sequence after the USB storage device
         is plugged into the DUT and the system restarted. The snippet ID is the relative
         path from the ``robot/snippets`` path in the Zapper repository.
-    * - ``storage_layout``
+    * - ``autoinstall_storage_layout``
       - When provisioning an image supporting *autoinstall*, the storage_layout can
         be either ``lvm`` (default), ``direct``, ``zfs`` or ``hybrid`` (Desktop 23.10+, UC24)
     * - ``cmdline_append``
       - (Optional) When provisioning an image supporting *autoinstall*, the cmdline_append can
         be used to append Kernel parameters to the standard GRUB entry.
-    * - ``base_user_data``
+    * - ``autoinstall_base_user_data``
       - (Optional) A string containing base64 encoded user-data to use as base for autoinstall-driven provisioning.
         For more information, see
         `Autoinstall Reference <https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html>`_.

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -284,7 +284,7 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
         path from the ``robot/snippets`` path in the Zapper repository.
     * - ``storage_layout``
       - When provisioning an image supporting *autoinstall*, the storage_layout can
-        be either ``lvm`` (default), ``direct``, ``zfs`` or ``hybrid`` (Core, Desktop 23.10+)
+        be either ``lvm`` (default), ``direct``, ``zfs`` or ``hybrid`` (Desktop 23.10+, UC24)
     * - ``cmdline_append``
       - (Optional) When provisioning an image supporting *autoinstall*, the cmdline_append can
         be used to append Kernel parameters to the standard GRUB entry.
@@ -295,6 +295,9 @@ The ``zapper_kvm`` device connector, depending on the target image, supports the
         on this topic
     * - ``autoinstall_oem``:
       - (Optional) Set to "true" to install OEM meta-packages and the reset partition (Desktop 24.04+).
+    * - ``ubuntu_sso_email``:
+      - (Optional) A valid Ubuntu SSO email to which the DUT provisioned with a non-dangerous grade UC image will be linked (UC24).
+.
 
 .. list-table:: Supported ``provision_data`` keys for ``zapper_kvm`` with target Ubuntu OEM 22.04
     :header-rows: 1


### PR DESCRIPTION
## Description

This PR addresses a few problems detected while provisioning a device with UC24-subiquity and Desktop 24.04 OEM.

About UC24:
- being a non-dangerous grade image, the installed user will be given by `ubuntu_sso_email`. This PR forwards the `ubuntu_sso_email` argument to the zapper.provision() API and assert that `test_username` matches the local part of the SSO email. The DUT pulls TF SSH key from the account, so it's accessible and reservation works fine.

About 24.04 OEM:
- `user_data_base` was intended as a plain string, making it difficult to include in a TF job yaml. Taking inspiration from the MAAS connector I made it a base64 encoded field. Added tests and assertions.
- being a common case, instead of asking the user to pass the `user_data_base` argument, I added a dedicated `autoinstall_oem` boolean flag. It will be handled on the Zapper side as described in the autoinstall docs. See https://github.com/canonical/zapper/pull/311 for reference on what it actually does on the Zapper side.

## Resolved issues

Resolves [ZAP-873](https://warthogs.atlassian.net/browse/ZAP-873)
Part of [ZAP-776](https://warthogs.atlassian.net/browse/ZAP-776)

## Documentation

Updated README and `docs/`.

## Web service API changes

N/A

## Tests

About **UC24**: couldn't really test it e2e but, once manually provisioned via Zapper API, the device is accessible as usual by TF with:
```
~ cat uc24.yaml       
job_queue: 202101-28611
**test_data:
  test_username: ce-certification-qa**
reserve_data:
  ssh_keys:
    - lp:pgentili
  ```

About 24.04 OEM: tested on the Zapper side as part of https://github.com/canonical/zapper/pull/311 passing `oem=True`.


[ZAP-873]: https://warthogs.atlassian.net/browse/ZAP-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ