### PR TITLE
Fix provision_log reporting

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -278,19 +278,17 @@ class TestflingerAgent:
                             exit_event = TestEvent.RECOVERY_FAIL
                         else:
                             exit_event = TestEvent(phase + "_fail")
-                        event_emitter.emit_event(exit_event)
-                        if phase == "provision":
-                            self.client.post_provision_log(
-                                job.job_id, exit_code, exit_event
-                            )
-                        if phase != "test":
-                            logger.debug(
-                                "Phase %s failed, aborting job" % phase
-                            )
-                            job_end_reason = exit_event
-                            break
                     else:
-                        event_emitter.emit_event(TestEvent(phase + "_success"))
+                        exit_event = TestEvent(phase + "_success")
+                    event_emitter.emit_event(exit_event)
+                    if phase == TestPhase.PROVISION:
+                        self.client.post_provision_log(
+                            job.job_id, exit_code, exit_event
+                        )
+                    if exit_code and phase != TestPhase.TEST:
+                        logger.debug("Phase %s failed, aborting job" % phase)
+                        job_end_reason = exit_event
+                        break
             except Exception as e:
                 logger.exception(e)
             finally:


### PR DESCRIPTION
## Description

Not sure where exactly, but one of the recent changes seems to have broken provision log reporting. So it was working for a while, but after deploying updated agents in the last few days, there are some cases where it doesn't manage to report the provision_logs correctly. (this is not the TO events, this is the reporting of provision outcome for calculating pass/fail streak for provisioning on the testflinger UI).

This fixes it.

## Resolved issues

See above

## Documentation

N/A

## Web service API changes
N/A

## Tests

Added unit tests to ensure it's called properly for both cases of successful and unsuccessful provision attempts.
