### PR TITLE
feat(muxpi): Record the time when the DUT has been rebooted

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -256,6 +256,7 @@ class MuxPi:
             self.run_post_provision_script()
 
         logger.info("Booting Test Image")
+        Path("provision-boot-time.stamp").touch()
         self.hardreset()
         self.check_test_image_booted()
 


### PR DESCRIPTION
## Description

This is a proposal for creating a timestamp file at the time where the DUT is rebooted, so that tests that want to measure boot times will have a reference timestamp.

With this change, the testing code can [`stat(2)`](https://manpages.ubuntu.com/manpages/xenial/en/man2/stat.2.html) the file and compare the `st_mtim` to the current time and get a better estimate of the full boot time (including low-level boot loaders, second-stage boot loaders and early kernel loading).

Using e.g. the device's uptime wouldn't take early bootloader stages into account, hence if those stages take too long, this isn't captured with uptime, so having the time when the device was "powered on" (hard-reset) would be good.

This is just an implementation proposal, it might be that such facilities already exist.

## Resolved issues

-

## Documentation

Not documented at the moment.

## Web service API changes

None.

## Tests

This has not been tested. I also haven't checked if the file would be cleared when a new provisioning session is started (it might be that we need to force-delete an existing file if it exists).