### PR TITLE
Fix broken logo on Documentation

### DIFF
--- a/docs/.sphinx/_templates/header.html
+++ b/docs/.sphinx/_templates/header.html
@@ -6,7 +6,7 @@
 
       <li>
         <a class="p-logo" href="https://{{ product_page }}" aria-current="page">
-          <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
+          <img src="{{ pathto(product_tag) }}" alt="Logo" class="p-logo-image">
           <div class="p-logo-text p-heading--4">{{ project }}
           </div>
         </a>


### PR DESCRIPTION
## Description

Fix the broken logo on the Testflinger Documentation Webstie

## Resolved issues

[issue#378](https://github.com/canonical/testflinger/issues/378)

## Documentation

N/A

## Web service API changes

N/A

## Tests

![Screenshot from 2024-10-15 11-10-25](https://github.com/user-attachments/assets/ee06b508-e425-4a06-a508-a8d6a0b1774c)

