### PR TITLE
Add agent_name in TF environment

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -195,6 +195,12 @@ class DefaultDevice:
         serial_port = config.get("serial_port")
         serial_proc = SerialLogger(serial_host, serial_port, "test-serial.log")
         serial_proc.start()
+
+        extra_env = {}
+        extra_env["agent_name"] = self.config.get("agent_name")
+        if "env" not in self.config:
+            self.config["env"] = {}
+        self.config["env"].update(extra_env)
         try:
             exitcode = testflinger_device_connectors.run_test_cmds(
                 test_cmds, config

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -197,10 +197,10 @@ class DefaultDevice:
         serial_proc.start()
 
         extra_env = {}
-        extra_env["AGENT_NAME"] = self.config.get("agent_name", "")
-        if "env" not in self.config:
-            self.config["env"] = {}
-        self.config["env"].update(extra_env)
+        extra_env["AGENT_NAME"] = config.get("agent_name", "")
+        if "env" not in config:
+            config["env"] = {}
+        config["env"].update(extra_env)
         try:
             exitcode = testflinger_device_connectors.run_test_cmds(
                 test_cmds, config

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -197,7 +197,7 @@ class DefaultDevice:
         serial_proc.start()
 
         extra_env = {}
-        extra_env["agent_name"] = self.config.get("agent_name")
+        extra_env["AGENT_NAME"] = self.config.get("agent_name", "")
         if "env" not in self.config:
             self.config["env"] = {}
         self.config["env"].update(extra_env)


### PR DESCRIPTION

## Description
It is currently impossible to guess the name of the device agent from a testflinger job running from a device agent queue. This is unfortunate since we have a few Riverside tools that abstract the complexity of a setup, given the device name as an argument. Adding it as an environment variable would reduce the development effort on those tools and can probably benefit as well to other use cases.

We feel the need for this change in the context of https://warthogs.atlassian.net/browse/PERI-572.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
