### PR TITLE
Generate prometheus metrics for flask and add metrics endpoint

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -24,6 +24,7 @@ urllib3 = "^2.2.1"
 pymongo = "<4.9.0"
 pyjwt = "^2.8.0"
 bcrypt = "^4.2.0"
+prometheus-flask-exporter = "^0.23.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.1.2"

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -38,9 +38,14 @@ from src import database
 from . import schemas
 
 
-jobs_metric = Counter("jobs", "Number of jobs", ["queue"])
+jobs_metric = Counter(
+    "jobs", "Number of jobs", ["queue"], namespace="testflinger"
+)
 reservations_metric = Counter(
-    "reservations", "Number of reservations", ["queue"]
+    "reservations",
+    "Number of reservations",
+    ["queue"],
+    namespace="testflinger",
 )
 
 

--- a/server/src/application.py
+++ b/server/src/application.py
@@ -29,6 +29,7 @@ from src.database import setup_mongodb
 from src.api.v1 import v1
 from src.providers import ISODatetimeProvider
 from src.views import views
+from .extensions import metrics
 
 try:
     import sentry_sdk
@@ -62,6 +63,9 @@ def create_flask_app(config=None):
         sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
             dsn=sentry_dsn, integrations=[FlaskIntegration()]
         )
+
+    metrics.group_by = "endpoint"
+    metrics.init_app(tf_app)
 
     @tf_app.errorhandler(NotFound)
     def handle_404(exc):

--- a/server/src/extensions.py
+++ b/server/src/extensions.py
@@ -1,0 +1,7 @@
+"""
+Flask extensions that may be imported by other modules
+"""
+
+from prometheus_flask_exporter import PrometheusMetrics
+
+metrics = PrometheusMetrics.for_app_factory()


### PR DESCRIPTION
## Description

Adds a /metrics route for prometheus to pull lots of data about what flask is doing, and also a few testflinger things like job submissions. This can be extended if we want to add more things.

## Resolved issues
N/A

## Documentation
N/A (the more interesting bits will come when we hook it up to grafana)

## Web service API changes
Technically, yes it adds `/metrics` but it's only meant to be consumed by prometheus and is a well-known interface for anything that uses prometheus metrics. It's not a Testflinger API

## Tests
I've hooked this up to a local prometheus/grafana instance and was able to get data from it
