### PR TITLE
Add -q flag for ssh to prevent from outputing warning string

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -71,6 +71,7 @@ class MuxPi:
             "StrictHostKeyChecking=no",
             "-o",
             "UserKnownHostsFile=/dev/null",
+            "-q",
         )
 
     def get_credentials(self):

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -348,7 +348,12 @@ class MuxPi:
         lsblk_data = self._run_control(
             "lsblk -o NAME,LABEL -J {}".format(self.test_device)
         )
-        lsblk_json = json.loads(lsblk_data.decode())
+        filtered_lsblk_data = "\n".join(
+            line
+            for line in lsblk_data.splitlines()
+            if "Warning: Permanently added" not in line
+        )
+        lsblk_json = json.loads(filtered_lsblk_data.decode())
         # List of (name, label) pairs
         return [
             (x.get("name"), self.mount_point / x.get("label"))

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -350,10 +350,10 @@ class MuxPi:
         )
         filtered_lsblk_data = "\n".join(
             line
-            for line in lsblk_data.splitlines()
+            for line in lsblk_data.decode().splitlines()
             if "Warning: Permanently added" not in line
         )
-        lsblk_json = json.loads(filtered_lsblk_data.decode())
+        lsblk_json = json.loads(filtered_lsblk_data)
         # List of (name, label) pairs
         return [
             (x.get("name"), self.mount_point / x.get("label"))

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -71,7 +71,6 @@ class MuxPi:
             "StrictHostKeyChecking=no",
             "-o",
             "UserKnownHostsFile=/dev/null",
-            "-q",
         )
 
     def get_credentials(self):


### PR DESCRIPTION
## Description
The output from ssh commandf may contain some strings like `Warning: ...`. This will cause some string parsing error, so I suggest to add `-q` flag to prevent from outputing warning message.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
#352
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
N/A
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
N/A
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
