### PR TITLE
Agent host terraform module

### DIFF
--- a/agent/terraform/README.md
+++ b/agent/terraform/README.md
@@ -1,0 +1,70 @@
+# Deploying with Terraform + Juju
+
+This Terraform module can be used for deploying the Testflinger agent
+host on a physical or virtual machine model using Juju.
+
+## Deploying an Environment
+
+This terraform module assume that the Juju model you want to deploy
+to has already been created.
+
+1. First, create the model
+```
+    $ juju add-model agent-host-1
+```
+
+2. Create ssh keys to use on the agent host
+```
+    $ ssh-keygen -t rsa -f mykey
+```
+
+3. Create a git repo with the Testflinger configs
+
+If you have more than one agent host to deploy, create a separate directory
+for each of them in this repo. Then create a separate directory for each
+agent in the agent host directory where they reside. For example:
+
+```
+/agent-host-1
+-/agent-101
+  -testflinger-agent.yaml
+  -default.conf
+-/agent-102
+  -testflinger-agent.yaml
+  -default.conf
+/agent-host-2
+...
+```
+
+4. Create a main.tf which specifies the required parameters for this module
+
+```
+terraform {
+  required_providers {
+    juju = {
+      version = "~> 0.13.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+module "lab1" {
+  source = "/path/to/this/module"
+  agent_host_name = "agent-host-1"
+  juju_model = "agent-host-1"
+  config_repo = "https://github.com/path_to/config_repo.git"
+  config_branch = "main"
+  config_dir = "agent-host-1"
+  ssh_public_key = filebase64("mykey.pub")
+  ssh_private_key = filebase64("mykey")
+}
+```
+
+5. Initialize terraform and apply
+```
+    $ terraform init
+    $ terraform apply
+```
+

--- a/agent/terraform/main.tf
+++ b/agent/terraform/main.tf
@@ -1,39 +1,3 @@
-
-variable "juju_model" {
-  type        = string
-  description = "Name of the Juju model"
-}
-
-variable "agent_host_name" {
-  type        = string
-  description = "Name of the agent host juju application"
-}
-
-variable "config_repo" {
-  type        = string
-  description = "Repository URL for the agent configs on this agent host"
-}
-
-variable "config_branch" {
-  type        = string
-  description = "Repository branch for the agent configs"
-}
-
-variable "config_dir" {
-  type        = string
-  description = "Directory within the config repo containing the charm configuration"
-}
-
-variable "ssh_public_key" {
-  type        = string
-  description = "base64 encoded ssh public key to use on the agent host"
-}
-
-variable "ssh_private_key" {
-  type        = string
-  description = "base64 encoded ssh private key to use on the agent host"
-}
-
 resource "juju_application" "testflinger-agent-host" {
   name  = var.agent_host_name
   model = var.juju_model

--- a/agent/terraform/main.tf
+++ b/agent/terraform/main.tf
@@ -1,0 +1,57 @@
+
+variable "juju_model" {
+  type        = string
+  description = "Name of the Juju model"
+}
+
+variable "agent_host_name" {
+  type        = string
+  description = "Name of the agent host juju application"
+}
+
+variable "config_repo" {
+  type        = string
+  description = "Repository URL for the agent configs on this agent host"
+}
+
+variable "config_branch" {
+  type        = string
+  description = "Repository branch for the agent configs"
+}
+
+variable "config_dir" {
+  type        = string
+  description = "Directory within the config repo containing the charm configuration"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "base64 encoded ssh public key to use on the agent host"
+}
+
+variable "ssh_private_key" {
+  type        = string
+  description = "base64 encoded ssh private key to use on the agent host"
+}
+
+resource "juju_application" "testflinger-agent-host" {
+  name  = var.agent_host_name
+  model = var.juju_model
+
+  units = 1
+
+  charm {
+    name    = "testflinger-agent-host"
+    base    = "ubuntu@22.04"
+    channel = "latest/beta"
+  }
+
+  config = {
+    ssh-public-key  = var.ssh_public_key
+    ssh-private-key = var.ssh_private_key
+    config-repo     = var.config_repo
+    config-branch   = var.config_branch
+    config-dir      = var.config_dir
+  }
+}
+

--- a/agent/terraform/variables.tf
+++ b/agent/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "juju_model" {
+  type        = string
+  description = "Name of the Juju model"
+}
+
+variable "agent_host_name" {
+  type        = string
+  description = "Name of the agent host juju application"
+}
+
+variable "config_repo" {
+  type        = string
+  description = "Repository URL for the agent configs on this agent host"
+}
+
+variable "config_branch" {
+  type        = string
+  description = "Repository branch for the agent configs"
+}
+
+variable "config_dir" {
+  type        = string
+  description = "Directory within the config repo containing the charm configuration"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "base64 encoded ssh public key to use on the agent host"
+}
+
+variable "ssh_private_key" {
+  type        = string
+  description = "base64 encoded ssh private key to use on the agent host"
+}
+

--- a/agent/terraform/versions.tf
+++ b/agent/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    juju = {
+      version = "~> 0.13.0"
+      source  = "juju/juju"
+    }
+  }
+}
+


### PR DESCRIPTION
## Description

The existing terraform module doesn't allow specifying constraints for the virtual machine that should be deployed, if you are deploying this to something like LXD. This adds some reasonable defaults and also allows you to override them.

## Resolved issues
N/A

## Documentation
Covered the new options in the README.md

## Web service API changes
N/A

## Tests
Confirmed these options can be used to deploy a new instance, and also confirmed that overriding works properly if you have an old instance with some previous default like "arch=amd64" and need to keep it without terraform trying to remove/re-add it.
