### PR TITLE
Automatically release and power-off maas nodes at the end of a job

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
@@ -4,4 +4,5 @@ AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
 echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE cleanup -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
 

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
@@ -49,8 +49,14 @@ class DeviceConnector(DefaultDevice):
         except ProvisioningError as err:
             logger.error("Provisioning failed: %s", str(err))
             raise
-        except Exception as e:
-            raise e
         finally:
             serial_proc.stop()
-        logger.info("END provision")
+            logger.info("END provision")
+
+    def cleanup(self, args):
+        device = Maas2(args.config, args.job_data)
+        try:
+            device.cleanup()
+        except ProvisioningError as err:
+            logger.error("Provisioning failed: %s", str(err))
+            raise

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -391,8 +391,8 @@ class Maas2:
         cmd = ["maas", self.maas_user, "machine", "release", self.node_id]
         subprocess.run(cmd, check=False)
         # Make sure the device is available before returning
-        for _ in range(0, 10):
-            time.sleep(5)
+        for _ in range(0, 30):
+            time.sleep(10)
             status = self.node_status()
             if status == "Ready":
                 return

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -68,6 +68,9 @@ class Maas2:
     def recover(self):
         self._logger_info("Releasing node {}".format(self.agent_name))
         self.node_release()
+        self._logger_info(
+            "Successfully released node {}".format(self.agent_name)
+        )
 
     def provision(self):
         if self.config.get("reset_efi"):
@@ -82,6 +85,10 @@ class Maas2:
         user_data = provision_data.get("user_data")
         storage_data = provision_data.get("disks")
         self.deploy_node(distro, kernel, user_data, storage_data)
+
+    def cleanup(self):
+        """Try to release the node in maas at the end of the job."""
+        self.recover()
 
     def _install_efitools_snap(self):
         cmd = [


### PR DESCRIPTION
## Description

Some maas-deployed systems use a lot of power. Rather than leaving them on between jobs, we should power them off automatically when the job is complete. The cleanup step is currently only used to ensure the agent container is removed, but can also be used for operations specific to the device connector.

## Resolved issues
CERTTF-427

## Documentation

There are some new log messages saying that the node was released. But there's nothing the user needs to do to activate this, it will happen automatically once the job is complete or cancelled.

## Web service API changes

N/A

## Tests

Tested on a maas deployed node. Attached images on jira card show the job being run, and then the maas screen showing that the device was released and powered off.
