### PR TITLE
Update configs action

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/README.md
+++ b/agent/charms/testflinger-agent-host-charm/README.md
@@ -28,3 +28,6 @@ The following actions are supported for this charm:
   - update-testflinger:
       This action is used to update the testflinger-agent and install it to a
       location shared by all the agents running on this host.
+  - update-configs:
+      This action pulls the git repo set in the charm config to update the
+      agent configs on the agent host.

--- a/agent/charms/testflinger-agent-host-charm/actions.yaml
+++ b/agent/charms/testflinger-agent-host-charm/actions.yaml
@@ -1,2 +1,4 @@
+update-configs:
+  description: Update Testflinger agent configs
 update-testflinger:
   description: Update Testflinger agent code

--- a/agent/charms/testflinger-agent-host-charm/config.yaml
+++ b/agent/charms/testflinger-agent-host-charm/config.yaml
@@ -1,4 +1,16 @@
 options:
+  config-repo:
+    type: string
+    description: Git repo containing device agent config data
+    default: ""
+  config-branch:
+    type: string
+    description: Git branch to pull for the config data
+    default: "main"
+  config-dir:
+    type: string
+    description: Path from the root of the config repo where the directories and configs are located for this agent host
+    default: ""
   ssh_private_key:
     type: string
     description: ssh private key for connecting to local test devices

--- a/agent/charms/testflinger-agent-host-charm/requirements.txt
+++ b/agent/charms/testflinger-agent-host-charm/requirements.txt
@@ -1,2 +1,3 @@
 ops >= 1.4.0
 GitPython==3.1.43
+Jinja2==3.1.4

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -6,10 +6,13 @@
 
 
 import logging
-import shutil
 import os
-from pathlib import PosixPath
+import shutil
+import sys
+from pathlib import Path
 from common import run_with_logged_errors
+from git import Repo, GitCommandError
+from jinja2 import Template
 
 from charms.operator_libs_linux.v0 import apt
 from ops.charm import CharmBase
@@ -22,7 +25,7 @@ from ops.model import (
     ModelError,
 )
 import testflinger_source
-from defaults import LOCAL_TESTFLINGER_PATH
+from defaults import AGENT_CONFIGS_PATH, LOCAL_TESTFLINGER_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +42,10 @@ class TestflingerAgentHostCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self.on_config_changed)
         self.framework.observe(self.on.upgrade_charm, self.on_upgrade_charm)
         self.framework.observe(
+            self.on.update_configs_action,
+            self.on_update_configs_action,
+        )
+        self.framework.observe(
             self.on.update_testflinger_action,
             self.on_update_testflinger_action,
         )
@@ -53,6 +60,13 @@ class TestflingerAgentHostCharm(CharmBase):
         self.setup_docker()
         self.update_tf_cmd_scripts()
         self.update_testflinger_repo()
+        try:
+            self.update_config_files()
+        except ValueError:
+            self.unit.status = BlockedStatus(
+                "config-repo and config-dir must be set"
+            )
+            return
 
     def install_dependencies(self):
         """Install the packages needed for the agent"""
@@ -78,6 +92,39 @@ class TestflingerAgentHostCharm(CharmBase):
         testflinger_source.create_virtualenv()
         self.unit.status = MaintenanceStatus("Cloning testflinger repo")
         testflinger_source.clone_repo(LOCAL_TESTFLINGER_PATH)
+
+    def update_config_files(self):
+        """
+        Clone the config files from the repo and swap it in for whatever is
+        in AGENT_CONFIGS_PATH
+        """
+        config_repo = self.config.get("config-repo")
+        config_dir = self.config.get("config-dir")
+        config_branch = self.config.get("config-branch")
+        if not config_repo or not config_dir:
+            logger.error("config-repo and config-dir must be set")
+            raise ValueError("config-repo and config-dir must be set")
+        tmp_repo_path = Path("/srv/tmp-agent-configs")
+        repo_path = Path(AGENT_CONFIGS_PATH)
+        if tmp_repo_path.exists():
+            shutil.rmtree(tmp_repo_path, ignore_errors=True)
+        try:
+            Repo.clone_from(
+                url=config_repo,
+                branch=config_branch,
+                to_path=tmp_repo_path,
+                depth=1,
+            )
+        except GitCommandError:
+            logger.exception("Failed to update config files")
+            self.unit.status = BlockedStatus(
+                "Failed to update or config files"
+            )
+            sys.exit(1)
+
+        if repo_path.exists():
+            shutil.rmtree(repo_path, ignore_errors=True)
+        shutil.move(tmp_repo_path, repo_path)
 
     def setup_docker(self):
         run_with_logged_errors(["groupadd", "docker"])
@@ -122,6 +169,13 @@ class TestflingerAgentHostCharm(CharmBase):
     def on_config_changed(self, _):
         self.unit.status = MaintenanceStatus("Handling config_changed hook")
         self.copy_ssh_keys()
+        try:
+            self.update_config_files()
+        except ValueError:
+            self.unit.status = BlockedStatus(
+                "config-repo and config-dir must be set"
+            )
+            return
         self.unit.status = ActiveStatus()
 
     def install_apt_packages(self, packages: list):
@@ -140,8 +194,22 @@ class TestflingerAgentHostCharm(CharmBase):
 
     def on_update_testflinger_action(self, event):
         """Update Testflinger agent code"""
-        self.unit.status = MaintenanceStatus("Handling update action")
+        self.unit.status = MaintenanceStatus("Updating Testflinger Agent Code")
         self.update_testflinger_repo()
+        self.unit.status = ActiveStatus()
+
+    def on_update_configs_action(self, event):
+        """Update agent configs"""
+        self.unit.status = MaintenanceStatus(
+            "Updating Testflinger Agent Configs"
+        )
+        try:
+            self.update_config_files()
+        except ValueError:
+            self.unit.status = BlockedStatus(
+                "config-repo and config-dir must be set"
+            )
+            return
         self.unit.status = ActiveStatus()
 
 

--- a/agent/charms/testflinger-agent-host-charm/src/defaults.py
+++ b/agent/charms/testflinger-agent-host-charm/src/defaults.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Canonical
 # See LICENSE file for licensing details.
 
+AGENT_CONFIGS_PATH = "/srv/agent-configs"
 DEFAULT_TESTFLINGER_REPO = "https://github.com/canonical/testflinger.git"
 DEFAULT_BRANCH = "main"
 LOCAL_TESTFLINGER_PATH = "/srv/testflinger"

--- a/agent/charms/testflinger-agent-host-charm/tests/integration/data/agent001/default.yaml
+++ b/agent/charms/testflinger-agent-host-charm/tests/integration/data/agent001/default.yaml
@@ -1,0 +1,2 @@
+agent_name: agent001
+device_ip: 127.0.0.1

--- a/agent/charms/testflinger-agent-host-charm/tests/integration/data/agent001/testflinger-agent.conf
+++ b/agent/charms/testflinger-agent-host-charm/tests/integration/data/agent001/testflinger-agent.conf
@@ -1,0 +1,10 @@
+agent_id: agent-001
+server_address: http://127.0.0.1:5000
+logging_level: DEBUG
+job_queues:
+  - agent-001
+setup_command: bash -c "echo setup phase"
+provision_command: bash -c "echo provision phase"
+test_command: bash -c "echo test phase"
+provision_type: noprovision
+identifier: 202402-01010

--- a/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
@@ -1,16 +1,23 @@
 from pathlib import Path
+from unittest.mock import patch
 import pytest
 from pytest_operator.plugin import OpsTest
 
 # Root of the charm we need to build is two dirs up
 CHARM_PATH = Path(__file__).parent.parent.parent
 APP_NAME = "testflinger-agent-host"
+TEST_CONFIG = {
+    "config-repo": "https://github.com/canonical/testflinger.git",
+    "config-dir": "agent/charms/testflinger-agent-host-charm/tests/integration/data",
+    "config-branch": "update-configs-action",
+}
 
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     charm = await ops_test.build_charm(CHARM_PATH)
     app = await ops_test.model.deploy(charm)
+    await ops_test.model.applications[APP_NAME].set_config(TEST_CONFIG)
 
     await ops_test.model.wait_for_idle(status="active", timeout=600)
     assert app.status == "active"
@@ -24,3 +31,32 @@ async def test_action_update_testflinger(ops_test: OpsTest):
     await action.wait()
     assert action.status == "completed"
     assert action.results["return-code"] == 0
+
+
+async def test_action_update_configs(ops_test: OpsTest):
+    await ops_test.model.wait_for_idle(status="active", timeout=600)
+
+    # First, un-set the config-repo to trigger BlockedStatus
+    bad_config = {"config-repo": ""}
+    await ops_test.model.applications[APP_NAME].set_config(bad_config)
+    action = await ops_test.model.units.get(f"{APP_NAME}/0").run_action(
+        "update-configs"
+    )
+    await action.wait()
+    assert action.status == "completed"
+    assert (
+        ops_test.model.applications[APP_NAME].units[0].workload_status
+        == "blocked"
+    )
+
+    # Go back to the good config and make sure we get back to ActiveStatus
+    await ops_test.model.applications[APP_NAME].set_config(TEST_CONFIG)
+    action = await ops_test.model.units.get(f"{APP_NAME}/0").run_action(
+        "update-configs"
+    )
+    await action.wait()
+    assert action.status == "completed"
+    assert (
+        ops_test.model.applications[APP_NAME].units[0].workload_status
+        == "active"
+    )


### PR DESCRIPTION
## Description

Moving the code for deploying configs to the agent-host-charm from the agent-charm means that we can update all the configs at once. This should be a lot faster and easier to manage. The charm needs a place to pull them from. Right now, we store them in git, so it makes sense to add a config option for the git repo and path for the part of that repo that contains the configs this agent host should look at. NOTE: this does NOT tie us to using git forever. If a better option emerges, then we could support that in addition to, or instead of this.

The configs are not static. Agents will be added, removed, and changed over time. There should be a juju action that allows us to trigger an update to the agent configs.

## Resolved issues

CERTTF-377

## Documentation

Updated README

## Web service API changes

N/A

## Tests

Updated unit and integration tests

NOTE: For the integration tests, I added some data to THIS branch, and used config settings we provide here to force it to get that test data from this branch. Eventually, when this lands, we'll want to update this to point to main instead, but that's not something we can change until this lands.
