### PR TITLE
[CERTTF-412][CERTTF-413] refactor: treat attachment unpacking as a separate phase

### DIFF
--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -55,7 +55,7 @@ class TestflingerAgent:
     def __init__(self, client):
         self.client = client
         signal.signal(signal.SIGUSR1, self.restart_signal_handler)
-        # [TODO] What is the relation between the agent state and the job state?
+        # [TODO] Investigate relation between the agent state and the job state
         self.set_agent_state("waiting")
         self._post_initial_agent_data()
 

--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -20,11 +20,12 @@ import os
 from pathlib import Path
 import tempfile
 import time
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Type, NamedTuple
 
+from testflinger_agent.client import TestflingerClient
 from testflinger_agent.config import ATTACHMENTS_DIR
 from testflinger_agent.errors import TFServerError
-from testflinger_common.enums import TestEvent, TestPhase
+from testflinger_common.enums import TestEvent, TestPhase, JobState
 from .runner import CommandRunner, RunnerEvents
 from .handlers import LiveOutputHandler, LogUpdateHandler
 from .stop_condition_checkers import (
@@ -51,6 +52,35 @@ else:
 logger = logging.getLogger(__name__)
 
 
+class TestflingerJobParameters(NamedTuple):
+
+    job_data: dict
+    client: TestflingerClient
+    rundir: Path
+
+    def get_global_timeout(self):
+        """Get the global timeout for the test run in seconds"""
+        # Default timeout is 4 hours
+        default_timeout = 4 * 60 * 60
+
+        # Don't exceed the maximum timeout configured for the device!
+        return min(
+            self.job_data.get("global_timeout", default_timeout),
+            self.client.config.get("global_timeout", default_timeout),
+        )
+
+    def get_output_timeout(self):
+        """Get the output timeout for the test run in seconds"""
+        # Default timeout is 15 minutes
+        default_timeout = 15 * 60
+
+        # Don't exceed the maximum timeout configured for the device!
+        return min(
+            self.job_data.get("output_timeout", default_timeout),
+            self.client.config.get("output_timeout", default_timeout),
+        )
+
+
 class TestflingerJobPhase(ABC):
     """
     Represents a phase in a Testflinger job.
@@ -58,14 +88,14 @@ class TestflingerJobPhase(ABC):
 
     phase: TestPhase = None
 
-    def __init__(self, job_data, client, rundir):
-        self.client = client
-        self.job_data = job_data
-        self.rundir = rundir
-        self.results_file = os.path.join(rundir, "testflinger-outcome.json")
-        self.output_log = os.path.join(rundir, self.phase + ".log")
-        self.serial_log = os.path.join(rundir, self.phase + "-serial.log")
-        self.runner = CommandRunner(cwd=rundir, env=client.config)
+    def __init__(self, params: TestflingerJobParameters):
+        self.params = params
+        self.results_file = params.rundir / "testflinger-outcome.json"
+        self.output_log = params.rundir / f"{self.phase}.log"
+        self.serial_log = params.rundir / f"{self.phase}-serial.log"
+        self.runner = CommandRunner(
+            cwd=params.rundir, env=params.client.config
+        )
 
     @abstractmethod
     def go(self) -> bool:
@@ -90,7 +120,7 @@ class TestflingerJobPhase(ABC):
         """
         raise NotImplementedError
 
-    def post(self):
+    def post_core(self):
         """
         Execute any possible actions after the "core" of the phase
         """
@@ -108,7 +138,9 @@ class TestflingerJobPhase(ABC):
         # register the output handlers with the runner
         self.runner.register_output_handler(LogUpdateHandler(self.output_log))
         self.runner.register_output_handler(
-            LiveOutputHandler(self.client, self.job_data["job_id"])
+            LiveOutputHandler(
+                self.params.client, self.params.job_data["job_id"]
+            )
         )
         # perform additional runner registrations
         self.register()
@@ -116,23 +148,23 @@ class TestflingerJobPhase(ABC):
         # display phase banner in the Testflinger output
         for line in self.banner(
             f"Starting testflinger {self.phase} phase "
-            f"on {self.client.config.get('agent_id')}"
+            f"on {self.params.client.config.get('agent_id')}"
         ):
             self.runner.run(f"echo '{line}'")
 
         # run the "core" of the phase
         try:
             exitcode, exit_event, exit_reason = self.core()
-        except Exception as exc:
+        except Exception as error:
             exit_event = f"{self.phase}_fail"
             exitcode = 100
-            exit_reason = f"{type(exc).__name__}: {exc}"
+            exit_reason = f"{type(error).__name__}: {error}"
             logger.exception(exit_reason)
         finally:
             self._update_results(exitcode)
 
         # perform any post-core actions
-        self.post()
+        self.post_core()
 
         return exitcode, exit_event, exit_reason
 
@@ -144,45 +176,23 @@ class TestflingerJobPhase(ABC):
         """
         with open(self.results_file, "r+") as results:
             outcome_data = json.load(results)
-            outcome_data[self.phase + "_status"] = exitcode
+            outcome_data[f"{self.phase}_status"] = exitcode
             try:
                 with open(self.output_log, "r+", encoding="utf-8") as logfile:
-                    self._set_truncate(logfile)
-                    outcome_data[self.phase + "_output"] = logfile.read()
+                    set_truncate(logfile)
+                    outcome_data[f"{self.phase}_output"] = logfile.read()
             except FileNotFoundError:
                 pass
             try:
                 with open(
                     self.serial_log, "r+", encoding="utf-8", errors="ignore"
                 ) as logfile:
-                    self._set_truncate(logfile)
-                    outcome_data[self.phase + "_serial"] = logfile.read()
+                    set_truncate(logfile)
+                    outcome_data[f"{self.phase}_serial"] = logfile.read()
             except FileNotFoundError:
                 pass
             results.seek(0)
             json.dump(outcome_data, results)
-
-    def get_global_timeout(self):
-        """Get the global timeout for the test run in seconds"""
-        # Default timeout is 4 hours
-        default_timeout = 4 * 60 * 60
-
-        # Don't exceed the maximum timeout configured for the device!
-        return min(
-            self.job_data.get("global_timeout", default_timeout),
-            self.client.config.get("global_timeout", default_timeout),
-        )
-
-    def get_output_timeout(self):
-        """Get the output timeout for the test run in seconds"""
-        # Default timeout is 15 minutes
-        default_timeout = 15 * 60
-
-        # Don't exceed the maximum timeout configured for the device!
-        return min(
-            self.job_data.get("output_timeout", default_timeout),
-            self.client.config.get("output_timeout", default_timeout),
-        )
 
     def banner(self, line):
         """Yield text lines to print a banner around a string
@@ -194,33 +204,16 @@ class TestflingerJobPhase(ABC):
         yield "* {} *".format(line)
         yield "*" * (len(line) + 4)
 
-    def _set_truncate(self, f, size=1024 * 1024):
-        """Set up an open file so that we don't read more than a specified
-           size. We want to read from the end of the file rather than the
-           beginning. Write a warning at the end of the file if it was too big.
-
-        :param f:
-            The file object, which should be opened for read/write
-        :param size:
-            Maximum number of bytes we want to allow from reading the file
-        """
-        end = f.seek(0, 2)
-        if end > size:
-            f.write("\nWARNING: File has been truncated due to length!")
-            f.seek(end - size, 0)
-        else:
-            f.seek(0, 0)
-
 
 class ExternalCommandPhase(TestflingerJobPhase):
     """
     Phases with a core executing an external command, specified in the config
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, params: TestflingerJobParameters):
+        super().__init__(params)
         # retieve the external command to be executed
-        self.cmd = self.client.config.get(self.phase + "_command")
+        self.cmd = self.params.client.config.get(self.phase + "_command")
 
     def go(self) -> bool:
         # the phase is "go" if the external command has been specified
@@ -241,30 +234,30 @@ class UnpackPhase(TestflingerJobPhase):
 
     # phases for which attachments are allowed
     supported_phases = (
-        TestPhase.PROVISION, TestPhase.FIRMWARE_UPDATE, TestPhase.TEST
+        TestPhase.PROVISION,
+        TestPhase.FIRMWARE_UPDATE,
+        TestPhase.TEST,
     )
 
     def register(self):
         self.runner.register_stop_condition_checker(
-            GlobalTimeoutChecker(self.get_global_timeout())
+            GlobalTimeoutChecker(self.params.get_global_timeout())
         )
 
     def go(self) -> bool:
-        if self.job_data.get("attachments_status") != "complete":
+        if self.params.job_data.get("attachments_status") != "complete":
             # the phase is "go" if attachments have been provided
-            logger.info(
-                "No attachments provided in job data, skipping..."
-            )
+            logger.info("No attachments provided in job data, skipping...")
             return False
         return True
 
     def core(self) -> Tuple[int, Optional[TestEvent], str]:
         try:
-            self.unpack_attachments(self.job_data)
+            self.unpack_attachments()
         except Exception as error:
             # use the runner to display the error
             # (so that the output is also included in the phase results)
-            for line in f"{type(error).__name__}: {error}".split('\n'):
+            for line in f"{type(error).__name__}: {error}".split("\n"):
                 self.runner.run(f"echo '{line}'")
             # propagate the error (`run` uniformly handles fail cases)
             raise
@@ -286,35 +279,35 @@ class UnpackPhase(TestflingerJobPhase):
         if not str(resolved).startswith(
             tuple(f"{phase}/" for phase in self.supported_phases)
         ):
-            # trying to extract in an invalid folder, under the attachments folder
+            # trying to extract in invalid folder under the attachments folder
             raise tarfile.OutsideDestinationError(member, path)
         return tarfile.data_filter(member, path)
 
-    def unpack_attachments(self, job_data: dict):
+    def unpack_attachments(self):
         """Download and unpack the attachments associated with a job"""
-        job_id = job_data["job_id"]
+        job_id = self.params.job_data["job_id"]
 
         with tempfile.NamedTemporaryFile(suffix=".tar.gz") as archive_tmp:
             archive_path = Path(archive_tmp.name)
             # download attachment archive
             logger.info(f"Downloading attachments for {job_id}")
-            self.client.get_attachments(job_id, path=archive_path)
+            self.params.client.get_attachments(job_id, path=archive_path)
             # extract archive into the attachments folder
             logger.info(f"Unpacking attachments for {job_id}")
             with tarfile.open(archive_path, "r:gz") as tar:
                 tar.extractall(
-                    Path(self.rundir) / ATTACHMENTS_DIR,
-                    filter=self.secure_filter
+                    self.params.rundir / ATTACHMENTS_DIR,
+                    filter=self.secure_filter,
                 )
 
-        # side effect: remove all attachment data from `job_data`
+        # side effect: remove all attachment data from `self.params.job_data`
         # (so there is no interference with existing processes, especially
         # provisioning or firmware update, which are triggered when these
         # sections are not empty)
         for phase in self.supported_phases:
             phase_str = f"{phase}_data"
             try:
-                phase_data = job_data[phase_str]
+                phase_data = self.params.job_data[phase_str]
             except KeyError:
                 pass
             else:
@@ -323,7 +316,7 @@ class UnpackPhase(TestflingerJobPhase):
                 # it may be the case that attachments were the only data
                 # included for this phase, so the phase can now be removed
                 if not phase_data:
-                    del job_data[phase_str]
+                    del self.params.job_data[phase_str]
 
 
 class SetupPhase(ExternalCommandPhase):
@@ -332,7 +325,7 @@ class SetupPhase(ExternalCommandPhase):
 
     def register(self):
         self.runner.register_stop_condition_checker(
-            GlobalTimeoutChecker(self.get_global_timeout())
+            GlobalTimeoutChecker(self.params.get_global_timeout())
         )
 
 
@@ -344,7 +337,7 @@ class FirmwarePhase(ExternalCommandPhase):
         if not super().go():
             return False
         # the phase is "go" if the phase data has been provided
-        if not self.job_data.get(f"{self.phase}_data"):
+        if not self.params.job_data.get(f"{self.phase}_data"):
             logger.info(
                 "No %s_data defined in job data, skipping...", self.phase
             )
@@ -353,7 +346,7 @@ class FirmwarePhase(ExternalCommandPhase):
 
     def register(self):
         self.runner.register_stop_condition_checker(
-            GlobalTimeoutChecker(self.get_global_timeout())
+            GlobalTimeoutChecker(self.params.get_global_timeout())
         )
 
 
@@ -365,7 +358,7 @@ class ProvisionPhase(ExternalCommandPhase):
         if not super().go():
             return False
         # the phase is "go" if the phase data has been provided
-        if not self.job_data.get(f"{self.phase}_data"):
+        if not self.params.job_data.get(f"{self.phase}_data"):
             logger.info(
                 "No %s_data defined in job data, skipping...", self.phase
             )
@@ -374,11 +367,13 @@ class ProvisionPhase(ExternalCommandPhase):
 
     def register(self):
         self.runner.register_stop_condition_checker(
-            GlobalTimeoutChecker(self.get_global_timeout())
+            GlobalTimeoutChecker(self.params.get_global_timeout())
         )
         # Do not allow cancellation during provision for safety reasons
         self.runner.register_stop_condition_checker(
-            JobCancelledChecker(self.client, self.job_data["job_id"])
+            JobCancelledChecker(
+                self.params.client, self.params.job_data["job_id"]
+            )
         )
 
 
@@ -390,7 +385,7 @@ class TestCommandsPhase(ExternalCommandPhase):
         if not super().go():
             return False
         # the phase is "go" if the phase data has been provided
-        if not self.job_data.get(f"{self.phase}_data"):
+        if not self.params.job_data.get(f"{self.phase}_data"):
             logger.info(
                 "No %s_data defined in job data, skipping...", self.phase
             )
@@ -399,11 +394,11 @@ class TestCommandsPhase(ExternalCommandPhase):
 
     def register(self):
         self.runner.register_stop_condition_checker(
-            GlobalTimeoutChecker(self.get_global_timeout())
+            GlobalTimeoutChecker(self.params.get_global_timeout())
         )
         # We only need to check for output timeouts during the test phase
         output_timeout_checker = OutputTimeoutChecker(
-            self.get_output_timeout()
+            self.params.get_output_timeout()
         )
         self.runner.register_stop_condition_checker(output_timeout_checker)
         self.runner.subscribe_event(
@@ -420,22 +415,22 @@ class AllocatePhase(ExternalCommandPhase):
             return False
         # the phase is "go" if the phase data has been provided
         # (but no message is logged otherwise)
-        if not self.job_data.get(f"{self.phase}_data"):
+        if not self.params.job_data.get(f"{self.phase}_data"):
             return False
         return True
 
     def register(self):
         self.runner.register_stop_condition_checker(
-            GlobalTimeoutChecker(self.get_global_timeout())
+            GlobalTimeoutChecker(self.params.get_global_timeout())
         )
 
-    def post(self):
+    def post_core(self):
         """
         Read the json dict from "device-info.json" and send it to the server
         so that the multi-device agent can find the IP addresses of all
         subordinate jobs
         """
-        device_info_file = os.path.join(self.rundir, "device-info.json")
+        device_info_file = self.params.rundir / "device-info.json"
         with open(device_info_file, "r") as f:
             device_info = json.load(f)
 
@@ -443,13 +438,17 @@ class AllocatePhase(ExternalCommandPhase):
         # device job can't continue
         while True:
             try:
-                self.client.post_result(self.job_data["job_id"], device_info)
+                self.params.client.post_result(
+                    self.params.job_data["job_id"], device_info
+                )
                 break
             except TFServerError:
                 logger.warning("Failed to post device_info, retrying...")
                 time.sleep(60)
 
-        self.client.post_job_state(self.job_data["job_id"], "allocated")
+        self.params.client.post_job_state(
+            self.params.job_data["job_id"], JobState.ALLOCATED
+        )
         self.wait_for_completion()
 
     def wait_for_completion(self):
@@ -457,21 +456,29 @@ class AllocatePhase(ExternalCommandPhase):
 
         while True:
             try:
-                this_job_state = self.client.check_job_state(
-                    self.job_data["job_id"]
+                this_job_state = self.params.client.check_job_state(
+                    self.params.job_data["job_id"]
                 )
-                if this_job_state in ("complete", "completed", "cancelled"):
+                if this_job_state in (
+                    "complete",
+                    JobState.COMPLETED,
+                    JobState.CANCELLED,
+                ):
                     logger.info("This job completed, exiting...")
                     break
 
-                parent_job_id = self.job_data.get("parent_job_id")
+                parent_job_id = self.params.job_data.get("parent_job_id")
                 if not parent_job_id:
                     logger.warning("No parent job ID found while allocated")
                     continue
-                parent_job_state = self.client.check_job_state(
-                    self.job_data.get("parent_job_id")
+                parent_job_state = self.params.client.check_job_state(
+                    self.params.job_data.get("parent_job_id")
                 )
-                if parent_job_state in ("complete", "completed", "cancelled"):
+                if parent_job_state in (
+                    "complete",
+                    JobState.COMPLETED,
+                    JobState.CANCELLED,
+                ):
                     logger.info("Parent job completed, exiting...")
                     break
             except TFServerError:
@@ -488,7 +495,7 @@ class ReservePhase(ExternalCommandPhase):
             return False
         # the phase is "go" if the phase data has been provided
         # (but no message is logged otherwise)
-        if not self.job_data.get(f"{self.phase}_data"):
+        if not self.params.job_data.get(f"{self.phase}_data"):
             return False
         return True
 
@@ -503,7 +510,7 @@ class CleanupPhase(ExternalCommandPhase):
 
     def register(self):
         self.runner.register_stop_condition_checker(
-            GlobalTimeoutChecker(self.get_global_timeout())
+            GlobalTimeoutChecker(self.params.get_global_timeout())
         )
 
 
@@ -520,7 +527,7 @@ class TestflingerJob:
         TestPhase.CLEANUP: CleanupPhase,
     }
 
-    def __init__(self, job_data, client, rundir):
+    def __init__(self, job_data: dict, client: TestflingerClient, rundir: str):
         """
         :param job_data:
             Dictionary containing data for the test job_data
@@ -529,12 +536,16 @@ class TestflingerJob:
         :param rundir:
             Directory in which to run the command defined for the phase
         """
-        self.job_data = job_data
-        self.client = client
-        self.rundir = rundir
-        self.phase = "unknown"
+        # bundle all necessary job parameters into `self.params` so that
+        # the job phases are only passed a single reference
+        self.params = TestflingerJobParameters(job_data, client, Path(rundir))
+        self.phase = None
 
-    def run_test_phase(self, phase):
+    @classmethod
+    def get_phase_cls(cls, phase: TestPhase) -> Type[TestflingerJobPhase]:
+        return cls.phase_dict[phase]
+
+    def run_test_phase(self, phase: TestPhase):
         """Run the specified test phase in rundir
 
         :param phase:
@@ -544,8 +555,7 @@ class TestflingerJob:
             if there was no command to run
         """
         self.phase = phase
-        phase_cls = self.phase_dict[phase]
-        return phase_cls(self.job_data, self.client, self.rundir).run()
+        return self.get_phase_cls(phase)(self.params).run()
 
 
 def set_nonblock(fd):
@@ -559,3 +569,21 @@ def set_nonblock(fd):
     # moving it if it gets wider use in the future
     fl = fcntl.fcntl(fd, fcntl.F_GETFL)
     fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+
+
+def set_truncate(f, size=1024 * 1024):
+    """Set up an open file so that we don't read more than a specified
+        size. We want to read from the end of the file rather than the
+        beginning. Write a warning at the end of the file if it was too big.
+
+    :param f:
+        The file object, which should be opened for read/write
+    :param size:
+        Maximum number of bytes we want to allow from reading the file
+    """
+    end = f.seek(0, 2)
+    if end > size:
+        f.write("\nWARNING: File has been truncated due to length!")
+        f.seek(end - size, 0)
+    else:
+        f.seek(0, 0)

--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -12,6 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
+from abc import ABC, abstractmethod
 import fcntl
 import json
 import logging
@@ -19,6 +20,7 @@ import os
 import time
 
 from testflinger_agent.errors import TFServerError
+from testflinger_common.enums import TestPhase
 from .runner import CommandRunner, RunnerEvents
 from .handlers import LiveOutputHandler, LogUpdateHandler
 from .stop_condition_checkers import (
@@ -30,204 +32,114 @@ from .stop_condition_checkers import (
 logger = logging.getLogger(__name__)
 
 
-class TestflingerJob:
-    def __init__(self, job_data, client):
-        """
-        :param job_data:
-            Dictionary containing data for the test job_data
-        :param client:
-            Testflinger client object for communicating with the server
-        """
+class TestflingerJobPhase(ABC):
+    """
+    Represents a phase in a Testflinger job.
+    """
+
+    phase: TestPhase = None
+
+    def __init__(self, job_data, client, rundir):
         self.client = client
         self.job_data = job_data
-        self.job_id = job_data.get("job_id")
-        self.phase = "unknown"
+        self.rundir = rundir
+        self.results_file = os.path.join(rundir, "testflinger-outcome.json")
+        self.output_log = os.path.join(rundir, self.phase + ".log")
+        self.serial_log = os.path.join(rundir, self.phase + "-serial.log")
+        self.runner = CommandRunner(cwd=rundir, env=client.config)
 
-    def run_test_phase(self, phase, rundir):
-        """Run the specified test phase in rundir
-
-        :param phase:
-            Name of the test phase (setup, provision, test, ...)
-        :param rundir:
-            Directory in which to run the command defined for the phase
-        :return:
-            Returncode from the command that was executed, 0 will be returned
-            if there was no command to run
+    @abstractmethod
+    def go(self) -> bool:
         """
-        self.phase = phase
-        cmd = self.client.config.get(phase + "_command")
-        node = self.client.config.get("agent_id")
-        if not cmd:
-            logger.info("No %s_command configured, skipping...", phase)
-            return 0, None, None
-        if phase == "provision" and not self.job_data.get("provision_data"):
-            logger.info("No provision_data defined in job data, skipping...")
-            return 0, None, None
-        if phase == "firmware_update" and not self.job_data.get(
-            "firmware_update_data"
-        ):
-            logger.info(
-                "No firmware_update_data defined in job data, skipping..."
-            )
-            return 0, None, None
-        if phase == "test" and not self.job_data.get("test_data"):
-            logger.info("No test_data defined in job data, skipping...")
-            return 0, None, None
-        if phase == "allocate" and not self.job_data.get("allocate_data"):
-            return 0, None, None
-        if phase == "reserve" and not self.job_data.get("reserve_data"):
-            return 0, None, None
-        results_file = os.path.join(rundir, "testflinger-outcome.json")
-        output_log = os.path.join(rundir, phase + ".log")
-        serial_log = os.path.join(rundir, phase + "-serial.log")
+        Return True if the phase should run or False otherwise
+        """
+        raise NotImplementedError
 
-        logger.info("Running %s_command: %s", phase, cmd)
-        runner = CommandRunner(cwd=rundir, env=self.client.config)
-        output_log_handler = LogUpdateHandler(output_log)
-        live_output_handler = LiveOutputHandler(self.client, self.job_id)
-        runner.register_output_handler(output_log_handler)
-        runner.register_output_handler(live_output_handler)
+    @abstractmethod
+    def register(self):
+        """
+        Perform all necessary registrations with the phase runner
+        """
+        raise NotImplementedError
 
-        # Reserve phase uses a separate timeout handler
-        if phase != "reserve":
-            global_timeout_checker = GlobalTimeoutChecker(
-                self.get_global_timeout()
-            )
-            runner.register_stop_condition_checker(global_timeout_checker)
+    @abstractmethod
+    def core(self):
+        """
+        Execute the "core" of the phase.
+        """
+        raise NotImplementedError
 
-        # We only need to check for output timeouts during the test phase
-        if phase == "test":
-            output_timeout_checker = OutputTimeoutChecker(
-                self.get_output_timeout()
-            )
-            runner.register_stop_condition_checker(output_timeout_checker)
-            runner.subscribe_event(
-                RunnerEvents.OUTPUT_RECEIVED, output_timeout_checker.update
-            )
+    def post(self):
+        """
+        Execute any possible actions after the "core" of the phase
+        """
+        pass
 
-        # Do not allow cancellation during provision for safety reasons
-        if phase != "provision":
-            job_cancelled_checker = JobCancelledChecker(
-                self.client, self.job_id
-            )
-            runner.register_stop_condition_checker(job_cancelled_checker)
+    def run(self):
+        """
+        This is the generic structure of every phase
+        """
 
+        # check if the phase should actually run
+        if not self.go():
+            return 0, None, None
+
+        # register the output handlers with the runner
+        self.runner.register_output_handler(LogUpdateHandler(self.output_log))
+        self.runner.register_output_handler(
+            LiveOutputHandler(self.client, self.job_data["job_id"])
+        )
+        # perform additional runner registrations
+        self.register()
+
+        # display phase banner in the Testflinger output
         for line in self.banner(
-            "Starting testflinger {} phase on {}".format(phase, node)
+            f"Starting testflinger {self.phase} phase "
+            f"on {self.client.config.get('agent_id')}"
         ):
-            runner.run(f"echo '{line}'")
+            self.runner.run(f"echo '{line}'")
+
+        # run the "core" of the phase
         try:
-            # Set exit_event to fail for this phase in case of an exception
-            exit_event = f"{phase}_fail"
-            exitcode, exit_event, exit_reason = runner.run(cmd)
+            exitcode, exit_event, exit_reason = self.core()
         except Exception as exc:
             logger.exception(exc)
+            exit_event = f"{self.phase}_fail"
             exitcode = 100
             exit_reason = str(exc)  # noqa: F841 - ignore this until it's used
         finally:
-            self._update_phase_results(
-                results_file, phase, exitcode, output_log, serial_log
-            )
-        if phase == "allocate":
-            self.allocate_phase(rundir)
+            self._update_results(exitcode)
+
+        # perform any post-core actions
+        self.post()
+
         return exitcode, exit_event, exit_reason
 
-    def _update_phase_results(
-        self, results_file, phase, exitcode, output_log, serial_log
-    ):
+    def _update_results(self, exitcode):
         """Update the results file with the results of the specified phase
 
-        :param results_file:
-            Path to the results file
-        :param phase:
-            Name of the phase
         :param exitcode:
             Exitcode from the device agent
-        :param output_log:
-            Path to the output log file
-        :param serial_log:
-            Path to the serial log file
         """
-        with open(results_file, "r+") as results:
+        with open(self.results_file, "r+") as results:
             outcome_data = json.load(results)
-            if os.path.exists(output_log):
-                with open(output_log, "r+", encoding="utf-8") as logfile:
+            outcome_data[self.phase + "_status"] = exitcode
+            try:
+                with open(self.output_log, "r+", encoding="utf-8") as logfile:
                     self._set_truncate(logfile)
-                    outcome_data[phase + "_output"] = logfile.read()
-            if os.path.exists(serial_log):
+                    outcome_data[self.phase + "_output"] = logfile.read()
+            except FileNotFoundError:
+                pass
+            try:
                 with open(
-                    serial_log, "r+", encoding="utf-8", errors="ignore"
+                    self.serial_log, "r+", encoding="utf-8", errors="ignore"
                 ) as logfile:
                     self._set_truncate(logfile)
-                    outcome_data[phase + "_serial"] = logfile.read()
-            outcome_data[phase + "_status"] = exitcode
+                    outcome_data[self.phase + "_serial"] = logfile.read()
+            except FileNotFoundError:
+                pass
             results.seek(0)
             json.dump(outcome_data, results)
-
-    def allocate_phase(self, rundir):
-        """
-        Read the json dict from "device-info.json" and send it to the server
-        so that the multi-device agent can find the IP addresses of all
-        subordinate jobs
-        """
-        device_info_file = os.path.join(rundir, "device-info.json")
-        with open(device_info_file, "r") as f:
-            device_info = json.load(f)
-
-        # The allocated state MUST be reflected on the server or the multi-
-        # device job can't continue
-        while True:
-            try:
-                self.client.post_result(self.job_id, device_info)
-                break
-            except TFServerError:
-                logger.warning("Failed to post device_info, retrying...")
-                time.sleep(60)
-
-        self.client.post_job_state(self.job_id, "allocated")
-
-        self.wait_for_completion()
-
-    def wait_for_completion(self):
-        """Monitor the parent job and exit when it completes"""
-
-        while True:
-            try:
-                this_job_state = self.client.check_job_state(self.job_id)
-                if this_job_state in ("complete", "completed", "cancelled"):
-                    logger.info("This job completed, exiting...")
-                    break
-
-                parent_job_id = self.job_data.get("parent_job_id")
-                if not parent_job_id:
-                    logger.warning("No parent job ID found while allocated")
-                    continue
-                parent_job_state = self.client.check_job_state(
-                    self.job_data.get("parent_job_id")
-                )
-                if parent_job_state in ("complete", "completed", "cancelled"):
-                    logger.info("Parent job completed, exiting...")
-                    break
-            except TFServerError:
-                logger.warning("Failed to get allocated job status, retrying")
-            time.sleep(60)
-
-    def _set_truncate(self, f, size=1024 * 1024):
-        """Set up an open file so that we don't read more than a specified
-           size. We want to read from the end of the file rather than the
-           beginning. Write a warning at the end of the file if it was too big.
-
-        :param f:
-            The file object, which should be opened for read/write
-        :param size:
-            Maximum number of bytes we want to allow from reading the file
-        """
-        end = f.seek(0, 2)
-        if end > size:
-            f.write("\nWARNING: File has been truncated due to length!")
-            f.seek(end - size, 0)
-        else:
-            f.seek(0, 0)
 
     def get_global_timeout(self):
         """Get the global timeout for the test run in seconds"""
@@ -252,7 +164,7 @@ class TestflingerJob:
         )
 
     def banner(self, line):
-        """Yield text lines to print a banner around a sting
+        """Yield text lines to print a banner around a string
 
         :param line:
             Line of text to print a banner around
@@ -260,6 +172,267 @@ class TestflingerJob:
         yield "*" * (len(line) + 4)
         yield "* {} *".format(line)
         yield "*" * (len(line) + 4)
+
+    def _set_truncate(self, f, size=1024 * 1024):
+        """Set up an open file so that we don't read more than a specified
+           size. We want to read from the end of the file rather than the
+           beginning. Write a warning at the end of the file if it was too big.
+
+        :param f:
+            The file object, which should be opened for read/write
+        :param size:
+            Maximum number of bytes we want to allow from reading the file
+        """
+        end = f.seek(0, 2)
+        if end > size:
+            f.write("\nWARNING: File has been truncated due to length!")
+            f.seek(end - size, 0)
+        else:
+            f.seek(0, 0)
+
+
+class ExternalCommandPhase(TestflingerJobPhase):
+    """
+    Phases with a core executing an external command, specified in the config
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # retieve the external command to be executed
+        self.cmd = self.client.config.get(self.phase + "_command")
+
+    def go(self) -> bool:
+        # the phase is "go" if the external command has been specified
+        if not self.cmd:
+            logger.info("No %s_command configured, skipping...", self.phase)
+            return False
+        return True
+
+    def core(self):
+        # execute the external command
+        logger.info("Running %s_command: %s", self.phase, self.cmd)
+        return self.runner.run(self.cmd)
+
+
+class SetupPhase(ExternalCommandPhase):
+
+    phase = TestPhase.SETUP
+
+    def register(self):
+        self.runner.register_stop_condition_checker(
+            GlobalTimeoutChecker(self.get_global_timeout())
+        )
+
+
+class FirmwarePhase(ExternalCommandPhase):
+
+    phase = TestPhase.FIRMWARE_UPDATE
+
+    def go(self) -> bool:
+        if not super().go():
+            return False
+        # the phase is "go" if the phase data has been provided
+        if not self.job_data.get(f"{self.phase}_data"):
+            logger.info(
+                "No %s_data defined in job data, skipping...", self.phase
+            )
+            return False
+        return True
+
+    def register(self):
+        self.runner.register_stop_condition_checker(
+            GlobalTimeoutChecker(self.get_global_timeout())
+        )
+
+
+class ProvisionPhase(ExternalCommandPhase):
+
+    phase = TestPhase.PROVISION
+
+    def go(self) -> bool:
+        if not super().go():
+            return False
+        # the phase is "go" if the phase data has been provided
+        if not self.job_data.get(f"{self.phase}_data"):
+            logger.info(
+                "No %s_data defined in job data, skipping...", self.phase
+            )
+            return False
+        return True
+
+    def register(self):
+        self.runner.register_stop_condition_checker(
+            GlobalTimeoutChecker(self.get_global_timeout())
+        )
+        # Do not allow cancellation during provision for safety reasons
+        self.runner.register_stop_condition_checker(
+            JobCancelledChecker(self.client, self.job_data["job_id"])
+        )
+
+
+class TestCommandsPhase(ExternalCommandPhase):
+
+    phase = TestPhase.TEST
+
+    def go(self) -> bool:
+        if not super().go():
+            return False
+        # the phase is "go" if the phase data has been provided
+        if not self.job_data.get(f"{self.phase}_data"):
+            logger.info(
+                "No %s_data defined in job data, skipping...", self.phase
+            )
+            return False
+        return True
+
+    def register(self):
+        self.runner.register_stop_condition_checker(
+            GlobalTimeoutChecker(self.get_global_timeout())
+        )
+        # We only need to check for output timeouts during the test phase
+        output_timeout_checker = OutputTimeoutChecker(
+            self.get_output_timeout()
+        )
+        self.runner.register_stop_condition_checker(output_timeout_checker)
+        self.runner.subscribe_event(
+            RunnerEvents.OUTPUT_RECEIVED, output_timeout_checker.update
+        )
+
+
+class AllocatePhase(ExternalCommandPhase):
+
+    phase = TestPhase.ALLOCATE
+
+    def go(self) -> bool:
+        if not super().go():
+            return False
+        # the phase is "go" if the phase data has been provided
+        # (but no message is logged otherwise)
+        if not self.job_data.get(f"{self.phase}_data"):
+            return False
+        return True
+
+    def register(self):
+        self.runner.register_stop_condition_checker(
+            GlobalTimeoutChecker(self.get_global_timeout())
+        )
+
+    def post(self):
+        """
+        Read the json dict from "device-info.json" and send it to the server
+        so that the multi-device agent can find the IP addresses of all
+        subordinate jobs
+        """
+        device_info_file = os.path.join(self.rundir, "device-info.json")
+        with open(device_info_file, "r") as f:
+            device_info = json.load(f)
+
+        # The allocated state MUST be reflected on the server or the multi-
+        # device job can't continue
+        while True:
+            try:
+                self.client.post_result(self.job_data["job_id"], device_info)
+                break
+            except TFServerError:
+                logger.warning("Failed to post device_info, retrying...")
+                time.sleep(60)
+
+        self.client.post_job_state(self.job_data["job_id"], "allocated")
+        self.wait_for_completion()
+
+    def wait_for_completion(self):
+        """Monitor the parent job and exit when it completes"""
+
+        while True:
+            try:
+                this_job_state = self.client.check_job_state(
+                    self.job_data["job_id"]
+                )
+                if this_job_state in ("complete", "completed", "cancelled"):
+                    logger.info("This job completed, exiting...")
+                    break
+
+                parent_job_id = self.job_data.get("parent_job_id")
+                if not parent_job_id:
+                    logger.warning("No parent job ID found while allocated")
+                    continue
+                parent_job_state = self.client.check_job_state(
+                    self.job_data.get("parent_job_id")
+                )
+                if parent_job_state in ("complete", "completed", "cancelled"):
+                    logger.info("Parent job completed, exiting...")
+                    break
+            except TFServerError:
+                logger.warning("Failed to get allocated job status, retrying")
+            time.sleep(60)
+
+
+class ReservePhase(ExternalCommandPhase):
+
+    phase = TestPhase.RESERVE
+
+    def go(self) -> bool:
+        if not super().go():
+            return False
+        # the phase is "go" if the phase data has been provided
+        # (but no message is logged otherwise)
+        if not self.job_data.get(f"{self.phase}_data"):
+            return False
+        return True
+
+    def register(self):
+        # Reserve phase uses a separate timeout handler
+        pass
+
+
+class CleanupPhase(ExternalCommandPhase):
+
+    phase = TestPhase.CLEANUP
+
+    def register(self):
+        self.runner.register_stop_condition_checker(
+            GlobalTimeoutChecker(self.get_global_timeout())
+        )
+
+
+class TestflingerJob:
+
+    phase_dict = {
+        TestPhase.SETUP: SetupPhase,
+        TestPhase.PROVISION: ProvisionPhase,
+        TestPhase.FIRMWARE_UPDATE: FirmwarePhase,
+        TestPhase.TEST: TestCommandsPhase,
+        TestPhase.ALLOCATE: AllocatePhase,
+        TestPhase.RESERVE: ReservePhase,
+        TestPhase.CLEANUP: CleanupPhase,
+    }
+
+    def __init__(self, job_data, client, rundir):
+        """
+        :param job_data:
+            Dictionary containing data for the test job_data
+        :param client:
+            Testflinger client object for communicating with the server
+        :param rundir:
+            Directory in which to run the command defined for the phase
+        """
+        self.job_data = job_data
+        self.client = client
+        self.rundir = rundir
+        self.phase = "unknown"
+
+    def run_test_phase(self, phase):
+        """Run the specified test phase in rundir
+
+        :param phase:
+            Name of the test phase (setup, provision, test, ...)
+        :return:
+            Returncode from the command that was executed, 0 will be returned
+            if there was no command to run
+        """
+        self.phase = phase
+        phase_cls = self.phase_dict[phase]
+        return phase_cls(self.job_data, self.client, self.rundir).run()
 
 
 def set_nonblock(fd):

--- a/agent/testflinger_agent/tarfile_patch.py
+++ b/agent/testflinger_agent/tarfile_patch.py
@@ -259,14 +259,14 @@ class TarFilePatched(TarFile):
                 self._handle_nonfatal_error(e)
 
     def chmod(self, tarinfo, targetpath):
-        """Set file permissions of targetpath according to tarinfo.
-        """
+        """Set file permissions of targetpath according to tarinfo."""
         if tarinfo.mode is None:
             return
         try:
             os.chmod(targetpath, tarinfo.mode)
         except OSError:
             raise ExtractError("could not change mode")
+
 
 # make sure `open` is available when this module is imported and it
 # returns a `TarFilePatched` object instead of a `TarFile` one

--- a/agent/testflinger_agent/tarfile_patch.py
+++ b/agent/testflinger_agent/tarfile_patch.py
@@ -258,6 +258,15 @@ class TarFilePatched(TarFile):
             except ExtractError as e:
                 self._handle_nonfatal_error(e)
 
+    def chmod(self, tarinfo, targetpath):
+        """Set file permissions of targetpath according to tarinfo.
+        """
+        if tarinfo.mode is None:
+            return
+        try:
+            os.chmod(targetpath, tarinfo.mode)
+        except OSError:
+            raise ExtractError("could not change mode")
 
 # make sure `open` is available when this module is imported and it
 # returns a `TarFilePatched` object instead of a `TarFile` one

--- a/agent/testflinger_agent/tests/test_agent.py
+++ b/agent/testflinger_agent/tests/test_agent.py
@@ -145,8 +145,36 @@ class TestClient:
             # - there is a request to the job retrieval endpoint
             # - there a request to the attachment retrieval endpoint
             history = mocker.request_history
-            assert history[0].path == "/v1/job"
-            assert history[2].path == f"/v1/job/{job_id}/attachments"
+
+            # client.check_jobs()
+            assert (
+                history[0].path == "/v1/job"
+                and history[0].query == "queue=test"
+                and history[0].method == "GET"
+            )
+            # client.post_agent_data({"job_id": job_id})
+            assert (
+                history[1].path.startswith("/v1/agents/data")
+                and history[1].method == "POST"
+            )
+            # client.check_job_state(job_id)
+            assert (
+                history[2].path == f"/v1/result/{job_id}"
+                and history[2].method == "GET"
+            )
+            # self.client.post_job_state(job_id, phase)
+            assert (
+                history[3].path == f"/v1/result/{job_id}"
+                and history[3].method == "POST"
+            )
+            # self.set_agent_state(phase)
+            assert (
+                history[4].path.startswith("/v1/agents/data")
+                and history[4].method == "POST"
+            )
+            # after 3 lines of output
+            # client.get_attachments(job_id, path=archive_path)
+            assert history[8].path == f"/v1/job/{job_id}/attachments"
 
             # check that the attachment is where it's supposed to be
             basepath = Path(self.tmpdir) / mock_job_data["job_id"]
@@ -202,8 +230,36 @@ class TestClient:
             # - there is a request to the job retrieval endpoint
             # - there a request to the attachment retrieval endpoint
             history = mocker.request_history
-            assert history[0].path == "/v1/job"
-            assert history[2].path == f"/v1/job/{job_id}/attachments"
+
+            # client.check_jobs()
+            assert (
+                history[0].path == "/v1/job"
+                and history[0].query == "queue=test"
+                and history[0].method == "GET"
+            )
+            # client.post_agent_data({"job_id": job_id})
+            assert (
+                history[1].path.startswith("/v1/agents/data")
+                and history[1].method == "POST"
+            )
+            # client.check_job_state(job_id)
+            assert (
+                history[2].path == f"/v1/result/{job_id}"
+                and history[2].method == "GET"
+            )
+            # self.client.post_job_state(job_id, phase)
+            assert (
+                history[3].path == f"/v1/result/{job_id}"
+                and history[3].method == "POST"
+            )
+            # self.set_agent_state(phase)
+            assert (
+                history[4].path.startswith("/v1/agents/data")
+                and history[4].method == "POST"
+            )
+            # after 3 lines of output
+            # client.get_attachments(job_id, path=archive_path)
+            assert history[8].path == f"/v1/job/{job_id}/attachments"
 
             # check that the attachment is *not* where it's supposed to be
             basepath = Path(self.tmpdir) / mock_job_data["job_id"]
@@ -259,8 +315,38 @@ class TestClient:
             # - there is a request to the job retrieval endpoint
             # - there a request to the attachment retrieval endpoint
             history = mocker.request_history
-            assert history[0].path == "/v1/job"
-            assert history[2].path == f"/v1/job/{job_id}/attachments"
+            for request in history:
+                print(request, request.query)
+
+            # client.check_jobs()
+            assert (
+                history[0].path == "/v1/job"
+                and history[0].query == "queue=test"
+                and history[0].method == "GET"
+            )
+            # client.post_agent_data({"job_id": job_id})
+            assert (
+                history[1].path.startswith("/v1/agents/data")
+                and history[1].method == "POST"
+            )
+            # client.check_job_state(job_id)
+            assert (
+                history[2].path == f"/v1/result/{job_id}"
+                and history[2].method == "GET"
+            )
+            # self.client.post_job_state(job_id, phase)
+            assert (
+                history[3].path == f"/v1/result/{job_id}"
+                and history[3].method == "POST"
+            )
+            # self.set_agent_state(phase)
+            assert (
+                history[4].path.startswith("/v1/agents/data")
+                and history[4].method == "POST"
+            )
+            # after 3 lines of output
+            # client.get_attachments(job_id, path=archive_path)
+            assert history[8].path == f"/v1/job/{job_id}/attachments"
 
             # check that the attachment is *not* where it's supposed to be
             basepath = Path(self.tmpdir) / mock_job_data["job_id"]
@@ -615,7 +701,10 @@ class TestClient:
                 "testflinger_agent.agent.TestflingerJob.run_test_phase"
             ) as mock_run_test_phase:
 
-                def run_test_phase_side_effect(phase, rundir):
+                def run_test_phase_side_effect(phase):
+                    rundir = os.path.join(
+                        agent.client.config["execution_basedir"], job_id
+                    )
                     if phase == "provision":
                         provision_log_path = os.path.join(
                             rundir, "device-connector-error.json"
@@ -684,8 +773,11 @@ class TestClient:
                 "testflinger_agent.agent.TestflingerJob.run_test_phase"
             ) as mock_run_test_phase:
 
-                def run_test_phase_side_effect(phase, rundir):
-                    if phase == "provision":
+                def run_test_phase_side_effect(phase):
+                    rundir = os.path.join(
+                        agent.client.config["execution_basedir"], job_id
+                    )
+                    if phase == TestPhase.PROVISION:
                         provision_log_path = os.path.join(
                             rundir, "device-connector-error.json"
                         )

--- a/agent/testflinger_agent/tests/test_job.py
+++ b/agent/testflinger_agent/tests/test_job.py
@@ -8,14 +8,18 @@ from unittest.mock import patch
 
 import testflinger_agent
 from testflinger_agent.client import TestflingerClient as _TestflingerClient
-from testflinger_agent.job import TestflingerJob as _TestflingerJob
+from testflinger_agent.job import (
+    TestflingerJob as _TestflingerJob,
+    TestflingerJobParameters,
+    set_truncate,
+)
 from testflinger_agent.runner import CommandRunner
 from testflinger_agent.handlers import LogUpdateHandler
 from testflinger_agent.stop_condition_checkers import (
     GlobalTimeoutChecker,
     OutputTimeoutChecker,
 )
-from testflinger_common.enums import TestEvent
+from testflinger_common.enums import JobState, TestEvent, TestPhase
 
 
 class TestJob:
@@ -39,15 +43,15 @@ class TestJob:
         "phase",
         ["provision", "firmware_update", "test", "allocate", "reserve"],
     )
-    def test_skip_missing_data(self, client, phase):
+    def test_skip_missing_data(self, client, phase, tmp_path):
         """
         Test that optional phases are skipped when the data is missing
         """
         fake_job_data = {"global_timeout": 1, "provision_data": ""}
-        job = _TestflingerJob(fake_job_data, client)
+        job = _TestflingerJob(fake_job_data, client, tmp_path)
 
         self.config[f"{phase}_command"] = "/bin/true"
-        return_value, exit_event, exit_reason = job.run_test_phase(phase, None)
+        return_value, exit_event, exit_reason = job.run_test_phase(phase)
         assert return_value == 0
         assert exit_event is None
         assert exit_reason is None
@@ -55,14 +59,14 @@ class TestJob:
     @pytest.mark.parametrize(
         "phase", ["setup", "provision", "test", "allocate", "reserve"]
     )
-    def test_skip_empty_provision_data(self, client, phase):
+    def test_skip_empty_provision_data(self, client, phase, tmp_path):
         """
         Test that phases are skipped when there is no command configured
         """
         self.config[f"{phase}_command"] = ""
         fake_job_data = {"global_timeout": 1, f"{phase}_data": "foo"}
-        job = _TestflingerJob(fake_job_data, client)
-        return_value, exit_event, exit_reason = job.run_test_phase(phase, None)
+        job = _TestflingerJob(fake_job_data, client, tmp_path)
+        return_value, exit_event, exit_reason = job.run_test_phase(phase)
         assert return_value == 0
         assert exit_event is None
         assert exit_reason is None
@@ -84,12 +88,12 @@ class TestJob:
         assert exit_code == -9
         assert exit_event == TestEvent.GLOBAL_TIMEOUT
 
-    def test_config_global_timeout(self, client):
+    def test_config_global_timeout(self, client, tmp_path):
         """Test that timeout from device config is preferred"""
         self.config["global_timeout"] = 1
         fake_job_data = {"global_timeout": 3}
-        job = _TestflingerJob(fake_job_data, client)
-        timeout = job.get_global_timeout()
+        job_params = TestflingerJobParameters(fake_job_data, client, tmp_path)
+        timeout = job_params.get_global_timeout()
         assert timeout == 1
 
     def test_job_output_timeout(self, tmp_path):
@@ -111,36 +115,42 @@ class TestJob:
         assert exit_code == -9
         assert exit_event == TestEvent.OUTPUT_TIMEOUT
 
-    def test_config_output_timeout(self, client):
+    def test_config_output_timeout(self, client, tmp_path):
         """Test that output timeout from device config is preferred"""
         self.config["output_timeout"] = 1
         fake_job_data = {"output_timeout": 3}
-        job = _TestflingerJob(fake_job_data, client)
-        timeout = job.get_output_timeout()
+        job_params = TestflingerJobParameters(fake_job_data, client, tmp_path)
+        timeout = job_params.get_output_timeout()
         assert timeout == 1
 
     def test_no_output_timeout_in_provision(
         self, client, tmp_path, requests_mock
     ):
         """Test that output timeout is ignored when not in test phase"""
+
         timeout_str = "complete\n"
         logfile = tmp_path / "provision.log"
-        fake_job_data = {"output_timeout": 1, "provision_data": {"url": "foo"}}
+        fake_job_data = {
+            "job_id": "999",
+            "output_timeout": 1,
+            "provision_data": {"url": "foo"},
+        }
+        # we need to sleep for longer than 10 seconds here
+        # or else we fall under the polling time
         self.config["provision_command"] = (
             "bash -c 'sleep 12 && echo complete'"
         )
         requests_mock.post(rmock.ANY, status_code=200)
-        job = _TestflingerJob(fake_job_data, client)
-        job.phase = "provision"
 
         # create the outcome file since we bypassed that
         with open(tmp_path / "testflinger-outcome.json", "w") as outcome_file:
             outcome_file.write("{}")
 
-        # unfortunately, we need to sleep for longer that 10 seconds here
-        # or else we fall under the polling time
-        # job.run_with_log("sleep 12 && echo complete", logfile)
-        job.run_test_phase("provision", tmp_path)
+        # Make sure we return a job state that matches the one we are running
+        client.check_job_state = lambda _: JobState.PROVISION
+
+        job = _TestflingerJob(fake_job_data, client, tmp_path)
+        job.run_test_phase(TestPhase.PROVISION)
         with open(logfile) as log:
             log_data = log.read()
         assert timeout_str in log_data
@@ -159,46 +169,48 @@ class TestJob:
 
         self.config["setup_command"] = "fake_setup_command"
         requests_mock.post(rmock.ANY, status_code=200)
-        job = _TestflingerJob({}, client)
+        job = _TestflingerJob({"job_id": "999"}, client, tmp_path)
         job.phase = "setup"
         # Don't raise the exception on the 3 banner lines
         with patch(
             "testflinger_agent.job.CommandRunner.run",
             side_effect=[None, None, None, Exception("failed")],
         ):
-            exit_code, exit_event, exit_reason = job.run_test_phase(
-                "setup", tmp_path
-            )
+            exit_code, exit_event, exit_reason = job.run_test_phase("setup")
         assert exit_code == 100
         assert exit_event == "setup_fail"
-        assert exit_reason == "failed"
+        assert exit_reason == "Exception: failed"
 
-    def test_set_truncate(self, client):
-        """Test the _set_truncate method of TestflingerJob"""
-        job = _TestflingerJob({}, client)
+    def test_set_truncate(self):
+        """Test the _set_truncate function"""
         with tempfile.TemporaryFile(mode="r+") as f:
             # First check that a small file doesn't get truncated
             f.write("x" * 100)
-            job._set_truncate(f, size=100)
+            set_truncate(f, size=100)
             contents = f.read()
             assert len(contents) == 100
             assert "WARNING" not in contents
 
             # Now check that a larger file does get truncated
             f.write("x" * 100)
-            job._set_truncate(f, size=100)
+            set_truncate(f, size=100)
             contents = f.read()
             # It won't be exactly 100 bytes, because a warning is added
             assert len(contents) < 150
             assert "WARNING" in contents
 
     @pytest.mark.timeout(1)
-    def test_wait_for_completion(self, client):
+    def test_wait_for_completion(self, client, tmp_path):
         """Test that wait_for_completion works"""
 
         # Make sure we return "completed" for the parent job state
-        client.check_job_state = lambda _: "completed"
+        client.check_job_state = lambda _: JobState.COMPLETED
 
-        job = _TestflingerJob({"parent_job_id": "999"}, client)
-        job.wait_for_completion()
+        phase_cls = _TestflingerJob.get_phase_cls(TestPhase.ALLOCATE)
+        phase = phase_cls(
+            TestflingerJobParameters(
+                {"job_id": "999", "parent_job_id": "1"}, client, tmp_path
+            )
+        )
+        phase.wait_for_completion()
         # No assertions needed, just make sure we don't timeout

--- a/common/testflinger_common/enums.py
+++ b/common/testflinger_common/enums.py
@@ -22,6 +22,7 @@ from strenum import StrEnum
 
 class JobState(StrEnum):
     WAITING = "waiting"
+    UNPACK = "unpack"
     SETUP = "setup"
     PROVISION = "provision"
     FIRMWARE_UPDATE = "firmware_update"
@@ -35,6 +36,7 @@ class JobState(StrEnum):
 
 
 class TestPhase(StrEnum):
+    UNPACK = "unpack"
     SETUP = "setup"
     PROVISION = "provision"
     FIRMWARE_UPDATE = "firmware_update"
@@ -45,6 +47,7 @@ class TestPhase(StrEnum):
 
 
 class TestEvent(StrEnum):
+    UNPACK_START = "unpack_start"
     SETUP_START = "setup_start"
     PROVISION_START = "provision_start"
     FIRMWARE_UPDATE_START = "firmware_update_start"
@@ -53,6 +56,7 @@ class TestEvent(StrEnum):
     RESERVE_START = "reserve_start"
     CLEANUP_START = "cleanup_start"
 
+    UNPACK_SUCCESS = "unpack_success"
     SETUP_SUCCESS = "setup_success"
     PROVISION_SUCCESS = "provision_success"
     FIRMWARE_UPDATE_SUCCESS = "firmware_update_success"
@@ -61,6 +65,7 @@ class TestEvent(StrEnum):
     RESERVE_SUCCESS = "reserve_success"
     CLEANUP_SUCCESS = "cleanup_success"
 
+    UNPACK_FAIL = "unpack_fail"
     SETUP_FAIL = "setup_fail"
     PROVISION_FAIL = "provision_fail"
     FIRMWARE_UPDATE_FAIL = "firmware_update_fail"

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -146,6 +146,9 @@ class JobSearchResponse(Schema):
 class Result(Schema):
     """Result schema"""
 
+    unpack_status = fields.Integer(required=False)
+    unpack_output = fields.String(required=False)
+    unpack_serial = fields.String(required=False)
     setup_status = fields.Integer(required=False)
     setup_output = fields.String(required=False)
     setup_serial = fields.String(required=False)


### PR DESCRIPTION
## Description

Retrieving and unpacking the attachments of a Testflinger job is currently handled within the agent code, _before_ the agent starts going through the phases of that job. This imposes certain limitations with regards to how attachment-related failures are handled:
- There are no attachment-related start, success or failure events transmitted. In fact, attachment unpacking currently takes place even before the `job_start` event is emitted. If an error occurs during attachment unpacking, there is currently no way to convey that through events.
- There is no attachment-related result included in the results dict associated with a job. If an error occurs during attachment unpakcing, this is currently no way to convey that through the job results.
- If an error occurs during attachment unpacking it can be seen and investigated through the agent logs. However, there is no output to the user submitting the job (as would be required for resolving e.g. [CERTTF-412](https://warthogs.atlassian.net/browse/CERTTF-412) and subsequently in the job results. Anyone polling a Testflinger job or monitoring the output of a Jenkins job would not be able to see any sort of error message like the one recorded in the agent logs.

One way to lift all these restrictions simultaneously is to treat the retrieval and unpacking of the job attachments as a _separate phase_.

### Changelog

This PR:

- Introduces a new `TestflingerJobPhase` abstract base class, with an interface that captures how all phases are supposed to work procedurally.
- Introduces a new `ExternalCommandPhase` abstract base class, derived from `TestflingerJobPhase`, that captures the workings of phases that run a pre-configured external command. All previously existing phases fall into this category.
- Refactors the code previously in `TestflingerJob.run_test_phase` into separate classes derived from `ExternalCommandPhase`, each corresponding to a different phase.
- Introduces a new `UnpackPhase` derived from  `TestflingerJobPhase`.
- Fixes a minor issue in how `tarfile` is patched for Python 3.8 that allows directories to be included as attachments.

Some points to note while reviewing:

- It makes little sense to review the "diff" for `agent/testflinger_agent/job.py` as the refactoring is considerable. It is best to view the file in its entirety.
- There is now absolutely no attachment-related code under `TestflingerAgent`. It has all been moved into the newly introduced `UnpackPhase`. Functions/methods like `unpack_attachments` and `secure_filter` are now implemented as methods of the `UnpackPhase`, since this is the only phase they are relevant to.
- In a similar vein, phase-specific functionality is restricted to the class representing the corresponding phase. See, for example, the `wait_for_completion` method or the `post_core` implementation for the allocate phase: these used to be methods of `TestflingerJob`, whereas now they are methods of `AllocatePhase`, which is the only phase they are relevant to.
- Both jobs and job phases require access to the same bundle of parameters. This PR introduces the `TestflingerJobParameters` named tuple to hold this bundle. For each job, both the job and its phases store a reference to a single object of this class. This avoids duplication of this information across jobs and phases and, most importantly, allows jobs and phases to be loosely coupled, instead of one circularly referencing the other.
- The `rundir` is no longer provided as an argument to `TestflingerJob.run_test_phase`. This directory is always the same for each job and can be determined when instantiating the job.

## Resolved issues

Resolves [CERTTF-412](https://warthogs.atlassian.net/browse/CERTTF-412) and [CERTTF-413](https://warthogs.atlassian.net/browse/CERTTF-413).

## Documentation

N/A

## Web service API changes

N/A

## Tests



[CERTTF-412]: https://warthogs.atlassian.net/browse/CERTTF-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CERTTF-412]: https://warthogs.atlassian.net/browse/CERTTF-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ