### PR TITLE
Remove redundant level "iot_provision"

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -38,13 +38,13 @@ class DeviceConnector(ZapperConnector):
         for the Zapper `provision` API.
         """
         try:
-            tplan = self.job_data["provision_data"]["iot_provision"]["tplan"]
+            tplan = self.job_data["provision_data"]["tplan"]
             validate_tplan(tplan)
         except KeyError as e:
             raise ProvisioningError from e
 
         try:
-            url = self.job_data["provision_data"]["iot_provision"]["url"]
+            url = self.job_data["provision_data"]["url"]
             validate_url(url)
         except KeyError:
             url = []


### PR DESCRIPTION
## Description

Remove redundant level "iot_provision"

## Resolved issues

remove unnecessary level in provision data

## Documentation

## Web service API changes

## Tests

provision imx8mp-x8high-pdk successfully 
