### PR TITLE
Configure XDG_*_HOME directories based on SNAP_USER_DATA

### DIFF
--- a/cli/testflinger-cli.wrapper
+++ b/cli/testflinger-cli.wrapper
@@ -1,4 +1,8 @@
 #!/bin/sh
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
+export XDG_DATA_HOME=$SNAP_USER_DATA/.local/share
+export XDG_CONFIG_HOME=$SNAP_USER_DATA/.config
+export XDG_CACHE_HOME=$SNAP_USER_DATA/.cache
+export XDG_STATE_HOME=$SNAP_USER_DATA/.local/state
 exec testflinger-cli $@


### PR DESCRIPTION
## Description

testflinger_cli did throw an error when trying to write to ~/.local/share/testflinger-cli-history.json (see below)

I changed the 

```
Traceback (most recent call last):
  File "/snap/testflinger-cli/x1/bin/testflinger-cli", line 8, in <module>
    sys.exit(cli())
  File "/snap/testflinger-cli/x1/lib/python3.10/site-packages/testflinger_cli/__init__.py", line 53, in cli
    tfcli.run()
  File "/snap/testflinger-cli/x1/lib/python3.10/site-packages/testflinger_cli/__init__.py", line 182, in run
    sys.exit(self.args.func())
  File "/snap/testflinger-cli/x1/lib/python3.10/site-packages/testflinger_cli/__init__.py", line 427, in submit
    self.history.new(job_id, queue)
  File "/snap/testflinger-cli/x1/lib/python3.10/site-packages/testflinger_cli/history.py", line 54, in new
    self.save()
  File "/snap/testflinger-cli/x1/lib/python3.10/site-packages/testflinger_cli/history.py", line 74, in save
    with open(
PermissionError: [Errno 13] Permission denied: '/home/hartmut/.local/share/testflinger-cli-history.json'
```

## Documentation

No Tests are included for the changed functionality in this PR - I would need help in setting them up.

## Tests

Manual test:
```
snap install tf_...snap --dangerous
testflinger-cli
testflinger-cli submit example.yaml
```