### PR TITLE
Small fixes for the agent-host charm tests

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/tests/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical
+# Copyright 2024 Canonical
 # See LICENSE file for licensing details.
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
@@ -41,25 +41,20 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(mock_write_file.call_count, 2)
 
     @patch("os.listdir")
-    @patch("os.remove")
     @patch("shutil.copy")
     @patch("os.chmod")
     def test_update_tf_cmd_scripts(
-        self, mock_chmod, mock_copy, mock_remove, mock_listdir
+        self, mock_chmod, mock_copy, mock_listdir
     ):
         """Test the update_tf_cmd_scripts method"""
         charm = self.harness.charm
-        usr_local_bin_files = ["tf-script1", "tf-script2", "other-file"]
         tf_cmd_scripts_files = ["tf-script3", "tf-script4"]
 
-        mock_listdir.side_effect = [usr_local_bin_files, tf_cmd_scripts_files]
+        mock_listdir.side_effect = [tf_cmd_scripts_files]
 
         charm.update_tf_cmd_scripts()
         tf_cmd_dir = "src/tf-cmd-scripts/"
         usr_local_bin = "/usr/local/bin/"
-        mock_remove.assert_any_call(os.path.join(usr_local_bin, "tf-script1"))
-        mock_remove.assert_any_call(os.path.join(usr_local_bin, "tf-script2"))
-        self.assertEqual(mock_remove.call_count, 2)
         mock_copy.assert_any_call(
             os.path.join(tf_cmd_dir, "tf-script3"),
             usr_local_bin,

--- a/agent/tox.ini
+++ b/agent/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py
+envlist = py, charm
 skipsdist = true
 
 [testenv]
@@ -20,3 +20,13 @@ commands =
     {envbindir}/python -m black --check testflinger_agent
     {envbindir}/python -m flake8 testflinger_agent
     {envbindir}/python -m pytest --doctest-modules --cov=testflinger_agent testflinger_agent
+
+[testenv:charm]
+deps =
+    -r charms/testflinger-agent-host-charm/requirements.txt
+    pytest
+setenv =
+    PYTHONPATH = {toxinidir}/charms/testflinger-agent-host-charm/lib:{toxinidir}:charms/testflinger-agent-host-charm/src
+commands =
+    {envbindir}/python -m pytest charms/testflinger-agent-host-charm/tests
+


### PR DESCRIPTION
## Description
It looks like at one time there was an intent to remove the extraneous files in /usr/local/bin when installing the tf-* scripts, but that is no longer the case (understandable). Also, we need a slightly different environment to set up the tests for the charm, so let's add that here. Especially since we're in the process of expanding this charm and making it the only one for the agent, it would be good to make sure things are working correctly.

## Resolved issues
See above

## Documentation
N/A

## Web service API changes
N/A

## Tests
That's the point :)
