### PR TITLE
Agent host terraform constraints

### DIFF
--- a/agent/terraform/README.md
+++ b/agent/terraform/README.md
@@ -9,62 +9,64 @@ This terraform module assume that the Juju model you want to deploy
 to has already been created.
 
 1. First, create the model
-```
-    $ juju add-model agent-host-1
-```
+
+    ```
+        $ juju add-model agent-host-1
+    ```
 
 2. Create ssh keys to use on the agent host
-```
-    $ ssh-keygen -t rsa -f mykey
-```
+
+    ```
+        $ ssh-keygen -t rsa -f mykey
+    ```
 
 3. Create a git repo with the Testflinger configs
 
-If you have more than one agent host to deploy, create a separate directory
-for each of them in this repo. Then create a separate directory for each
-agent in the agent host directory where they reside. For example:
+    If you have more than one agent host to deploy, create a separate directory
+    for each of them in this repo. Then create a separate directory for each
+    agent in the agent host directory where they reside. For example:
 
-```
-/agent-host-1
--/agent-101
-  -testflinger-agent.yaml
-  -default.conf
--/agent-102
-  -testflinger-agent.yaml
-  -default.conf
-/agent-host-2
-...
-```
+    ```
+    /agent-host-1
+    -/agent-101
+      -testflinger-agent.yaml
+      -default.conf
+    -/agent-102
+      -testflinger-agent.yaml
+      -default.conf
+    /agent-host-2
+    ...
+    ```
 
 4. Create a main.tf which specifies the required parameters for this module
 
-```
-terraform {
-  required_providers {
-    juju = {
-      version = "~> 0.13.0"
-      source  = "juju/juju"
+    ```
+    terraform {
+      required_providers {
+        juju = {
+          version = "~> 0.13.0"
+          source  = "juju/juju"
+        }
+      }
     }
-  }
-}
 
-provider "juju" {}
+    provider "juju" {}
 
-module "lab1" {
-  source = "/path/to/this/module"
-  agent_host_name = "agent-host-1"
-  juju_model = "agent-host-1"
-  config_repo = "https://github.com/path_to/config_repo.git"
-  config_branch = "main"
-  config_dir = "agent-host-1"
-  ssh_public_key = filebase64("mykey.pub")
-  ssh_private_key = filebase64("mykey")
-}
-```
+    module "lab1" {
+      source = "/path/to/this/module"
+      agent_host_name = "agent-host-1"
+      juju_model = "agent-host-1"
+      config_repo = "https://github.com/path_to/config_repo.git"
+      config_branch = "main"
+      config_dir = "agent-host-1"
+      ssh_public_key = filebase64("mykey.pub")
+      ssh_private_key = filebase64("mykey")
+    }
+    ```
 
 5. Initialize terraform and apply
-```
-    $ terraform init
-    $ terraform apply
-```
+    ```
+        $ terraform init
+        $ terraform apply
+    ```
 

--- a/agent/terraform/README.md
+++ b/agent/terraform/README.md
@@ -11,13 +11,13 @@ to has already been created.
 1. First, create the model
 
     ```
-        $ juju add-model agent-host-1
+    $ juju add-model agent-host-1
     ```
 
 2. Create ssh keys to use on the agent host
 
     ```
-        $ ssh-keygen -t rsa -f mykey
+    $ ssh-keygen -t rsa -f mykey
     ```
 
 3. Create a git repo with the Testflinger configs
@@ -64,9 +64,16 @@ to has already been created.
     }
     ```
 
+    There are additional parameters you can adjust here if you want:
+     - **agent_host_cores**: (default: 4) Number of cpu cores to use for the agent host
+     - **agent_host_mem**: (default: "32768M") Amount of RAM to use for the agent host. This needs to be specified as a string with "M" at the end.
+     - **agent_host_storage: (default: 1048576M) Storage size for the agent host. This needs to be specified as a string with "M" at the end.
+     - **override_constraints**: By default, the constraints passed to Juju will use the previous parameters to build something in this format: `arch=amd64 cores=${var.agent_host_cores} mem=${var.agent_host_mem} root-disk=${var.agent_host_storage} root-disk-source=remote virt-type=virtual-machine`. If you need to override this entire line to send it something completely different, use this and the previous `agent_host_*` parameters will be ignored.
+
+
 5. Initialize terraform and apply
     ```
-        $ terraform init
-        $ terraform apply
+    $ terraform init
+    $ terraform apply
     ```
 

--- a/agent/terraform/locals.tf
+++ b/agent/terraform/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  agent_host_constraints = try(var.override_constraints, "arch=amd64 cores=${var.agent_host_cores} mem=${var.agent_host_mem} root-disk=${var.agent_host_storage} root-disk-source=remote virt-type=virtual-machine")
+}

--- a/agent/terraform/main.tf
+++ b/agent/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "testflinger-agent-host" {
-  name  = var.agent_host_name
-  model = var.juju_model
+  name        = var.agent_host_name
+  model       = var.juju_model
+  constraints = local.agent_host_constraints
 
   units = 1
 

--- a/agent/terraform/variables.tf
+++ b/agent/terraform/variables.tf
@@ -8,6 +8,30 @@ variable "agent_host_name" {
   description = "Name of the agent host juju application"
 }
 
+variable "agent_host_cores" {
+  type        = number
+  description = "Number of cpu cores to use for the agent host"
+  default     = 4
+}
+
+variable "agent_host_mem" {
+  type        = string
+  description = "Amount of RAM to use for the agent host"
+  default     = "32768M"
+}
+
+variable "agent_host_storage" {
+  type        = string
+  description = "Storage size for the agent host"
+  default     = "1048576M"
+}
+
+variable "override_constraints" {
+  type        = string
+  description = "Use if you need to override the constraints built with the other agent_host_* vars"
+  default     = ""
+}
+
 variable "config_repo" {
   type        = string
   description = "Repository URL for the agent configs on this agent host"
@@ -32,4 +56,5 @@ variable "ssh_private_key" {
   type        = string
   description = "base64 encoded ssh private key to use on the agent host"
 }
+
 


### PR DESCRIPTION
## Description

The existing terraform module doesn't allow specifying constraints for the virtual machine that should be deployed, if you are deploying this to something like LXD. This adds some reasonable defaults and also allows you to override them.

## Resolved issues
N/A

## Documentation
Covered the new options in the README.md

## Web service API changes
N/A

## Tests
Confirmed these options can be used to deploy a new instance, and also confirmed that overriding works properly if you have an old instance with some previous default like "arch=amd64" and need to keep it without terraform trying to remove/re-add it.
