### PR TITLE
refactor(agent): unify treatment of output and other events

### DIFF
--- a/agent/testflinger_agent/handlers.py
+++ b/agent/testflinger_agent/handlers.py
@@ -13,6 +13,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 from .client import TestflingerClient
+from .runner import OutputEvent
 
 
 class LiveOutputHandler:
@@ -20,14 +21,14 @@ class LiveOutputHandler:
         self.client = client
         self.job_id = job_id
 
-    def __call__(self, data: str):
-        self.client.post_live_output(self.job_id, data)
+    def __call__(self, event: OutputEvent):
+        self.client.post_live_output(self.job_id, event.output)
 
 
 class LogUpdateHandler:
     def __init__(self, log_file: str):
         self.log_file = log_file
 
-    def __call__(self, data: str):
+    def __call__(self, event: OutputEvent):
         with open(self.log_file, "a") as log:
-            log.write(data)
+            log.write(event.output)

--- a/agent/testflinger_agent/stop_condition_checkers.py
+++ b/agent/testflinger_agent/stop_condition_checkers.py
@@ -16,6 +16,7 @@ import time
 from typing import Optional, Tuple
 from testflinger_common.enums import JobState, TestEvent
 from .client import TestflingerClient
+from .runner import RunnerEvent
 
 
 class JobCancelledChecker:
@@ -59,6 +60,6 @@ class OutputTimeoutChecker:
             )
         return None, ""
 
-    def update(self):
+    def update(self, _: RunnerEvent):
         """Update the last output time to the current time."""
         self.last_output_time = time.time()

--- a/agent/testflinger_agent/tests/test_job.py
+++ b/agent/testflinger_agent/tests/test_job.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import testflinger_agent
 from testflinger_agent.client import TestflingerClient as _TestflingerClient
 from testflinger_agent.job import TestflingerJob as _TestflingerJob
-from testflinger_agent.runner import CommandRunner
+from testflinger_agent.runner import CommandRunner, OutputEvent
 from testflinger_agent.handlers import LogUpdateHandler
 from testflinger_agent.stop_condition_checkers import (
     GlobalTimeoutChecker,
@@ -73,7 +73,7 @@ class TestJob:
         logfile = tmp_path / "testlog"
         runner = CommandRunner(tmp_path, env={})
         log_handler = LogUpdateHandler(logfile)
-        runner.register_output_handler(log_handler)
+        runner.subscribe_event(OutputEvent, log_handler)
         global_timeout_checker = GlobalTimeoutChecker(1)
         runner.register_stop_condition_checker(global_timeout_checker)
         exit_code, exit_event, exit_reason = runner.run("sleep 12")
@@ -98,7 +98,7 @@ class TestJob:
         logfile = tmp_path / "testlog"
         runner = CommandRunner(tmp_path, env={})
         log_handler = LogUpdateHandler(logfile)
-        runner.register_output_handler(log_handler)
+        runner.subscribe_event(OutputEvent, log_handler)
         output_timeout_checker = OutputTimeoutChecker(1)
         runner.register_stop_condition_checker(output_timeout_checker)
         # unfortunately, we need to sleep for longer that 10 seconds here

--- a/agent/testflinger_agent/tests/test_stop_condition_checkers.py
+++ b/agent/testflinger_agent/tests/test_stop_condition_checkers.py
@@ -22,6 +22,7 @@ from ..stop_condition_checkers import (
 )
 
 from testflinger_common.enums import TestEvent
+from testflinger_agent.runner import OutputEvent
 
 
 class TestStopConditionCheckers:
@@ -68,5 +69,5 @@ class TestStopConditionCheckers:
         checker = OutputTimeoutChecker(0.3)
         for _ in range(5):
             time.sleep(0.1)
-            checker.update()
+            checker.update(OutputEvent(""))
             assert checker() == (None, "")


### PR DESCRIPTION
## Description

Even though there is currently only a single event (output) that can be subscribed to on `CommandRunner`, there are two different methods for subscribing:
- a generic `subscribe_event` method for registering handlers for events
- a specific `register_output_handler` method for registering handlers for output events

Likewise, there are two different methods for notifying the handlers that an event has taken place:
- a generic `post_event` method for events
- a specific `post_output` method for output events

This PR unifies the treatment of output events and general events, i.e. output events are treated no differently than any other event. This makes the `CommandRunner` interface slimmer and more consistent but also allows for extensibility when additional event types might be added. Event handlers are still callables but now expect the event as their argument (carrying all necessary information to handle the event, e.g. the output, within the passed argument).

## Resolved issues

This PR is not linked to a specific issue.

## Documentation

No changes required to the documentation.

## Web service API changes

No changes to the Web service API

## Tests

All existing tests are still passing (following a couple of minor modifications to reflect the PR changes). No additional functionality has been added and hence no additional tests have been introduced. 