### PR TITLE
[CERTTF-414] Generalise how the exit status of the `submit` action is determined

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -95,6 +95,6 @@ runs:
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
         # retrieve results
-        STATUS=$(testflinger --server $SERVER results $JOB_ID | jq -er .test_status)
+        STATUS=$(testflinger --server $SERVER results $JOB_ID | jq 'to_entries | map(select(.key | endswith("_status"))) | map(.value) | max')
         echo "Test exit status: $STATUS"
         exit $STATUS

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -96,6 +96,18 @@ runs:
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
         # retrieve results:
         # the exit status is the maximum status of the individual test phases
-        STATUS=$(testflinger --server $SERVER results $JOB_ID | jq 'to_entries | map(select(.key | endswith("_status"))) | map(.value) | max')
+        # (excluding the setup and cleanup phases)
+        STATUS=$(\
+          testflinger --server $SERVER results $JOB_ID  \
+          | jq 'to_entries
+              | map(
+                  select(
+                    (.key | endswith("_status"))
+                    and .key != "setup_status"
+                    and .key != "cleanup_status"
+                  ).value
+                )
+              | max'
+        )
         echo "Test exit status: $STATUS"
         exit $STATUS

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -94,7 +94,8 @@ runs:
       run: |
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
-        # retrieve results
+        # retrieve results:
+        # the exit status is the maximum status of the individual test phases
         STATUS=$(testflinger --server $SERVER results $JOB_ID | jq 'to_entries | map(select(.key | endswith("_status"))) | map(.value) | max')
         echo "Test exit status: $STATUS"
         exit $STATUS


### PR DESCRIPTION
## Description

A user of the Testflinger `submit` action [reported](https://chat.canonical.com/canonical/pl/h6za964h138rtekissqqj4n58r) that they ran a job that completed successfully, and yet the `submit` action failed. On examination, the user's [workflow](https://github.com/canonical/xlnx-image-definitions/actions/runs/10936195947/workflow) submitted a job that only had a provisioning phase, without a test phase. The `submit` action currently uses the result of the test phase as the exit status of the action, thus failing when there is no such phase.

This PR generalises the way that the exit status of the `submit` action is computed. In particular, instead of using only the result of the test phase (`test_status`) as previously, it takes the _maximum_ of the results of all phases, excluding the setup and cleanup phases. Therefore, the action fails if any of these phases fail and succeeds if all phases are successful.

## Resolved issues

Resolves [CERTTF-414](https://warthogs.atlassian.net/browse/CERTTF-414).

## Tests

The updated version of the `submit` action from this branch has been tested with three workflows:
- A workflow submitting a job that fails in the provisioning phase (by specifying a bogus image in the `provisioning_data`) [[run](https://github.com/canonical/hwcert-jenkins-tools/actions/runs/10941386993/job/30375906451)]
- A workflow submitting a job that fails in the test phase, after successful provisioning (by executing an `exit 1` in the `test_cmds`) [[run](https://github.com/canonical/hwcert-jenkins-tools/actions/runs/10944164805/job/30385365594)]
- A workflow submitting a job that succeeds (by executing an `exit 0` in the `test_cmds`) [[run](https://github.com/canonical/hwcert-jenkins-tools/actions/runs/10956003693/job/30422542892)]

[CERTTF-414]: https://warthogs.atlassian.net/browse/CERTTF-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ