### PR TITLE
fix filepath in docs/how-to/install-cli.rst in instructions

### DIFF
--- a/docs/how-to/install-cli.rst
+++ b/docs/how-to/install-cli.rst
@@ -25,7 +25,7 @@ To run it from the source code, please make sure that the ``python3-click`` and 
 .. code-block:: shell
 
   $ git clone https://github.com/canonical/testflinger
-  $ cd cli
+  $ cd testflinger/cli
   $ virtualenv -p python3 env
   $ . env/bin/activate
   $ pip install .


### PR DESCRIPTION
The `cd` command in the docs regarding installing the CLI in a venv had a wrong filepath.