### PR TITLE
[CERTTF-413] fix: include `chmod` method in the tarfile patch

### DIFF
--- a/agent/testflinger_agent/tarfile_patch.py
+++ b/agent/testflinger_agent/tarfile_patch.py
@@ -259,14 +259,14 @@ class TarFilePatched(TarFile):
                 self._handle_nonfatal_error(e)
 
     def chmod(self, tarinfo, targetpath):
-        """Set file permissions of targetpath according to tarinfo.
-        """
+        """Set file permissions of targetpath according to tarinfo."""
         if tarinfo.mode is None:
             return
         try:
             os.chmod(targetpath, tarinfo.mode)
         except OSError:
             raise ExtractError("could not change mode")
+
 
 # make sure `open` is available when this module is imported and it
 # returns a `TarFilePatched` object instead of a `TarFile` one

--- a/agent/testflinger_agent/tarfile_patch.py
+++ b/agent/testflinger_agent/tarfile_patch.py
@@ -258,6 +258,15 @@ class TarFilePatched(TarFile):
             except ExtractError as e:
                 self._handle_nonfatal_error(e)
 
+    def chmod(self, tarinfo, targetpath):
+        """Set file permissions of targetpath according to tarinfo.
+        """
+        if tarinfo.mode is None:
+            return
+        try:
+            os.chmod(targetpath, tarinfo.mode)
+        except OSError:
+            raise ExtractError("could not change mode")
 
 # make sure `open` is available when this module is imported and it
 # returns a `TarFilePatched` object instead of a `TarFile` one


### PR DESCRIPTION
## Description

This PR fixes a minor issue in how `tarfile` is patched for Python 3.8 that allows directories to be included as attachments.

Specifically `chmod` was previously left unpatched, using the native version which was unforgiving when the `mode` was `None`. However, the filtered `mode` for directories is actually `None`, so the unpatched version of `chmod` raised an error when unpacking directories. This PR patches `chmod` (in line with [Python's 3.8.17 `tarfile`](https://github.com/python/cpython/blob/63e54e6d4227e7cbdbb2a0ea69d11a904951f3a9/Lib/tarfile.py#L2562)) so that directories can also be extracted and therefore used as attachments.

## Resolved issues

Resolves [CERTTF-413](https://warthogs.atlassian.net/browse/CERTTF-413).

## Tests

Submitted the job below in a local Testflinger deployment:
```
job_queue: myqueue
test_data:
  attachments:
    - local: hwcert-jenkins-tools/install_tools.sh
      agent: install_tools.sh
    - local: hwcert-jenkins-tools/kernel-switcher/
      agent: switcher/
  test_cmds: |
    ls -alR .
```
With the following results (for the test phase):
```
.:
total 28
drwxrwxr-x 3 boukeas boukeas 4096 Oct  3 12:33 .
drwxrwxr-x 4 boukeas boukeas 4096 Oct  3 12:33 ..
drwxrwxr-x 3 boukeas boukeas 4096 Oct  3 12:33 attachments
-rw-rw-r-- 1 boukeas boukeas    0 Oct  3 12:33 device-connector-error.json
-rw-rw-r-- 1 boukeas boukeas  266 Oct  3 12:33 testflinger.json
-rw-rw-r-- 1 boukeas boukeas    2 Oct  3 12:33 testflinger-outcome.json
-rw-rw-r-- 1 boukeas boukeas  147 Oct  3 12:33 test.log
-rwxrwxr-x 1 boukeas boukeas   22 Oct  3 12:33 tf_cmd_script

./attachments:
total 12
drwxrwxr-x 3 boukeas boukeas 4096 Oct  3 12:33 .
drwxrwxr-x 3 boukeas boukeas 4096 Oct  3 12:33 ..
drwxrwxr-x 3 boukeas boukeas 4096 Oct  3 12:33 test

./attachments/test:
total 16
drwxrwxr-x 3 boukeas boukeas 4096 Oct  3 12:33 .
drwxrwxr-x 3 boukeas boukeas 4096 Oct  3 12:33 ..
-rwxr-xr-x 1 boukeas boukeas 2802 Oct  3 11:43 install_tools.sh
drwx------ 2 boukeas boukeas 4096 Jun 21 13:04 switcher

./attachments/test/switcher:
total 56
drwx------ 2 boukeas boukeas  4096 Jun 21 13:04 .
drwxrwxr-x 3 boukeas boukeas  4096 Oct  3 12:33 ..
-rw-r--r-- 1 boukeas boukeas  1109 Jun 21 13:04 README.md
-rwxr-xr-x 1 boukeas boukeas  7068 Jun 21 13:04 switch_kernel.py
-rwxr-xr-x 1 boukeas boukeas  6476 Jun 21 13:04 test_in_lxd_vm.py
-rw-r--r-- 1 boukeas boukeas 25453 Jun 21 13:04 test_switch_kernel.py
```

[CERTTF-413]: https://warthogs.atlassian.net/browse/CERTTF-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ