### PR TITLE
Mount value needs to be converted to a string from Path object

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -367,10 +367,12 @@ class MuxPi:
         for dev, mount in mount_list:
             try:
                 self._run_control(
-                    "sudo mkdir -p {}".format(shlex.quote(mount))
+                    "sudo mkdir -p {}".format(shlex.quote(str(mount)))
                 )
                 self._run_control(
-                    "sudo mount /dev/{} {}".format(dev, shlex.quote(mount))
+                    "sudo mount /dev/{} {}".format(
+                        dev, shlex.quote(str(mount))
+                    )
                 )
             except Exception:
                 # If unmountable or any other error, go on to the next one
@@ -380,7 +382,9 @@ class MuxPi:
             yield self.mount_point
         finally:
             for _, mount in mount_list:
-                self._run_control("sudo umount {}".format(shlex.quote(mount)))
+                self._run_control(
+                    "sudo umount {}".format(shlex.quote(str(mount)))
+                )
 
     def hardreset(self):
         """


### PR DESCRIPTION
## Description

Quick fix for a problem Kevin reported:
```
packages/testflinger_device_connectors/devices/muxpi/muxpi.py", line 383, in remote_mount
    self._run_control("sudo umount {}".format(shlex.quote(mount)))
  File "/usr/lib/python3.10/shlex.py", line 329, in quote
    if _find_unsafe(s) is None:
TypeError: expected string or bytes-like object
```

## Resolved issues

See above

## Documentation

N/A

## Web service API changes

N/A

## Tests

Tested deployment with this to ensure nothing else was needed.
