### PR TITLE
device_connectors: zapper_iot: provide non blocking console command

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
@@ -137,6 +137,16 @@ TPLAN_SCHEMA = {
                                     },
                                 },
                             },
+                            "console_commands_nb": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cmd": {"type": "string"},
+                                    },
+                                },
+                            },
                         },
                     },
                 ]


### PR DESCRIPTION
## Description
Add one more section for support non-blocking send command


## Resolved issues
Prevent some commands like "reboot" stocks our tool due to it could never back to enterable state

## Documentation


## Web service API changes

## Tests
send "reboot" command through testflinger and zapper to DUT, and make sure it would 
not wait for enterable
