### PR TITLE
[CERTTF-424] feat: support a reference directory for attachments

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -22,10 +22,6 @@ inputs:
   attachments-relative-to:
     description: The reference directory for relative attachment paths
     required: false
-  attachments-relative-to-job-file:
-    description: Specify that the reference directory for relative attachment paths is the location of the job file
-    required: false
-    default: false
 outputs:
   id:
     description: 'The ID of the submitted job'
@@ -89,12 +85,9 @@ runs:
       env:
         SERVER: https://${{ inputs.server }}
         RELATIVE_TO: ${{ inputs.attachments-relative-to }}
-        RELATIVE_TO_JOB_FILE: ${{ inputs.attachments-relative-to-job-file }}
       run: |
         if [ -n "$RELATIVE_TO" ]; then
           RELATIVE="--attachments-relative-to $RELATIVE_TO"
-        elif [ "$RELATIVE_TO_JOB_FILE" = "true" ]; then
-          RELATIVE="--attachments-relative-to-job-file"
         fi
         JOB_ID=$(testflinger --server $SERVER submit --quiet "$RELATIVE" "$JOB")
         echo "job id: $JOB_ID"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -19,6 +19,13 @@ inputs:
     description: The Testflinger server to use
     required: false
     default: testflinger.canonical.com
+  attachments-relative-to:
+    description: The reference directory for relative attachment paths
+    required: false
+  attachments-relative-to-job-file:
+    description: Specify that the reference directory for relative attachment paths is the location of the job file
+    required: false
+    default: false
 outputs:
   id:
     description: 'The ID of the submitted job'
@@ -81,8 +88,15 @@ runs:
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
+        RELATIVE_TO: ${{ inputs.attachments-relative-to }}
+        RELATIVE_TO_JOB_FILE: ${{ inputs.attachments-relative-to-job-file }}
       run: |
-        JOB_ID=$(testflinger --server $SERVER submit --quiet "$JOB")
+        if [ -n "$RELATIVE_TO" ]; then
+          RELATIVE="--attachments-relative-to $RELATIVE_TO"
+        elif [ "$RELATIVE_TO_JOB_FILE" = "true" ]; then
+          RELATIVE="--attachments-relative-to-job-file"
+        fi
+        JOB_ID=$(testflinger --server $SERVER submit --quiet "$RELATIVE" "$JOB")
         echo "job id: $JOB_ID"
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This monorepo is organized in a way that is consistant with the components descr
 
 # Github actions
 
-If you need to submit a job to a testflinger server through a Github action (instead, for example, of using the command-line tool), you can use the [`submit` action](https://github.com/canonical/testflinger/blob/main/.github/actions/submit/action.yaml) in a CI workflow.
+If you need to submit a job to a testflinger server through a Github action (instead, for example, of using the command-line tool), you can use the [`submit` action](https://github.com/canonical/testflinger/blob/main/.github/actions/submit/action.yaml) in a CI workflow. Please refer to the `inputs` field of the action for a complete list of the arguments that the action can receive.
 
 The corresponding step in the workflow would look like this:
 ```yaml

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -331,14 +331,17 @@ class TestflingerCli:
     @staticmethod
     def extract_attachment_data(job_data: dict) -> Optional[dict]:
         """Pull together the attachment data per phase from the `job_data`"""
-        attachment_data = {}
+        attachments = {}
         for phase in ("provision", "firmware_update", "test"):
-            phase_str = f"{phase}_data"
             try:
-                attachment_data[phase] = job_data[phase_str]["attachments"]
+                attachments[phase] = [
+                    attachment
+                    for attachment in job_data[f"{phase}_data"]["attachments"]
+                    if attachment.get("local")
+                ]
             except KeyError:
                 pass
-        return attachment_data or None
+        return attachments or None
 
     def pack_attachments(self, archive: str, attachment_data: dict):
         """Pack the attachments specifed by `attachment_data` into `archive`

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -267,15 +267,6 @@ class TestflingerCli:
             dest="relative",
             help="The reference directory for relative attachment paths",
         )
-        relative.add_argument(
-            "--attachments-relative-to-job-file",
-            action="store_true",
-            dest="relative_to_job_file",
-            help="""
-            Use the location of the job file as a reference directory for
-            relative attachment paths
-            """,
-        )
 
         self.args = parser.parse_args()
         self.help = parser.format_help()
@@ -357,12 +348,9 @@ class TestflingerCli:
         if self.args.relative:
             # provided as a command-line argument
             reference = Path(self.args.relative).resolve(strict=True)
-        elif self.args.relative_to_job_file:
+        else:
             # retrieved from the directory where the job file is contained
             reference = Path(self.args.filename).parent.resolve(strict=True)
-        else:
-            # default to the current working directory
-            reference = Path.cwd().resolve()
 
         with tarfile.open(archive, "w:gz") as tar:
             for phase, attachments in attachment_data.items():

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -215,7 +215,9 @@ Example agent configuration:
 
 Attachments
 ------------
-In the `provisioning`, `firmware_update` and `test` phases, it is also possible to specify attachments, i.e. local files that are to be copied over to the Testflinger agent host.
+In the `provisioning`, `firmware_update` and `test` phases, it is also possible
+to specify attachments, i.e. local files that are to be copied over to
+the Testflinger agent host.
 
 * Example job definition:
 
@@ -239,13 +241,17 @@ In the `provisioning`, `firmware_update` and `test` phases, it is also possible 
         chmod u+x attachments/test/script.sh
         attachments/test/script.sh
 
-  The `local` fields specify where the attachments are to be found locally, e.g. on the machine where the CLI is executed.
-  Unless otherwise specified, relative paths are interpreted in relation to the current working directory.
+  The `local` fields specify where the attachments are to be found locally,
+  e.g. on the machine where the CLI is executed. Unless otherwise specified,
+  relative paths are interpreted in relation to the location of the Testflinger
+  job file (which is convenient since the job file and the attachments are
+  usually stored together).
   So for this particular example, this sort of file tree is expected:
 
   .. code-block:: bash
 
     .
+    ├── job.yaml
     ├── config.json
     ├── images
     │   └── ubuntu-logo.png
@@ -253,7 +259,10 @@ In the `provisioning`, `firmware_update` and `test` phases, it is also possible 
     │   └── my_test_script.sh
     └── ubuntu-22.04.4-preinstalled-desktop-arm64+raspi.img.xz
 
-  On the agent host, the attachments are placed under the `attachments` folder and distributed in separate sub-folders according to phase. If an `agent` field is provided, the attachments are also moved or renamed accordingly. For the example above, the file tree on the agent host would look like this:
+  On the agent host, the attachments are placed under the `attachments` folder
+  and distributed in separate sub-folders according to phase. If an `agent`
+  field is provided, the attachments are also moved or renamed accordingly.
+  For the example above, the file tree on the agent host would look like this:
 
   .. code-block:: bash
 
@@ -269,16 +278,13 @@ In the `provisioning`, `firmware_update` and `test` phases, it is also possible 
             │   └── ubuntu-logo.png
             └── script.sh
 
-The Testflinger CLI also accepts an optional `--attachments-relative-to` argument. When provided,
-relative paths are interpreted in relation to this reference path, instead of the current working directory.
+The Testflinger CLI also accepts an optional `--attachments-relative-to` argument.
+When provided, relative paths are interpreted in relation to this reference path,
+instead of the default,  i.e. the location of the Testflinger job file.
 
-It is often convenient for that reference path to be the directory where the Testflinger job file itself is located
-(e.g. when the job file and the attachments are stored together). In other words, attachments specified with relative paths
-are resolved in relation to the location of the job file. For these cases, the command-line flag
-`--attachments-relative-to-job-file` can be used, without the need to provide the reference path explicitly.
-
-In the example above, there is no `url` field under the `provision_data` to specify where to download the provisioning image from.
-Instead, there is a `use_attachment` field that indicates which attachment should be used as a provisioning image.
+In the example above, there is no `url` field under the `provision_data` to specify
+where to download the provisioning image from. Instead, there is a `use_attachment`
+field that indicates which attachment should be used as a provisioning image.
 The presence of *either* `url` or `use_attachment` is required.
 
 At the moment, only the :ref:`muxpi` device connector supports provisioning using an attached image.

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -239,7 +239,9 @@ In the `provisioning`, `firmware_update` and `test` phases, it is also possible 
         chmod u+x attachments/test/script.sh
         attachments/test/script.sh
 
-  The `local` fields specify where the attachments are to be found locally, e.g. on the machine where the CLI is executed. For this particular example, this sort of file tree is expected:
+  The `local` fields specify where the attachments are to be found locally, e.g. on the machine where the CLI is executed.
+  Unless otherwise specified, relative paths are interpreted in relation to the current working directory.
+  So for this particular example, this sort of file tree is expected:
 
   .. code-block:: bash
 
@@ -267,7 +269,15 @@ In the `provisioning`, `firmware_update` and `test` phases, it is also possible 
             │   └── ubuntu-logo.png
             └── script.sh
 
-In this example, there is no `url` field under the `provision_data` to specify where to download the provisioning image from.
+  The Testflinger CLI also accepts an optional `--attachments-relative-to` argument. When provided,
+  relative paths are interpreted in relation to this reference path, instead of the current working directory.
+
+  It is often convenient for that reference path to be the directory where the Testflinger job file itself is located
+  (e.g. when the job file and the attachments are stored together). In other words, attachments specified with relative paths
+  are resolved in relation to the location of the job file. For these cases, the command-line flag
+  `--attachments-relative-to-job-file` can be used, without the need to provide the reference path explicitly.
+
+In the example above, there is no `url` field under the `provision_data` to specify where to download the provisioning image from.
 Instead, there is a `use_attachment` field that indicates which attachment should be used as a provisioning image.
 The presence of *either* `url` or `use_attachment` is required.
 

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -269,13 +269,13 @@ In the `provisioning`, `firmware_update` and `test` phases, it is also possible 
             │   └── ubuntu-logo.png
             └── script.sh
 
-  The Testflinger CLI also accepts an optional `--attachments-relative-to` argument. When provided,
-  relative paths are interpreted in relation to this reference path, instead of the current working directory.
+The Testflinger CLI also accepts an optional `--attachments-relative-to` argument. When provided,
+relative paths are interpreted in relation to this reference path, instead of the current working directory.
 
-  It is often convenient for that reference path to be the directory where the Testflinger job file itself is located
-  (e.g. when the job file and the attachments are stored together). In other words, attachments specified with relative paths
-  are resolved in relation to the location of the job file. For these cases, the command-line flag
-  `--attachments-relative-to-job-file` can be used, without the need to provide the reference path explicitly.
+It is often convenient for that reference path to be the directory where the Testflinger job file itself is located
+(e.g. when the job file and the attachments are stored together). In other words, attachments specified with relative paths
+are resolved in relation to the location of the job file. For these cases, the command-line flag
+`--attachments-relative-to-job-file` can be used, without the need to provide the reference path explicitly.
 
 In the example above, there is no `url` field under the `provision_data` to specify where to download the provisioning image from.
 Instead, there is a `use_attachment` field that indicates which attachment should be used as a provisioning image.


### PR DESCRIPTION
## Description

At the moment, when Testflinger attachments are not specified through absolute path names (in the `local` field) they are interpreted relevant to the current working directory. This is quite restrictive and becomes an inconvenience especially when Testflinger jobs and their attachments are created in Github workflows and submitted through the Testflinger submit Github action.

This PR:
- Changes the default behaviour to interpret relative attachment path names against the directory where the submitted job file is located.
- Introduces the `--attachments-relative-to` command-line argument to the Testflinger CLI, for specifying the directory that relative attachment path names will be resolved against.
- Introduces a new input to the Testflinger `submit` Github action, corresponding to the new command-line argument
- Adds documentation for the additional CLI and Github action arguments

## Resolved issues

Resolves [CERTTF-424](https://warthogs.atlassian.net/browse/CERTTF-424).

## Tests

- Manual tests in a local Testflinger deployment
- New unit tests have been introduced to test attachment packing, including packing when a reference directory is provided.

Changes to the Github `submit` action can only be tested once the updated Testflinger CLI snap has been deployed.

[CERTTF-424]: https://warthogs.atlassian.net/browse/CERTTF-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ