### PR TITLE
fix(muxpi): Escape/quote partition labels

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -19,6 +19,7 @@ import json
 import logging
 from pathlib import Path
 import requests
+import shlex
 import subprocess
 import tempfile
 import time
@@ -349,8 +350,12 @@ class MuxPi:
             mount_list = self._get_part_labels()
         for dev, mount in mount_list:
             try:
-                self._run_control("sudo mkdir -p {}".format(mount))
-                self._run_control("sudo mount /dev/{} {}".format(dev, mount))
+                self._run_control(
+                    "sudo mkdir -p {}".format(shlex.quote(mount))
+                )
+                self._run_control(
+                    "sudo mount /dev/{} {}".format(dev, shlex.quote(mount))
+                )
             except Exception:
                 # If unmountable or any other error, go on to the next one
                 mount_list.remove((dev, mount))
@@ -359,7 +364,7 @@ class MuxPi:
             yield self.mount_point
         finally:
             for _, mount in mount_list:
-                self._run_control("sudo umount {}".format(mount))
+                self._run_control("sudo umount {}".format(shlex.quote(mount)))
 
     def hardreset(self):
         """


### PR DESCRIPTION
## Description

Make sure partition labels are not passed unquoted/unescaped to the shell.

## Resolved issues

When a provisioning image contains a partition which has a label that contains special characters interpreted by the shell, these are not properly escaped, leading to issues with mounting and potentially executing unexpected code:

```
% lsblk -o NAME,LABEL -J /dev/loop35
{
   "blockdevices": [
      {
         "name": "loop35",
         "label": null,
         "children": [
            {
               "name": "loop35p1",
               "label": "; echo Hello"
            }
         ]
      }
   ]
}
```

That "label" value is returned by `_get_part_labels()`, and currently passed unescaped to `self._run_control()` in `remote_mount()` (this here assumes `self.mount_point == "/foo"`):

```python3
self._run_control("sudo mkdir -p {}".format(mount))
```

For a label of "; echo Hello", or a `mount` value of `"/foo/;echo Hello"`, this would expand to:

```python3
self._run_control("sudo mkdir -p {}".format("/foo/; echo Hello"))
```

Which would run on the control host:

```python3
self._run_control("sudo mkdir -p /foo/; echo Hello")
```

Example disk image containing an ext4 partition with the label "; echo Hello" (can easily be re-created with `gnome-disks` by creating a new disk image of 16 MiB, initializing it with a GPT and creating a single ext4 partition with the label "; echo Hello"):

[Unnamed (2024-08-26 0823).img.zip](https://github.com/user-attachments/files/16744906/Unnamed.2024-08-26.0823.img.zip)

Apart from the special shell characters causing wrong code to be run, even for cases where the partition label contains just spaces (e.g. a partition with the label "My Documents"), this is already an issue.

## Documentation

No changes.

## Web service API changes

No changes.

## Tests

Not tested.