### PR TITLE
Cancel job on cancel

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -44,6 +44,7 @@ runs:
         else
           echo "Successful server ping at $SERVER, status: $STATUS"
         fi
+
     - name: Create job file, if required
       id: create-job-file
       shell: bash
@@ -98,7 +99,8 @@ runs:
         STATUS=$(testflinger --server $SERVER results $JOB_ID | jq -er .test_status)
         echo "Test exit status: $STATUS"
         exit $STATUS
-    - name: Cleanup the job if the action is cancelled
+
+    - name: Cancel the job if the action is cancelled
       if: ${{ cancelled() }}
       shell: bash
       env:

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -98,3 +98,10 @@ runs:
         STATUS=$(testflinger --server $SERVER results $JOB_ID | jq -er .test_status)
         echo "Test exit status: $STATUS"
         exit $STATUS
+    - name: Cleanup the job if the action is cancelled
+      if: ${{ cancelled() }}
+      env:
+        SERVER: https://${{ inputs.server }}
+        JOB_ID: ${{ steps.submit.outputs.id }}
+      run: |
+        testflinger --server $SERVER cancel $JOB_ID

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -100,6 +100,7 @@ runs:
         exit $STATUS
     - name: Cleanup the job if the action is cancelled
       if: ${{ cancelled() }}
+      shell: bash
       env:
         SERVER: https://${{ inputs.server }}
         JOB_ID: ${{ steps.submit.outputs.id }}


### PR DESCRIPTION
## Description

If the parent job is cancelled, the action doesn't cancel the ongoing job on the agent. This leaves the machine "booked", therefore makes re-runs more clunky because one has to recover the job id and cancel it manually (and if one doesn't know to do that, they have to wait for themselves and will make everybody else wait for no reason). 

## Resolved issues

N/A

## Documentation

I think the behaviour is sort of expected of the action, so I feel like it doesn't need to be documented.

## Web service API changes

N/A

## Tests

Workflow cancelled: https://github.com/canonical/checkbox/actions/runs/11030566598/job/30635402882

Also cancelled on testflinger: https://testflinger.canonical.com/jobs/7db6277b-1b93-46f0-a63a-ca4ee7d420c6
