### PR TITLE
fix(device-connectors): Remove unused code

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -89,9 +89,6 @@ class RealSerialLogger:
 
     def __init__(self, host, port, filename):
         """Set up a subprocess to connect to an ip and collect serial logs"""
-        if not (host and port and filename):
-            self.stub = True
-        self.stub = False
         self.host = host
         self.port = int(port)
         self.filename = filename


### PR DESCRIPTION
## Description

The check whether `RealSerialLogger` or `StubSerialLogger` is used is done in the `def SerialLogger()` function now:

https://github.com/canonical/testflinger/blob/88454c9d61a0f66e0dff50f2b1f9ae8c4247d57c/device-connectors/src/testflinger_device_connectors/devices/__init__.py#L69-L71

In addition, grep'ing for `\.stub` (and even just `stub`) seems to not yield any results, so the `self.stub` property might not be used at all (and even if it would be, it would always be overwritten by the unconditional `self.stub = False` in the line after the `if` block.

## Resolved issues

None, but makes the code easier to follow.

## Documentation

No changes.

## Web service API changes

No changes.

## Tests

I have not tested this.