### PR TITLE
Create new endpoint in Testflinger Server to authenticate clients and distribute tokens for submitting jobs with priority

### DIFF
--- a/docs/reference/testflinger-server-conf.rst
+++ b/docs/reference/testflinger-server-conf.rst
@@ -23,6 +23,8 @@ The configuration values of Testflinger servers are read from environment variab
      - MongoDB port to connect to (Default: 27017)
    * - ``MONGODB_URI``
      - URI for connecting to MongoDB (used instead of the above config options). For example: ``mongodb://user:pass@host:27017/dbname``
+   * - ``JWT_SIGNING_KEY``
+     - Secret key used for signing tokens with permissions for authenticated clients
 
 
 Example configuration
@@ -38,3 +40,4 @@ Example configuration
   MONGODB_DATABASE="testflinger_db"
   MONGODB_HOST="mongo"
   MONGODB_URI="mongodb://mongo:27017/testflinger_db"
+  JWT_SIGNING_KEY="my_secret_key"

--- a/server/README.rst
+++ b/server/README.rst
@@ -399,15 +399,12 @@ The job_status_webhook parameter is required for this endpoint. Other parameters
 
     $ curl http://localhost:8000/v1/queues/wait_times?queue=foo\&queue=bar
 
-**[GET] /v1/authenticate/token/<client_id>** - Authenticate client key and return JWT with permissions
-
-- Parameters:
-
-  - client_id (string): Client identifier
+**[POST] /v1/oauth2/token** - Authenticate client key and return JWT with permissions
 
 - Headers:
 
-  - client-key (string): unique secret key for client
+  - Basic Authorization: client_id:client_key (Base64 Encoded)
+    
 
 - Status Codes:
 
@@ -422,5 +419,5 @@ The job_status_webhook parameter is required for this endpoint. Other parameters
 
   .. code-block:: console
 
-    $ curl http://localhost:8000/v1/authenticate/token/101 \
-           -X GET --header "client-key: ABCDEF12345"
+    $ curl http://localhost:8000/v1/oauth2/token \
+           -X GET --header "Authorization: Basic ABCDEF12345"

--- a/server/README.rst
+++ b/server/README.rst
@@ -398,3 +398,29 @@ The job_status_webhook parameter is required for this endpoint. Other parameters
   .. code-block:: console
 
     $ curl http://localhost:8000/v1/queues/wait_times?queue=foo\&queue=bar
+
+**[GET] /v1/authenticate/token/<client_id>** - Authenticate client key and return JWT with permissions
+
+- Parameters:
+
+  - client_id (string): Client identifier
+
+- Headers:
+
+  - client-key (string): unique secret key for client
+
+- Status Codes:
+
+  - HTTP 200 (OK)
+  - HTTP 401 (Unauthorized) - Invalid client_id or client-key
+
+- Returns:
+
+  Signed JWT with permissions for client
+
+- Example:
+
+  .. code-block:: console
+
+    $ curl http://localhost:8000/v1/authenticate/token/101 \
+           -X GET --header "client-key: ABCDEF12345"

--- a/server/charm/config.yaml
+++ b/server/charm/config.yaml
@@ -11,3 +11,7 @@ options:
     default: 100
     description: Maximum number of concurrent connections to the database
     type: int
+  jwt_signing_key:
+    default: ""
+    description: Secret key used for signing authorization tokens
+    type: string

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -191,7 +191,10 @@ class TestflingerCharm(ops.CharmBase):
 
     @property
     def app_environment(self) -> dict:
-        """Get dict of env data for the mongodb credentials"""
+        """
+        Get dict of env data for the mongodb credentials
+        and other config variables
+        """
         db_data = self.fetch_mongodb_relation_data()
         env = {
             "MONGODB_HOST": db_data.get("db_host"),
@@ -200,6 +203,7 @@ class TestflingerCharm(ops.CharmBase):
             "MONGODB_PASSWORD": db_data.get("db_password"),
             "MONGODB_DATABASE": db_data.get("db_database"),
             "MONGODB_MAX_POOL_SIZE": str(self.config["max_pool_size"]),
+            "JWT_SIGNING_KEY": self.config["jwt_signing_key"],
         }
         return env
 

--- a/server/devel/docker-compose.override.yml
+++ b/server/devel/docker-compose.override.yml
@@ -12,6 +12,7 @@ services:
       - MONGODB_DATABASE=testflinger_db
       - MONGODB_HOST=mongo
       - MONGODB_AUTH_SOURCE=admin
+      - JWT_SIGNING_KEY=my_secret_key
     volumes:
       - .:/srv/testflinger
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -19,6 +19,7 @@ requests = "^2.31.0"
 urllib3 = "^2.2.1"
 pymongo = "<4.9.0"
 pyjwt = "^2.8.0"
+bcrypt = "^4.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.1.2"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -18,6 +18,7 @@ sentry-sdk = { extras = ["flask"], version = "^2.0.1" }
 requests = "^2.31.0"
 urllib3 = "^2.2.1"
 pymongo = "<4.9.0"
+pyjwt = "^2.8.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.1.2"

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -658,15 +658,16 @@ def queue_wait_time_percentiles_get():
     return queue_percentile_data
 
 
-def generate_token(permissions, secret_key):
+def generate_token(max_priority, secret_key):
     """Generates JWT token with queue permission given a secret key"""
     expiration_time = datetime.utcnow() + timedelta(seconds=2)
     token_payload = {
         "exp": expiration_time,
         "iat": datetime.now(timezone.utc),  # Issued at time
         "sub": "access_token",
-        "permissions": permissions,
+        "max_priority": max_priority,
     }
+
     token = jwt.encode(token_payload, secret_key, algorithm="HS256")
     return token
 
@@ -687,8 +688,8 @@ def validate_client_key_pair(client_id: str, client_key: str):
         client_permissions_entry["client_secret_hash"].encode("utf8"),
     ):
         return None
-    permissions = client_permissions_entry["permissions"]
-    return permissions
+    max_priority = client_permissions_entry["max_priority"]
+    return max_priority
 
 
 SECRET_KEY = os.environ.get("JWT_SIGNING_KEY")

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -17,9 +17,9 @@
 Testflinger v1 API
 """
 
+import os
 import uuid
 from datetime import datetime, timezone, timedelta
-import secrets
 
 import pkg_resources
 from apiflask import APIBlueprint, abort
@@ -692,7 +692,7 @@ def validate_client_key_pair(client_id: str, client_key: str):
     return permissions
 
 
-SECRET_KEY = secrets.token_hex(20)
+SECRET_KEY = os.environ.get("JWT_SIGNING_KEY")
 
 
 @v1.get("/authenticate/token/<client_id>")

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -692,11 +692,8 @@ def validate_client_key_pair(client_id: str, client_key: str):
     return max_priority
 
 
-SECRET_KEY = os.environ.get("JWT_SIGNING_KEY")
-
-
 @v1.post("/oauth2/token")
-def authenticate_client_post():
+def retrieve_token():
     """Get JWT with priority and queue permissions"""
     auth_header = request.authorization
     if auth_header is None:
@@ -712,5 +709,6 @@ def authenticate_client_post():
     allowed_resources = validate_client_key_pair(client_id, client_key)
     if allowed_resources is None:
         return "Invalid client id or client key", 401
-    token = generate_token(allowed_resources, SECRET_KEY)
+    secret_key = os.environ.get("JWT_SIGNING_KEY")
+    token = generate_token(allowed_resources, secret_key)
     return token

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -16,7 +16,6 @@
 """
 Fixtures for testing
 """
-
 from dataclasses import dataclass
 import pytest
 import mongomock
@@ -71,17 +70,16 @@ def mongo_app_with_permissions(mongo_app):
     client_id = "my_client_id"
     client_key = "my_client_key"
     client_salt = bcrypt.gensalt()
-    client_key_hash = bcrypt.hashpw(client_key.encode("utf-8"), client_salt)
-    permissions = [
-        {
-            "max_priority": 100,
-            "queue_name": "myqueue",
-        },
-        {
-            "max_priority": 200,
-            "queue_name": "myqueue2",
-        },
-    ]
+    client_key_hash = bcrypt.hashpw(
+        client_key.encode("utf-8"), client_salt
+    ).decode("utf-8")
+
+    permissions = {
+        "max_priority": {
+            "myqueue": 100,
+            "myqueue2": 200,
+        }
+    }
     mongo.client_permissions.insert_one(
         {
             "client_id": client_id,

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -74,17 +74,15 @@ def mongo_app_with_permissions(mongo_app):
         client_key.encode("utf-8"), client_salt
     ).decode("utf-8")
 
-    permissions = {
-        "max_priority": {
-            "myqueue": 100,
-            "myqueue2": 200,
-        }
+    max_priority = {
+        "myqueue": 100,
+        "myqueue2": 200,
     }
     mongo.client_permissions.insert_one(
         {
             "client_id": client_id,
             "client_secret_hash": client_key_hash,
-            "permissions": permissions,
+            "max_priority": max_priority,
         }
     )
-    yield app, mongo, client_id, client_key, permissions
+    yield app, mongo, client_id, client_key, max_priority

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -16,6 +16,9 @@
 """
 Fixtures for testing
 """
+
+import os
+
 from dataclasses import dataclass
 import pytest
 import mongomock
@@ -66,6 +69,7 @@ def mongo_app_with_permissions(mongo_app):
     Pytest fixture that adds permissions
     to the mock db for priority
     """
+    os.environ["JWT_SIGNING_KEY"] = "my_secret_key"
     app, mongo = mongo_app
     client_id = "my_client_id"
     client_key = "my_client_key"

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -744,7 +744,7 @@ def create_auth_header(client_id: str, client_key: str) -> dict:
 
 def test_authenticate_client_post(mongo_app_with_permissions):
     """Tests authentication endpoint which returns JWT with permissions"""
-    app, _, client_id, client_key, permissions = mongo_app_with_permissions
+    app, _, client_id, client_key, max_priority = mongo_app_with_permissions
     v1.SECRET_KEY = "my_secret_key"
     output = app.post(
         "/v1/oauth2/token",
@@ -756,9 +756,9 @@ def test_authenticate_client_post(mongo_app_with_permissions):
         token,
         v1.SECRET_KEY,
         algorithms="HS256",
-        options={"require": ["exp", "iat", "sub", "permissions"]},
+        options={"require": ["exp", "iat", "sub", "max_priority"]},
     )
-    assert decoded_token["permissions"] == permissions
+    assert decoded_token["max_priority"] == max_priority
 
 
 def test_authenticate_invalid_client_id(mongo_app_with_permissions):

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -751,6 +751,7 @@ def test_generate_token():
 def test_authenticate_client_get(mongo_app):
     """Tests authentication endpoint which returns JWT with permissions"""
     app, mongo = mongo_app
+    v1.SECRET_KEY = "my_secret_key"
     client_id = "my_client_id"
     client_key = "my_client_key"
     client_salt = bcrypt.gensalt()
@@ -776,6 +777,7 @@ def test_authenticate_client_get(mongo_app):
         f"/v1/authenticate/token/{client_id}",
         headers={"client-key": client_key},
     )
+    assert output.status_code == 200
     token = output.data
     decoded_token = jwt.decode(token, v1.SECRET_KEY, algorithms="HS256")
     assert decoded_token["permissions"] == permissions

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -21,7 +21,9 @@ from datetime import datetime
 from io import BytesIO
 import json
 import os
+
 import jwt
+import bcrypt
 
 from src.api import v1
 
@@ -751,6 +753,8 @@ def test_authenticate_client_get(mongo_app):
     app, mongo = mongo_app
     client_id = "my_client_id"
     client_key = "my_client_key"
+    client_salt = bcrypt.gensalt()
+    client_key_hash = bcrypt.hashpw(client_key.encode("utf-8"), client_salt)
     permissions = [
         {
             "max_priority": 100,
@@ -764,7 +768,7 @@ def test_authenticate_client_get(mongo_app):
     mongo.client_permissions.insert_one(
         {
             "client_id": client_id,
-            "client_secret_hash": client_key,
+            "client_secret_hash": client_key_hash,
             "permissions": permissions,
         }
     )

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -779,3 +779,19 @@ def test_authenticate_client_get(mongo_app):
     token = output.data
     decoded_token = jwt.decode(token, v1.SECRET_KEY, algorithms="HS256")
     assert decoded_token["permissions"] == permissions
+
+
+def test_authenticate_invalid_credentials(mongo_app):
+    """
+    Tests that authentication endpoint returns 401 error code
+    when receiving invalid credentials
+    """
+    app, _ = mongo_app
+    client_id = "my_client_id"
+    client_key = "my_client_key"
+
+    output = app.get(
+        f"/v1/authenticate/token/{client_id}",
+        headers={"client-key": client_key},
+    )
+    assert output.status_code == 401


### PR DESCRIPTION
## Description

In order to support authorized clients sending jobs to Testflinger with priority, we need some way to identify clients and their permissions. Every authorized client will have client_id and client-key(stored as a hash in the database) with a list of permissions.
This PR adds a new endpoint which takes in a client_id and client-key and returns an encoded list of their permissions in the form of a JWT:
```
{
    "exp": <datetime> # time that the token expires
    "iat": <datetime> # time that the token was generated
    "sub": <str> # description of token("access_token")
    "max_priority": {
        "queue_name": <int> # queue name to priority map
        ...
    }
}
```
The JWT is then signed with a secret key, provided by the environment variable JWT_SIGNING_KEY, which is set in the charm config. The client can then use this token to submit privileged jobs.

## Resolved issues

Resolves https://warthogs.atlassian.net/browse/CERTTF-370 

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

Documentation for the new endpoint was added in the server README and documentation regarding the new environment variable was added to the server configuration docs.
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

GET /v1/authenticate/token/<client_id>
- Authorization
    - client_id must be provided in the url
    - client-key must be provided in a header with title "client-key"
    - Invalid client_id and client-key tested in test_v1.py
- Returns status code 200 with correct credentials
- Returns status code 401 with invalid credentials
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

Unit Tests were added to test_v1.py. These tests test JWT generation and the new endpoint, testing both valid and invalid credentials. A new test fixture was added to conftest.py to set up the mongo_app with permissions pre-populated in the database. In support of this, the "mongo_app" fixture was renamed to "mongo_app_fixture" to fix a linting issue where the "mongo_app" name was shadowed.

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
