### PR TITLE
Add a config option with a sane default for the agent host ssh config

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/README.md
+++ b/agent/charms/testflinger-agent-host-charm/README.md
@@ -42,6 +42,8 @@ Supported options for this charm are:
       base64 encoded ssh private keyfile
   - ssh-public-key:
       base64 encoded ssh public keyfile
+  - ssh-config:
+      config data to write as ~/.ssh/config
   - config-repo:
       Git repo containing device agent config data
   - config-branch:

--- a/agent/charms/testflinger-agent-host-charm/config.yaml
+++ b/agent/charms/testflinger-agent-host-charm/config.yaml
@@ -19,3 +19,11 @@ options:
     type: string
     description: ssh public key for connecting to local test devices
     default: ""
+  ssh-config:
+    type: string
+    description: ssh config for connecting to local test devices
+    default: |
+      StrictHostKeyChecking no
+      UserKnownHostsFile /dev/null
+      LogLevel QUIET
+      ConnectTimeout 30

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -201,12 +201,18 @@ class TestflingerAgentHostCharm(CharmBase):
 
     def copy_ssh_keys(self):
         try:
+            ssh_config = self.config.get("ssh-config")
+            self.write_file("/home/ubuntu/.ssh/config", ssh_config)
+            os.chown("/home/ubuntu/.ssh/config", 1000, 1000)
+            os.chmod("/home/ubuntu/.ssh/config", 0o640)
+
             priv_key = self.config.get("ssh-private-key", "")
             self.write_file(
                 "/home/ubuntu/.ssh/id_rsa", b64decode(priv_key).decode()
             )
             os.chown("/home/ubuntu/.ssh/id_rsa", 1000, 1000)
             os.chmod("/home/ubuntu/.ssh/id_rsa", 0o600)
+
             pub_key = self.config.get("ssh-public-key", "")
             self.write_file(
                 "/home/ubuntu/.ssh/id_rsa.pub", b64decode(pub_key).decode()


### PR DESCRIPTION
## Description

In order to avoid ssh failures due to unknown host keys, we need some sane defaults in the ssh config on the agent host. I've made it configurable so that it's easy to make changes if we ever want to, but this sets a default that we already use successfully in the Taipei lab.

## Resolved issues
#369 


## Documentation

Added the new config option to the README

## Web service API changes
N/A

## Tests

Tested locally through deployment
