### PR TITLE
update: resolve issues while provisioning noble oem machine using oem_autoinstall

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/provision-image.sh
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/provision-image.sh
@@ -122,7 +122,7 @@ wget_iso_on_dut() {
             exit 4
         fi
     else
-        WGET_OPTS="--tries=3"
+        WGET_OPTS="--tries=3 --progress=bar:force"
         # Optional URL credentials
         if [ -r "$URL_TOKEN" ]; then
             username=$(awk -F':' '/^username:/ {print $2}' "$URL_TOKEN" | xargs)

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -26,6 +26,7 @@ import subprocess
 import yaml
 import shutil
 import time
+import os
 
 from testflinger_device_connectors.devices import (
     ProvisioningError,
@@ -76,6 +77,7 @@ class OemAutoinstall:
 
             if not default_user_data.exists():
                 raise ProvisioningError("Default user-data file not found")
+            os.makedirs(ATTACHMENTS_PROV_DIR, exist_ok=True)
             shutil.copy(default_user_data, ATTACHMENTS_PROV_DIR)
             user_data = "default-user-data"
 


### PR DESCRIPTION
## Description

- While trying to provision with oem_autoinstall, I found that the provisioning always failed at [this line](https://github.com/canonical/testflinger/blob/main/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py#L79), after some investigation, the provision directory hasn't been created when using default user data, so just added one line for creating the directory before copy data.
- The default output of wget progress is using `dot` style, which will make the log hard to read, so I propose to use the `bar` style.

## Resolved issues

- unable to provision: 
```
2024-11-08 06:58:15,698 dell-xps139340-c34207 INFO: DEVICE CONNECTOR: No user-data provided, using default user-data file
```

- output is hard to read
```
Saving to: ‘/home/ubuntu/somerville-noble-oem-24.04a-20240729-53.iso’

     0K .......... .......... .......... .......... ..........  0%  104K 14h23m
    50K .......... .......... .......... .......... ..........  0%  484K 8h43m
   100K .......... .......... .......... .......... ..........  0%  268K 7h40m
   150K .......... .......... .......... .......... ..........  0%  565K 6h24m
   200K .......... .......... .......... .......... ..........  0%  492K 5h44m
   250K .......... .......... .......... .......... ..........  0% 1003K 5h1m
   300K .......... .......... .......... .......... ..........  0%  902K 4h32m
   350K .......... .......... .......... .......... ..........  0% 1014K 4h9m
```


## Tests

Test with this TF job.
https://testflinger.canonical.com/jobs/1d67567a-0c62-4846-be87-a72e285f3714
