### PR TITLE
fix(agent): make sure phase exit codes are in the 0-255 range

### DIFF
--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -120,6 +120,9 @@ class TestflingerJob:
             # Set exit_event to fail for this phase in case of an exception
             exit_event = f"{phase}_fail"
             exitcode, exit_event, exit_reason = runner.run(cmd)
+            # make sure the exit code is within the expected 0-255 range
+            # (this also handles negative numbers)
+            exitcode = exitcode % 256
         except Exception as exc:
             logger.exception(exc)
             exitcode = 100


### PR DESCRIPTION
## Description

When a process is terminated due to a "stop condition checker", it ends up [receiving a SIGKILL](https://github.com/canonical/testflinger/blob/8007913e6396fc05b760a59a46f1b90acfdfd335/agent/testflinger_agent/runner.py#L117) and [the `returncode` for a process that receives a SIGKILL (signal 9) is -9](https://docs.python.org/3.9/library/subprocess.html#subprocess.Popen.returncode). That `returncode` is used as the exit status of the phase, which means that exit statuses reported by Testflinger can be negative, rather than in the [expected range](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html) of 0-255.

This PR ensures that phase exit codes are in the 0-255 range.

## Tests

In a local Testflinger deployment, this job was used for testing, deliberately timing out:
```
job_queue: myqueue
output_timeout: 60
test_data:
  test_cmds: |
    echo "Starting"
    sleep 120
    echo "Ending"
```
Here are the results when the agent was deployed from `main`:
```
{
    "job_state": "complete",
    "test_output": "************************************************\n* Starting testflinger test phase on agent-007 *\n************************************************\n2024-10-21 10:54:54,795 myqueue INFO: DEVICE CONNECTOR: BEGIN testrun\n\nERROR: Output timeout reached! (60s)\n",
    "test_status": -9
}
```
And here are the results when the agent was deployed from this branch:
```
{
    "job_state": "complete",
    "test_output": "************************************************\n* Starting testflinger test phase on agent-007 *\n************************************************\n2024-10-21 10:52:13,757 myqueue INFO: DEVICE CONNECTOR: BEGIN testrun\n\nERROR: Output timeout reached! (60s)\n",
    "test_status": 247
}
```