### PR TITLE
fix(oem_autoinstall): Fix download ISO from webdav URL with password

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/muxpi/oem_autoinstall/provision-image.sh
+++ b/device-connectors/src/testflinger_device_connectors/data/muxpi/oem_autoinstall/provision-image.sh
@@ -94,22 +94,50 @@ create_meta_data() {
 wget_iso_on_dut() {
     # Download ISO on DUT
     URL_TOKEN="$CONFIG_REPO_PATH"/url_token
-    WGET_OPTS="--no-verbose --tries=3"
-    # Optional URL credentials
-    if [ -r "$URL_TOKEN" ]; then
-        username=$(awk -F':' '/^username:/ {print $2}' "$URL_TOKEN" | xargs)
-        token=$(awk -F':' '/^token:/ {print $2}' "$URL_TOKEN" | xargs)
-        if [ -z "$username" ] || [ -z "$token" ]; then
-            echo "Error: check username or token format in $URL_TOKEN file"
-            exit 3
-        fi
-        WGET_OPTS+=" --auth-no-challenge --user=$username --password=$token"
-    fi
 
     echo "Downloading ISO on DUT..."
-    if ! $SSH "$TARGET_USER"@"$addr" -- sudo wget "$WGET_OPTS" -O /home/"$TARGET_USER"/"$ISO" "$URL_DUT"; then
-        echo "Downloading ISO on DUT failed."
-        exit 4
+    if [[ "$URL_DUT" =~ "oem-share" ]]; then
+        # use rclone for oem-share webdav storage, coz wget fails OpenID
+        if [ ! -f "$URL_TOKEN" ]; then
+            echo "oem-share URL requires webdav authentication. Please provide url_token file"
+            exit 3
+        fi
+        $SCP "$URL_TOKEN" "$TARGET_USER"@"$addr":/home/"$TARGET_USER"/
+
+        if ! $SSH "$TARGET_USER"@"$addr" -- sudo command -v rclone  >/dev/null 2>&1; then
+            $SSH "$TARGET_USER"@"$addr" -- sudo sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
+            $SSH "$TARGET_USER"@"$addr" -- sudo sudo DEBIAN_FRONTEND=noninteractive apt-get install -yqq rclone
+        fi
+
+        if [[ "$URL_DUT" =~ "partners" ]]; then
+            PROJECT=$(echo "$URL_DUT" | cut -d "/" -f 5)
+            FILEPATH=$(echo "$URL_DUT" | sed "s/.*share\///g")
+        else
+            PROJECT=$(echo "$URL_DUT" | cut -d "/" -f 5)
+            FILEPATH=$(echo "$URL_DUT" | sed "s/.*$PROJECT\///g")
+        fi
+
+        if ! $SSH "$TARGET_USER"@"$addr" -- sudo rclone --config /home/"$TARGET_USER"/url_token copy "$PROJECT":"$FILEPATH" /home/"$TARGET_USER"/; then
+            echo "Downloading ISO on DUT from oem-share failed."
+            exit 4
+        fi
+    else
+        WGET_OPTS="--no-verbose --tries=3"
+        # Optional URL credentials
+        if [ -r "$URL_TOKEN" ]; then
+            username=$(awk -F':' '/^username:/ {print $2}' "$URL_TOKEN" | xargs)
+            token=$(awk -F':' '/^token:/ {print $2}' "$URL_TOKEN" | xargs)
+            if [ -z "$username" ] || [ -z "$token" ]; then
+                echo "Error: check username or token format in $URL_TOKEN file"
+                exit 3
+            fi
+            WGET_OPTS+=" --auth-no-challenge --user=$username --password=$token"
+        fi
+
+        if ! $SSH "$TARGET_USER"@"$addr" -- sudo wget "$WGET_OPTS" -O /home/"$TARGET_USER"/"$ISO" "$URL_DUT"; then
+            echo "Downloading ISO on DUT failed."
+            exit 4
+        fi
     fi
 
     if ! $SSH "$TARGET_USER"@"$addr" -- sudo test -e /home/"$TARGET_USER"/"$ISO"; then

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -76,6 +76,7 @@ preconfigured
 preloaded
 provisionable
 provisioner
+rclone
 ReadMe
 readthedocs
 reST
@@ -112,6 +113,7 @@ USB
 UUID
 virtualenv
 VM
+webdav
 webhook
 WPA
 xenial

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -288,7 +288,7 @@ The ``oem_autoinstall`` device connector supports the following ``provision_data
 
           token: $MY_TOKEN
 
-        If ``url`` requries Webdav authentication, then device will use rclone to copy the file.
+        If ``url`` requires webdav authentication, then device will use rclone to copy the file.
         The rclone configurations must be provided in the following format:
 
           [$PROJECT]

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -288,6 +288,21 @@ The ``oem_autoinstall`` device connector supports the following ``provision_data
 
           token: $MY_TOKEN
 
+        If ``url`` requries Webdav authentication, then device will use rclone to copy the file.
+        The rclone configurations must be provided in the following format:
+
+          [$PROJECT]
+
+          type = webdav
+
+          url = $URL
+
+          vendor = other
+
+          user = $USER
+
+          pass = $PASSWORD
+
     * - ``user_data``
       - Required file provided with :ref:`file attachments <file_attachments>`.
         This file will be consumed by the autoinstall and cloud-init.


### PR DESCRIPTION
## Description
- When DUT needs to download ISO from the oem-share webdav behind OpenID, then wget fails.
So we have to use rclone in this case.
 Make provision-image.sh script to install rclone and scp rclone.conf to DUT, then run `rclone copy` on DUT to download the ISO

- When download from tel cache server need to add the tls cert. So provision-image.sh will copy the agent's cert to DUT
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Closes https://warthogs.atlassian.net/browse/OEX86-425
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
- Update oem_autoinstall docs to specify the rclone config file format
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
n/a
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
- Run charm agent and provision the laptop
- Use webdav [url](https://oem-share.canonical.com/partners/somerville/share/releases/noble/oem-24.04a/20240822-73/somerville-noble-oem-24.04a-20240822-73.iso) for ISO
Job pass:
https://testflinger.canonical.com/jobs/43a8a102-8e5a-4db5-8911-f0d858b0b1d0
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
