### PR TITLE
Trigger an agent restart if USR1 signal is received

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -344,6 +344,6 @@ class TestflingerAgent:
         If we receive the restart signal, tell the agent to restart safely when
         it is not running a job
         """
-        logger.info("Triggering agent restart")
+        logger.info("Marked agent for restart")
         restart_file = self.get_restart_files()[0]
         open(restart_file, "w").close()

--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 Canonical
+# Copyright (C) 2017 Canonical
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +17,8 @@ import logging
 import os
 from pathlib import Path
 import shutil
+import signal
+import sys
 import tempfile
 
 from testflinger_agent.job import TestflingerJob
@@ -68,6 +70,7 @@ def secure_filter(member, path):
 class TestflingerAgent:
     def __init__(self, client):
         self.client = client
+        signal.signal(signal.SIGUSR1, self.restart_signal_handler)
         self.set_agent_state("waiting")
         self._post_initial_agent_data()
 
@@ -142,7 +145,7 @@ class TestflingerAgent:
                     os.unlink(restart_file)
                     logger.info("Restarting agent")
                     self.set_agent_state("offline")
-                    raise SystemExit("Restart Requested")
+                    sys.exit("Restart Requested")
                 except OSError:
                     logger.error(
                         "Restart requested, but unable to remove marker file!"
@@ -335,3 +338,12 @@ class TestflingerAgent:
             except TFServerError:
                 # Problems still, better luck next time?
                 pass
+
+    def restart_signal_handler(self, _, __):
+        """
+        If we receive the restart signal, tell the agent to restart safely when
+        it is not running a job
+        """
+        logger.info("Triggering agent restart")
+        restart_file = self.get_restart_files()[0]
+        open(restart_file, "w").close()

--- a/agent/testflinger_agent/tests/test_agent_process.py
+++ b/agent/testflinger_agent/tests/test_agent_process.py
@@ -46,7 +46,7 @@ def test_restart_signal_handler(tmp_path):
 
         assert os.path.exists("/tmp/TESTFLINGER-DEVICE-RESTART-test-agent-1")
         assert (
-            "Triggering agent restart" in agent_process.stderr.read().decode()
+            "Marked agent for restart" in agent_process.stderr.read().decode()
         )
 
         # Ensure the agent process is terminated

--- a/agent/testflinger_agent/tests/test_agent_process.py
+++ b/agent/testflinger_agent/tests/test_agent_process.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import signal
+import subprocess
+import time
+import os
+
+
+def test_restart_signal_handler(tmp_path):
+    # Ensure the agent restarts when it receives the restart signal
+    agent_config_file = tmp_path / "testflinger-agent.conf"
+    agent_config_file.write_text(
+        "agent_id: test-agent-1\n"
+        "server_address: http://127.0.0.1:5000\n"
+        "polling_interval: 5\n"
+        "job_queues:\n"
+        "  - test\n"
+    )
+
+    agent_process = subprocess.Popen(
+        [
+            "testflinger-agent",
+            "-c",
+            str(agent_config_file),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        # Wait for the agent to start
+        time.sleep(1)
+        os.kill(agent_process.pid, signal.SIGUSR1)
+        time.sleep(1)
+
+        assert os.path.exists("/tmp/TESTFLINGER-DEVICE-RESTART-test-agent-1")
+        assert (
+            "Triggering agent restart" in agent_process.stderr.read().decode()
+        )
+
+        # Ensure the agent process is terminated
+        assert agent_process.wait(timeout=2) == 1
+    finally:
+        agent_process.kill()

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -86,6 +86,7 @@ RTD
 runtime
 SDWire
 SecureBoot
+SIGUSR
 SKU
 SQA
 SSID
@@ -93,7 +94,9 @@ SSO
 subdirectories
 subfolders
 subtree
+supervisord
 SUT
+systemd
 Tegra
 templating
 Testflinger

--- a/docs/explanation/agents.rst
+++ b/docs/explanation/agents.rst
@@ -32,3 +32,19 @@ be updated even if the agent is offline as long as the agent is still running an
 able to communicate with the server. If an agent has not checked in after 7 days,
 it will automatically be removed from the database and will no longer appear in
 the "Agents" list.
+
+Safely Restarting or Shutting Down an Agent
+-------------------------------------------
+
+When an agent needs to be re-executed due to something like a code update or a
+configuration change, it is important to shut it down safely so that it does not
+interfere with a job currently running. To do this, you can use one of the
+following methods:
+
+1.  create a file called ``/tmp/TESTFLINGER-DEVICE-RESTART-(agent_name)`` (where ``(agent_name)`` is the name of the agent). 
+2. Send a SIGUSR1 signal to the agent's process
+
+Both of these methods will cause the agent to exit when it is no longer running
+a job. You will need to ensure something like systemd or supervisord is watching
+the agent process and restarting it if it exits in order to actually restart the
+agent.


### PR DESCRIPTION
So I'm proposing this one against main rather than the feature branch.

## Description

We already have a “safe restart” mechanism for the testflinger agent.  This works by waiting until the agent is not running a job, then checking for a marker file that signals the agent to restart.  This way, individual agents can be safely updated, then told to restart whenever they are done with their current jobs, so that we avoid a hard-restart that interrupts a job in progress.

Since supervisord gives us a nice mechanism for sending signals to all processes, we should take advantage of that by changing testflinger-agent to also respond to a signal as a trigger that it needs to perform a safe-restart. It’s common to use HUP to signal that something should reload it’s configuration files, but I’m not sure that really fits here. That’s normally just a “reread” of the configs, but in this case we’re telling it to completely exit so that it not only rereads the configs but also reloads the new version of the code that was potentially installed. So I would suggest using USR1 for the signal in this case.

## Resolved issues

CERTTF-379

## Documentation

Added documentation in the explanation section about this, and other methods for safely shutting down or restarting an agent

## Web service API changes

N/A

## Tests

Tested locally and also added a new test that executes the real agent, triggers a reset with the signal, and ensure it takes all the right steps.
