### PR TITLE
Lock pymongo to version < 4.9.0 - fails to start with newer versions

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -17,6 +17,7 @@ pyyaml = "^6.0.1"
 sentry-sdk = { extras = ["flask"], version = "^2.0.1" }
 requests = "^2.31.0"
 urllib3 = "^2.2.1"
+pymongo = "<4.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.1.2"


### PR DESCRIPTION
## Description

Varun pointed out that he was having trouble getting testflinger to start a few days ago. It looks like it's due to a change in pymongo recently, which is pulled in by flask-pymongo. I think the latest pymongo might break some things with GridFS (though I haven't tested it out completely yet), but it definitely breaks some things for us with both flask-pymongo and mongomock. For now, let's avoid the update until all of them play nice together again.

## Resolved issues

I'm logging an issue for this, but we shouldn't close it with this patch. This is just a temporary fix to keep Testflinger functioning for now.

## Documentation

N/A

## Web service API changes

N/A

## Tests

Confirmed that rebuilding the OCI and running it still works after this patch. But this is the version we've been using for a while now, so it just keeps what's already in production.
