### PR TITLE
Update tf-cmd-scripts to work with the new agent-host charm

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -151,10 +151,20 @@ class TestflingerAgentHostCharm(CharmBase):
         """Update tf-cmd-scripts"""
         self.unit.status = MaintenanceStatus("Installing tf-cmd-scripts")
         tf_cmd_dir = "src/tf-cmd-scripts/"
-        usr_local_bin = "/usr/local/bin/"
+        usr_local_bin = Path("/usr/local/bin")
+
         for tf_cmd_file in os.listdir(tf_cmd_dir):
-            shutil.copy(os.path.join(tf_cmd_dir, tf_cmd_file), usr_local_bin)
-            os.chmod(os.path.join(usr_local_bin, tf_cmd_file), 0o775)
+            template = Template(
+                open(os.path.join(tf_cmd_dir, tf_cmd_file)).read()
+            )
+            rendered = template.render(
+                agent_configs_path=AGENT_CONFIGS_PATH,
+                config_dir=self.config.get("config-dir"),
+                virtual_env_path=VIRTUAL_ENV_PATH,
+            )
+            agent_file = usr_local_bin / tf_cmd_file
+            agent_file.write_text(rendered)
+            agent_file.chmod(0o775)
 
     def on_upgrade_charm(self, _):
         """Upgrade hook"""

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-allocate
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-allocate
@@ -3,4 +3,13 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE allocate -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+# The following variables are set by the agent charm
+AGENT_CONFIGS_PATH={{ agent_configs_path }}
+CONFIG_DIR="{{ config_dir }}"
+VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
+
+if [ -d "$VIRTUAL_ENV_PATH" ]; then
+    PYTHONUNBUFFERED=1 $VIRTUAL_ENV_PATH/bin/testflinger-device-connector $PROVISION_TYPE allocate -c $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json
+else
+    . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE allocate -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
@@ -2,6 +2,11 @@
 
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
+VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
-echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+if [ -d "$VIRTUAL_ENV_PATH" ]; then
+    echo Cleaning up container if it exists... && docker rm -f $agent_id || /bin/true
+else
+    echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+fi
 

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-firmware-update
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-firmware-update
@@ -3,4 +3,13 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE firmware_update -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+# The following variables are set by the agent charm
+AGENT_CONFIGS_PATH={{ agent_configs_path }}
+CONFIG_DIR="{{ config_dir }}"
+VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
+
+if [ -d "$VIRTUAL_ENV_PATH" ]; then
+    PYTHONUNBUFFERED=1 $VIRTUAL_ENV_PATH/bin/testflinger-device-connector $PROVISION_TYPE firmware_update -c $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json
+else
+    . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE firmware_update -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-provision
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-provision
@@ -3,4 +3,13 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE provision -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+# The following variables are set by the agent charm
+AGENT_CONFIGS_PATH={{ agent_configs_path }}
+CONFIG_DIR="{{ config_dir }}"
+VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
+
+if [ -d "$VIRTUAL_ENV_PATH" ]; then
+    PYTHONUNBUFFERED=1 $VIRTUAL_ENV_PATH/bin/testflinger-device-connector $PROVISION_TYPE provision -c $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json
+else
+    . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE provision -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-reserve
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-reserve
@@ -3,4 +3,13 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE reserve -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+# The following variables are set by the agent charm
+AGENT_CONFIGS_PATH={{ agent_configs_path }}
+CONFIG_DIR="{{ config_dir }}"
+VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
+
+if [ -d "$VIRTUAL_ENV_PATH" ]; then
+    PYTHONUNBUFFERED=1 $VIRTUAL_ENV_PATH/bin/testflinger-device-connector $PROVISION_TYPE reserve -c $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json
+else
+    . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE reserve -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-setup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-setup
@@ -2,6 +2,11 @@
 
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
+VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
-echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+if [ -d "$VIRTUAL_ENV_PATH" ]; then
+    echo Cleaning up container if it exists... && docker rm -f $agent_id || /bin/true
+else
+    echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+fi
 

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -3,4 +3,19 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-docker run -t --name $AGENT -v $PWD:/home/ubuntu -v ~/.ssh:/home/ubuntu/.ssh:ro -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT plars/testflinger-testenv-focal bash -c "(cd /srv/testflinger-agent/$AGENT/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json"
+# The following variables are set by the agent charm
+AGENT_CONFIGS_PATH={{ agent_configs_path }}
+CONFIG_DIR="{{ config_dir }}"
+VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
+
+if [ -d "$VIRTUAL_ENV_PATH" ]; then
+    docker run -t --name $agent_id \
+        -v $PWD:/home/ubuntu \
+        -v ~/.ssh:/home/ubuntu/.ssh:ro \
+        -v /srv/testflinger:/srv/testflinger \
+        -v $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id:$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id \
+        plars/testflinger-testenv-focal \
+        bash -c "(cd /srv/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json"
+else
+    docker run -t --name $AGENT -v $PWD:/home/ubuntu -v ~/.ssh:/home/ubuntu/.ssh:ro -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT plars/testflinger-testenv-focal bash -c "(cd /srv/testflinger-agent/$AGENT/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json"
+fi


### PR DESCRIPTION
## Description

Update the tf-cmd-scripts used to simplify what we need to run during the agent phases. This version of them will work with the existing agent just in case we need that for transition (but I doubt that will really be needed). So they technially *could* land against main, but it's best to keep them with the feature branch I think. This will make it so that they use the single environment where testflinger agent/device-connector is installed.

## Resolved issues

CERTTF-381

## Documentation

N/A

## Web service API changes

N/A

## Tests

Tested locally with some "fake" agents that actually ran some test commands in the docker container, completed a reservation, etc.
