### PR TITLE
Add github token secret to the workflow for uploading agent charms

### DIFF
--- a/.github/workflows/agent-charm-release-edge.yml
+++ b/.github/workflows/agent-charm-release-edge.yml
@@ -25,4 +25,6 @@ jobs:
         with:
           charm-path: agent/charms/testflinger-agent-charm
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "latest/edge"
+          tag-prefix: "agent-charm"

--- a/.github/workflows/agent-host-charm-release-edge.yml
+++ b/.github/workflows/agent-host-charm-release-edge.yml
@@ -25,4 +25,6 @@ jobs:
         with:
           charm-path: agent/charms/testflinger-agent-host-charm
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "latest/edge"
+          tag-prefix: "agent-host-charm"


### PR DESCRIPTION
## Description
It looks like the upload-charm needs the github token even if you don't pull an oci container from ghcr.io. It seems to use it for tagging. I'm not sure how the current set of tags it seems to have used really line up with the charm releases, but there also seems to be a tag prefix you can use that helps differentiate them here so I added that also.

## Resolved issues
Charm fails to upload without the token at least

## Documentation
N/A

## Web service API changes
N/A

## Tests
