### PR TITLE
fix(serial): Write log file from TCP in binary format

### DIFF
--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -155,7 +155,9 @@ class TestflingerJob:
                     self._set_truncate(logfile)
                     outcome_data[phase + "_output"] = logfile.read()
             if os.path.exists(serial_log):
-                with open(serial_log, "r+", encoding="utf-8") as logfile:
+                with open(
+                    serial_log, "r+", encoding="utf-8", errors="ignore"
+                ) as logfile:
                     self._set_truncate(logfile)
                     outcome_data[phase + "_serial"] = logfile.read()
             outcome_data[phase + "_status"] = exitcode

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -112,7 +112,7 @@ class RealSerialLogger:
 
     def _log_serial(self):
         """Log data to the serial data to the output file"""
-        with open(self.filename, "a+") as f:
+        with open(self.filename, "ab+") as f:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.connect((self.host, self.port))
                 logger.info("Successfully connected to serial logging server")
@@ -121,9 +121,7 @@ class RealSerialLogger:
                     for sock in read_sockets:
                         data = sock.recv(4096)
                         if data:
-                            f.write(
-                                data.decode(encoding="utf-8", errors="ignore")
-                            )
+                            f.write(data)
                             f.flush()
                         else:
                             logger.error(


### PR DESCRIPTION
## Description

By opening the serial log file in binary ("b") mode, we can write the binary data received from the TCP socket directly to the file without having to (try to) decode the content as UTF-8. This makes serial logging [8-bit clean](https://en.wikipedia.org/wiki/8-bit_clean).

This is especially important if a character in an otherwise valid UTF-8 string happens to cross the boundary of a 4096-byte read, resulting in lost data instead of a single, valid UTF-8 character in the file:

```python3
>>> ("x"*4096+"ü").encode("utf-8")[4096:].decode("utf-8")
'ü'
>>> ("x"*4095+"ü").encode("utf-8")[4096:].decode("utf-8")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbc in position 0: invalid start byte
```

The same is true for binary data (basically bytes with values 127-255) that can be passed through as-is without being interpreted as UTF-8, e.g:

```python3
>>> b"\xff".decode("utf-8")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```

And - as a side-effect of the previous one - log output encoded in non-UTF8 encodings will have their non-ASCII characters stripped:

```python3
>>> b = "Jö".encode("latin-1")
>>> b
b'J\xf6'
>>> b.decode("utf-8", "ignore")
'J'
```

In all 3 cases, since we use `"ignore"`, bytes that are not a valid UTF-8 sequence will just be silently thrown away.

## Resolved issues

This resolves issue with:

* UTF-8 characters crossing a 4096-byte boundary being potentially split and garbled
* Non-text binary data (with the MSB set; 127-255) being sent over the serial line being mangled
* Non-UTF-8 encoded non-ASCII text (e.g. encoded in Latin-1) having their non-ASCII characters stripped

## Documentation

No changes.

## Web service API changes

No changes.

## Tests

I have not tested this.