### PR TITLE
Add logic to validate token and check priority permissions

### DIFF
--- a/docs/reference/job-schema.rst
+++ b/docs/reference/job-schema.rst
@@ -54,7 +54,7 @@ The following table lists the key elements that a job definition file should con
     - | (Optional) URL to send job status updates to. These updates originate from the agent and get posted to the server which then posts the update to the webhook. If no webhook is specified, these updates will not be generated.
   * - ``job_priority``
     - integer
-    - | (Optional) Integer specifying how much priority this job has. Jobs with higher job_priority will be selected by agents before other jobs. Specifying a job priority requires authorization in the form of a JWT obtained by sending a GET request to /v1/authenticate/<client-id> with a valid client_id and client-key.
+    - | (Optional) Integer specifying how much priority this job has. Jobs with higher job_priority will be selected by agents before other jobs. Specifying a job priority requires authorization in the form of a JWT obtained by sending a POST request to /v1/oauth2/token with a client id and client key specified in an Authorization header.
 
 Example jobs in YAML
 ----------------------------

--- a/docs/reference/job-schema.rst
+++ b/docs/reference/job-schema.rst
@@ -52,6 +52,9 @@ The following table lists the key elements that a job definition file should con
     - string
     - /
     - | (Optional) URL to send job status updates to. These updates originate from the agent and get posted to the server which then posts the update to the webhook. If no webhook is specified, these updates will not be generated.
+  * - ``job_priority``
+    - integer
+    - | (Optional) Integer specifying how much priority this job has. Jobs with higher job_priority will be selected by agents before other jobs. Specifying a job priority requires authorization in the form of a JWT obtained by sending a GET request to /v1/authenticate/<client-id> with a valid client_id and client-key.
 
 Example jobs in YAML
 ----------------------------

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -115,6 +115,7 @@ class Job(Schema):
     allocate_data = fields.Dict(required=False)
     reserve_data = fields.Dict(required=False)
     job_status_webhook = fields.String(required=False)
+    job_priority = fields.Integer(required=False)
 
 
 class JobId(Schema):

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -20,7 +20,6 @@ Testflinger v1 API
 import os
 import uuid
 from datetime import datetime, timezone, timedelta
-
 import pkg_resources
 from apiflask import APIBlueprint, abort
 from flask import jsonify, request, send_file
@@ -75,9 +74,9 @@ def job_post(json_data: dict):
         job_queue = ""
     if not job_queue:
         abort(422, message="Invalid data or no job_queue specified")
-
+    auth_token = request.headers.get("Authorization")
     try:
-        job = job_builder(json_data)
+        job = job_builder(json_data, auth_token)
     except ValueError:
         abort(400, message="Invalid job_id specified")
 
@@ -101,7 +100,33 @@ def has_attachments(data: dict) -> bool:
     )
 
 
-def job_builder(data):
+def check_token_permission(
+    auth_token: str, secret_key: str, priority: int, queue: str
+) -> bool:
+    """
+    Validates token received from client and checks if it can
+    push a job to the queue with the requested priority
+    """
+    if auth_token is None:
+        abort(401, "No authentication token specified")
+    else:
+        try:
+            decoded_jwt = jwt.decode(
+                auth_token,
+                secret_key,
+                algorithms="HS256",
+                options={"require": ["exp", "iat", "sub", "max_priority"]},
+            )
+        except jwt.exceptions.ExpiredSignatureError:
+            abort(403, "Token has expired")
+        except jwt.exceptions.InvalidTokenError:
+            abort(403, "Invalid Token")
+
+        max_priority = decoded_jwt["max_priority"].get(queue, 0)
+        return max_priority >= priority
+
+
+def job_builder(data: dict, auth_token: str):
     """Build a job from a dictionary of data"""
     job = {
         "created_at": datetime.now(timezone.utc),
@@ -124,6 +149,27 @@ def job_builder(data):
     if has_attachments(data):
         data["attachments_status"] = "waiting"
 
+    if "job_priority" in data:
+        priority_level = data["job_priority"]
+        job_queue = data["job_queue"]
+        allowed = check_token_permission(
+            auth_token,
+            os.environ.get("JWT_SIGNING_KEY"),
+            priority_level,
+            job_queue,
+        )
+        if not allowed:
+            abort(
+                403,
+                (
+                    f"Not enough permissions to push to {job_queue}",
+                    f"with priority {priority_level}",
+                ),
+            )
+        job["job_priority"] = priority_level
+        data.pop("job_priority")
+    else:
+        job["job_priority"] = 0
     job["job_id"] = job_id
     job["job_data"] = data
     return job
@@ -676,6 +722,8 @@ def validate_client_key_pair(client_id: str, client_key: str):
     """
     Checks client_id and key pair for validity and returns their permissions
     """
+    if client_key is None:
+        return None
     client_key_bytes = client_key.encode("utf-8")
     client_permissions_entry = database.mongo.db.client_permissions.find_one(
         {

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -79,6 +79,7 @@ def mongo_app_with_permissions(mongo_app):
     ).decode("utf-8")
 
     max_priority = {
+        "*": 1,
         "myqueue": 100,
         "myqueue2": 200,
     }

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -803,6 +803,24 @@ def test_job_with_priority(mongo_app_with_permissions):
     assert 200 == job_response.status_code
 
 
+def test_star_priority(mongo_app_with_permissions):
+    """
+    Tests submission of priority job for a generic queue
+    with star priority permissions
+    """
+    app, _, client_id, client_key, _ = mongo_app_with_permissions
+    authenticate_output = app.post(
+        "/v1/oauth2/token",
+        headers=create_auth_header(client_id, client_key),
+    )
+    token = authenticate_output.data.decode("utf-8")
+    job = {"job_queue": "mygenericqueue", "job_priority": 1}
+    job_response = app.post(
+        "/v1/job", json=job, headers={"Authorization": token}
+    )
+    assert 200 == job_response.status_code
+
+
 def test_priority_no_token(mongo_app_with_permissions):
     """Tests rejection of priority job with no token"""
     app, _, _, _, _ = mongo_app_with_permissions


### PR DESCRIPTION
## Description

Requires #335. This PR updates the job schema include a new job_priority field. In order for a job to specify a job_priority, the client needs to include a signed JWT that gives them the permission to push a job to the specified queue at their specified priority level. This PR includes validation of the attached JWT with jobs that specify priority. After token validation, job priority is added to the job structure in the database.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

Resolves https://warthogs.atlassian.net/browse/CERTTF-371

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
 
Job schema docs were updated to reflect addition of job_priority field.
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

POST /v1/job endpoint updated to include token validation  

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Unit tests were added to test_v1.py.
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
