### PR TITLE
Reset storage to flat layout if no default is specified

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -254,8 +254,9 @@ class Maas2:
             if not def_storage_data:
                 self._logger_warning(
                     "'default_disks' and/or 'disks' unspecified; "
-                    "skipping storage layout configuration"
+                    "setting default storage layout to flat"
                 )
+                self.set_flat_storage_layout()
             else:
                 # reset to the default layout
                 try:
@@ -401,3 +402,19 @@ class Maas2:
             "recover!".format(self.agent_name, status)
         )
         raise RecoveryError("Device recovery failed!")
+
+    def set_flat_storage_layout(self):
+        """Reset to default flat storage layout"""
+        cmd = [
+            "maas",
+            self.maas_user,
+            "machine",
+            "set-storage-layout",
+            self.node_id,
+            "storage_layout=flat",
+        ]
+        proc = subprocess.run(cmd, check=False)
+        if proc.returncode:
+            self._logger_error(
+                "Unable to set flat disk layout, attempting to continue anyway"
+            )


### PR DESCRIPTION
## Description

The maas device connector supports specifying a storage configuration in the job, and allows a default to be set in the device-connector config for it to reset back to if it's not specified. However, if this isn't set, there's no way for it to know how to set it back to something "safe". This forces it back into a default "flat" layout which should match what it had when the system was originally enrolled in maas.

## Resolved issues

N/A

## Documentation
N/A

## Web service API changes
N/A

## Tests
Tested on a maas agent by sending a job with a storage layout to see that it used the one in the job, then sending one without a storage layout in the job to see that it was reset back to a flat layout. This system did not have a default layout configured in the device connector config.