### PR TITLE
device-connectors: Fix handling attachments with absolute path in oem-autoinstall

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/muxpi/oem_autoinstall/provision-image.sh
+++ b/device-connectors/src/testflinger_device_connectors/data/muxpi/oem_autoinstall/provision-image.sh
@@ -268,7 +268,7 @@ do
     sleep 180
     currentTime=$(date +%s)
     if [[ $((currentTime - startTime)) -gt $TIMEOUT ]]; then
-        echo "Timeout is reached, deployment are not finished"
+        echo "Timeout is reached, deployment was not finished"
         break
     fi
 

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -95,8 +95,12 @@ class OemAutoinstall:
         Verify if attachment exists, then copy when
         it's missing in deployment dir
         """
+        source_path = Path(source_path)
+        if source_path.is_absolute():
+            source_path = source_path.relative_to("/")
         source_path = ATTACHMENTS_PROV_DIR / source_path
         dest_path = ATTACHMENTS_PROV_DIR / dest_path
+
         if not source_path.exists():
             logger.error(
                 f"{source_path} file was not found in attachments. "


### PR DESCRIPTION
## Description
`oem_autoinstall` fails when user gives absolute path in job.yaml (i.e `/home/artur/files/jenkins-token.txt`), but if relative path (i.e `files/jenkins-token.txt`) is given then it works.
Missed this bug at first, because was testing on local machine and when absolute path was overwriting ATTACHMENTS_DIR it still pointed to the right file. But when deployed in charm it failed to find the attachments correctly.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Closes https://warthogs.atlassian.net/browse/OEX86-416
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
n/a
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
n/a
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Run agent charm and test provisioning on HP machine.

Before fix:
https://testflinger.canonical.com/jobs/67001261-d590-41a1-bb3d-43a3e5db153b

After fix:
https://testflinger.canonical.com/jobs/f86f6684-45be-407b-8db6-ca724c828606
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
