### PR TITLE
[CERTTF-452] Modify `submit` action behaviour for reservation jobs

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -182,7 +182,7 @@ runs:
         done
         echo "::endgroup::"
         echo "::group::Retrieve IP of reserved machine"
-        DEVICE_IP=$(grep "^Now try logging into the machine" "$CAPTURED_OUTPUT | sed -n "s/.*@\([0-9.]*\).*/\1/p")
+        DEVICE_IP=$(grep "^Now try logging into the machine" "$CAPTURED_OUTPUT" | sed -n "s/.*@\([0-9.]*\).*/\1/p")
         [ "$?" -eq 0 ] && DEVICE_IP_FLAG=true
         [ -n "$DEVICE_IP_FLAG" ] && echo "device-ip=$DEVICE_IP" | tee -a $GITHUB_OUTPUT
         echo "::endgroup::"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -182,13 +182,12 @@ runs:
         done
         echo "::endgroup::"
         echo "::group::Retrieve IP of reserved machine"
-        DEVICE_IP=$(grep "^Now try logging into the machine" "$CAPTURED_OUTPUT" | sed -n "s/.*@\([0-9.]*\).*/\1/p")
+        DEVICE_IP=$(grep -m 1 "^Now try logging into the machine" "$CAPTURED_OUTPUT" | sed -n "s/.*@\([0-9.]*\).*/\1/p")
         [ "$?" -eq 0 ] && DEVICE_IP_FLAG=true
         [ -n "$DEVICE_IP_FLAG" ] && echo "ip=$DEVICE_IP" >> $GITHUB_OUTPUT
         echo "::endgroup::"
         echo "::notice::Reserve exit status: $EXIT_STATUS"
         [ -n "$DEVICE_IP_FLAG" ] && echo "::notice::Device IP: $DEVICE_IP"
-        cat $GITHUB_OUTPUT
         exit $EXIT_STATUS
 
     - name: Cancel the job if the action is cancelled

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -144,9 +144,9 @@ runs:
                 )
               | max'
         )
-        echo "Test exit status: $EXIT_STATUS"
-        exit $EXIT_STATUS
         echo "::endgroup::"
+        echo "::notice::Test exit status: $EXIT_STATUS"
+        exit $EXIT_STATUS
 
     - name: Track the status of the job (reservation)
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation == 'true'
@@ -176,9 +176,9 @@ runs:
           fi
           sleep 10
         done
-        echo "Reserve exit status: $EXIT_STATUS"
-        exit $EXIT_STATUS
         echo "::endgroup::"
+        echo "::notice::Reserve exit status: $EXIT_STATUS"
+        exit $EXIT_STATUS
 
     - name: Cancel the job if the action is cancelled
       if: ${{ cancelled() }}

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -74,6 +74,17 @@ runs:
       shell: bash
       run: cat "$JOB"
 
+    - name: Determine if this is a reservation job
+      id: check-reservation
+      shell: bash
+      run: |
+        if grep -q "^reserve_data:" $JOB; then
+          RESERVATION=true
+        else
+          RESERVATION=false
+        fi
+        echo "reservation=$RESERVATION" >> $GITHUB_OUTPUT
+
     - name: Install prerequisites
       shell: bash
       run: sudo snap install testflinger-cli jq
@@ -93,8 +104,8 @@ runs:
         echo "job id: $JOB_ID"
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
 
-    - name: Track the status of the job
-      if: inputs.poll == 'true' && inputs.dry-run != 'true'
+    - name: Track the status of the job (non-reservation)
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.reservation != 'true'
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
@@ -103,8 +114,38 @@ runs:
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
 
+    - name: Track the status of the job (reservation)
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.reservation == 'true'
+      shell: bash
+      env:
+        SERVER: https://${{ inputs.server }}
+        JOB_ID: ${{ steps.submit.outputs.id }}
+        TERMINATION: "TESTFLINGER SYSTEM RESERVED"
+      run: |
+        # specify file for capturing output and clear it
+        CAPTURED_OUTPUT=output
+        > "$CAPTURED_OUTPUT"
+        # perform one-shot polling until the reserve phase has been reached
+        # and the captured out contains the TERMINATION string
+        while true; do
+          PYTHONUNBUFFERED=1 testflinger --server $SERVER poll --oneshot $JOB_ID | tee -a "$CAPTURED_OUTPUT"
+          JOB_STATUS="$(testflinger --server $SERVER status $JOB_ID)"
+          if [ "$JOB_STATUS" = "reserve" ]; then
+            if grep -q "$TERMINATION" "$CAPTURED_OUTPUT"; then
+              EXIT_STATUS=0
+              break
+            fi
+          elif [[ "$JOB_STATUS" =~ ^(complete|cancelled)$ ]]; then
+            EXIT_STATUS=1
+            break
+          fi
+          sleep 10
+        done
+        echo "Reserve exit status: $EXIT_STATUS"
+        exit $EXIT_STATUS
+
     - name: Retrieve job results and compute exit status
-      if: inputs.poll == 'true' && inputs.dry-run != 'true'
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.reservation != 'true'
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
@@ -113,7 +154,7 @@ runs:
         # retrieve results:
         # the exit status is the maximum status of the individual test phases
         # (excluding the setup and cleanup phases)
-        STATUS=$(\
+        EXIT_STATUS=$(\
           testflinger --server $SERVER results $JOB_ID  \
           | jq 'to_entries
               | map(
@@ -125,8 +166,8 @@ runs:
                 )
               | max'
         )
-        echo "Test exit status: $STATUS"
-        exit $STATUS
+        echo "Test exit status: $EXIT_STATUS"
+        exit $EXIT_STATUS
 
     - name: Cancel the job if the action is cancelled
       if: ${{ cancelled() }}

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -26,6 +26,9 @@ outputs:
   id:
     description: 'The ID of the submitted job'
     value: ${{ steps.submit.outputs.id }}
+  device-ip:
+    description: 'The IP of the reserved device (if applicable)'
+    value: ${{ steps.track-reservation.outputs.device-ip }}
 runs:
   using: composite
   steps:
@@ -149,6 +152,7 @@ runs:
         exit $EXIT_STATUS
 
     - name: Track the status of the job (reservation)
+      id: track-reservation
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation == 'true'
       shell: bash
       env:
@@ -177,7 +181,13 @@ runs:
           sleep 10
         done
         echo "::endgroup::"
+        echo "::group::Retrieve IP of reserved machine"
+        DEVICE_IP=$(grep "^Now try logging into the machine" "$CAPTURED_OUTPUT | sed -n "s/.*@\([0-9.]*\).*/\1/p")
+        [ "$?" -eq 0 ] && DEVICE_IP_FLAG=true
+        [ -n "$DEVICE_IP_FLAG" ] && echo "device-ip=$DEVICE_IP" | tee -a $GITHUB_OUTPUT
+        echo "::endgroup::"
         echo "::notice::Reserve exit status: $EXIT_STATUS"
+        [ -n "$DEVICE_IP_FLAG" ] && echo "::notice::Device IP: $DEVICE_IP"
         exit $EXIT_STATUS
 
     - name: Cancel the job if the action is cancelled

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -34,6 +34,7 @@ runs:
       env:
         SERVER: https://${{ inputs.server }}
       run: |
+        echo "::group::Test connection to Testflinger server"
         STATUS=$(curl --stderr error.log -Ivw "%{http_code}\n" -o /dev/null $SERVER/jobs)
         ERROR=$?
         if [ ! $ERROR -eq 0 ]; then
@@ -47,11 +48,13 @@ runs:
         else
           echo "Successful server ping at $SERVER, status: $STATUS"
         fi
+        echo "::endgroup::"
 
     - name: Create job file, if required
       id: create-job-file
       shell: bash
       run: |
+        echo "::group::Create job file (if required)"
         if [ -n "${{ inputs.job-path }}" ]; then
         # the `$JOB` environment variable points to the job path provided as input
         echo "JOB=${{ inputs.job-path }}" >> $GITHUB_ENV
@@ -69,25 +72,34 @@ runs:
         # the `$JOB` environment variable points to the newly created job file
         echo "JOB=$FILE" >> $GITHUB_ENV
         fi
+        echo "::endgroup::"
 
     - name: Display contents of job file (for verification)
       shell: bash
-      run: cat "$JOB"
+      run: |
+        echo "::group::Display job file"
+        cat "$JOB"
+        echo "::endgroup::"
 
     - name: Determine if this is a reservation job
       id: check-reservation
       shell: bash
       run: |
+        echo "::group::Determine if this is a reservation job"
         if grep -q "^reserve_data:" $JOB; then
           RESERVATION=true
         else
           RESERVATION=false
         fi
         echo "reservation=$RESERVATION" | tee -a $GITHUB_OUTPUT
+        echo "::endgroup::"
 
     - name: Install prerequisites
       shell: bash
-      run: sudo snap install testflinger-cli jq
+      run: |
+        echo "::group::Install prerequisites"
+        sudo snap install testflinger-cli jq
+        echo "::endgroup::"
 
     - name: Submit job to the Testflinger server
       id: submit
@@ -97,12 +109,14 @@ runs:
         SERVER: https://${{ inputs.server }}
         RELATIVE_TO: ${{ inputs.attachments-relative-to }}
       run: |
+        echo "::group::Submit job to the Testflinger server"
         if [ -n "$RELATIVE_TO" ]; then
           RELATIVE="--attachments-relative-to $RELATIVE_TO"
         fi
         JOB_ID=$(testflinger --server $SERVER submit --quiet "$RELATIVE" "$JOB")
         echo "job id: $JOB_ID"
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
 
     - name: Track the status of the job (non-reservation)
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation != 'true'
@@ -111,47 +125,11 @@ runs:
         SERVER: https://${{ inputs.server }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
+        echo "::group::Track the status of the job"
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
-
-    - name: Track the status of the job (reservation)
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation == 'true'
-      shell: bash
-      env:
-        SERVER: https://${{ inputs.server }}
-        JOB_ID: ${{ steps.submit.outputs.id }}
-        TERMINATION: "TESTFLINGER SYSTEM RESERVED"
-      run: |
-        # specify file for capturing output and clear it
-        CAPTURED_OUTPUT=output
-        > "$CAPTURED_OUTPUT"
-        # perform one-shot polling until the reserve phase has been reached
-        # and the captured out contains the TERMINATION string
-        while true; do
-          PYTHONUNBUFFERED=1 testflinger --server $SERVER poll --oneshot $JOB_ID | tee -a "$CAPTURED_OUTPUT"
-          JOB_STATUS="$(testflinger --server $SERVER status $JOB_ID)"
-          if [ "$JOB_STATUS" = "reserve" ]; then
-            if grep -q "$TERMINATION" "$CAPTURED_OUTPUT"; then
-              EXIT_STATUS=0
-              break
-            fi
-          elif [[ "$JOB_STATUS" =~ ^(complete|cancelled)$ ]]; then
-            EXIT_STATUS=1
-            break
-          fi
-          sleep 10
-        done
-        echo "Reserve exit status: $EXIT_STATUS"
-        exit $EXIT_STATUS
-
-    - name: Retrieve job results and compute exit status
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation != 'true'
-      shell: bash
-      env:
-        SERVER: https://${{ inputs.server }}
-        JOB_ID: ${{ steps.submit.outputs.id }}
-      run: |
-        # retrieve results:
+        echo "::endgroup::"
+        echo "::group::Retrieve job results, determine exit status"
         # the exit status is the maximum status of the individual test phases
         # (excluding the setup and cleanup phases)
         EXIT_STATUS=$(\
@@ -168,6 +146,39 @@ runs:
         )
         echo "Test exit status: $EXIT_STATUS"
         exit $EXIT_STATUS
+        echo "::endgroup::"
+
+    - name: Track the status of the job (reservation)
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation == 'true'
+      shell: bash
+      env:
+        SERVER: https://${{ inputs.server }}
+        JOB_ID: ${{ steps.submit.outputs.id }}
+        TERMINATION: "TESTFLINGER SYSTEM RESERVED"
+      run: |
+        echo "::group::Track the status of the reservation job"
+        # specify file for capturing output and clear it
+        CAPTURED_OUTPUT=output
+        > "$CAPTURED_OUTPUT"
+        # perform one-shot polling until the reserve phase has been reached
+        # and the captured output contains the TERMINATION string
+        while true; do
+          PYTHONUNBUFFERED=1 testflinger --server $SERVER poll --oneshot $JOB_ID | tee -a "$CAPTURED_OUTPUT"
+          JOB_STATUS="$(testflinger --server $SERVER status $JOB_ID)"
+          if [ "$JOB_STATUS" = "reserve" ]; then
+            if grep -q "$TERMINATION" "$CAPTURED_OUTPUT"; then
+              EXIT_STATUS=0
+              break
+            fi
+          elif [[ "$JOB_STATUS" =~ ^(complete|cancelled)$ ]]; then
+            EXIT_STATUS=1
+            break
+          fi
+          sleep 10
+        done
+        echo "Reserve exit status: $EXIT_STATUS"
+        exit $EXIT_STATUS
+        echo "::endgroup::"
 
     - name: Cancel the job if the action is cancelled
       if: ${{ cancelled() }}
@@ -176,4 +187,6 @@ runs:
         SERVER: https://${{ inputs.server }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
+        echo "::group::Cancel job"
         testflinger --server $SERVER cancel $JOB_ID
+        echo "::endgroup::"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -188,6 +188,7 @@ runs:
         echo "::endgroup::"
         echo "::notice::Reserve exit status: $EXIT_STATUS"
         [ -n "$DEVICE_IP_FLAG" ] && echo "::notice::Device IP: $DEVICE_IP"
+        cat $GITHUB_OUTPUT
         exit $EXIT_STATUS
 
     - name: Cancel the job if the action is cancelled

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -28,7 +28,7 @@ outputs:
     value: ${{ steps.submit.outputs.id }}
   device-ip:
     description: 'The IP of the reserved device (if applicable)'
-    value: ${{ steps.track-reservation.outputs.device-ip }}
+    value: ${{ steps.track-reservation.outputs.ip }}
 runs:
   using: composite
   steps:
@@ -184,7 +184,7 @@ runs:
         echo "::group::Retrieve IP of reserved machine"
         DEVICE_IP=$(grep "^Now try logging into the machine" "$CAPTURED_OUTPUT" | sed -n "s/.*@\([0-9.]*\).*/\1/p")
         [ "$?" -eq 0 ] && DEVICE_IP_FLAG=true
-        [ -n "$DEVICE_IP_FLAG" ] && echo "device-ip=$DEVICE_IP" | tee -a $GITHUB_OUTPUT
+        [ -n "$DEVICE_IP_FLAG" ] && echo "ip=$DEVICE_IP" >> $GITHUB_OUTPUT
         echo "::endgroup::"
         echo "::notice::Reserve exit status: $EXIT_STATUS"
         [ -n "$DEVICE_IP_FLAG" ] && echo "::notice::Device IP: $DEVICE_IP"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -93,7 +93,7 @@ runs:
         echo "job id: $JOB_ID"
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
 
-    - name: Track the status of the job and mirror its exit status
+    - name: Track the status of the job
       if: inputs.poll == 'true' && inputs.dry-run != 'true'
       shell: bash
       env:
@@ -102,6 +102,14 @@ runs:
       run: |
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
+
+    - name: Retrieve job results and compute exit status
+      if: inputs.poll == 'true' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        SERVER: https://${{ inputs.server }}
+        JOB_ID: ${{ steps.submit.outputs.id }}
+      run: |
         # retrieve results:
         # the exit status is the maximum status of the individual test phases
         # (excluding the setup and cleanup phases)

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -125,7 +125,7 @@ runs:
         SERVER: https://${{ inputs.server }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
-        echo "::group::Track the status of job $JOB_ID"
+        echo "::group::Track the status of job \$JOB_ID"
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
         echo "::endgroup::"
@@ -156,7 +156,7 @@ runs:
         JOB_ID: ${{ steps.submit.outputs.id }}
         TERMINATION: "TESTFLINGER SYSTEM RESERVED"
       run: |
-        echo "::group::Track the status of reservation job $JOB_ID"
+        echo "::group::Track the status of reservation job \$JOB_ID"
         # specify file for capturing output and clear it
         CAPTURED_OUTPUT=output
         > "$CAPTURED_OUTPUT"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -105,7 +105,7 @@ runs:
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
 
     - name: Track the status of the job (non-reservation)
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.output.reservation != 'true'
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation != 'true'
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
@@ -115,7 +115,7 @@ runs:
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
 
     - name: Track the status of the job (reservation)
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.output.reservation == 'true'
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation == 'true'
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
@@ -145,7 +145,7 @@ runs:
         exit $EXIT_STATUS
 
     - name: Retrieve job results and compute exit status
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.output.reservation != 'true'
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation != 'true'
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -114,9 +114,9 @@ runs:
           RELATIVE="--attachments-relative-to $RELATIVE_TO"
         fi
         JOB_ID=$(testflinger --server $SERVER submit --quiet "$RELATIVE" "$JOB")
-        echo "job id: $JOB_ID"
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
         echo "::endgroup::"
+        echo "::notice::Submitted job $JOB_ID"
 
     - name: Track the status of the job (non-reservation)
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.outputs.reservation != 'true'
@@ -125,7 +125,7 @@ runs:
         SERVER: https://${{ inputs.server }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
-        echo "::group::Track the status of the job"
+        echo "::group::Track the status of job $JOB_ID"
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
         echo "::endgroup::"
@@ -156,7 +156,7 @@ runs:
         JOB_ID: ${{ steps.submit.outputs.id }}
         TERMINATION: "TESTFLINGER SYSTEM RESERVED"
       run: |
-        echo "::group::Track the status of the reservation job"
+        echo "::group::Track the status of reservation job $JOB_ID"
         # specify file for capturing output and clear it
         CAPTURED_OUTPUT=output
         > "$CAPTURED_OUTPUT"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -83,7 +83,7 @@ runs:
         else
           RESERVATION=false
         fi
-        echo "reservation=$RESERVATION" >> $GITHUB_OUTPUT
+        echo "reservation=$RESERVATION" | tee -a $GITHUB_OUTPUT
 
     - name: Install prerequisites
       shell: bash
@@ -105,7 +105,7 @@ runs:
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
 
     - name: Track the status of the job (non-reservation)
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.reservation != 'true'
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.output.reservation != 'true'
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
@@ -115,7 +115,7 @@ runs:
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
 
     - name: Track the status of the job (reservation)
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.reservation == 'true'
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.output.reservation == 'true'
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
@@ -145,7 +145,7 @@ runs:
         exit $EXIT_STATUS
 
     - name: Retrieve job results and compute exit status
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.reservation != 'true'
+      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-reservation.output.reservation != 'true'
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -125,7 +125,7 @@ runs:
         SERVER: https://${{ inputs.server }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
-        echo "::group::Track the status of job \$JOB_ID"
+        echo "::group::Track the status of job ${{ env.JOB_ID }}"
         # poll
         PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID
         echo "::endgroup::"
@@ -156,7 +156,7 @@ runs:
         JOB_ID: ${{ steps.submit.outputs.id }}
         TERMINATION: "TESTFLINGER SYSTEM RESERVED"
       run: |
-        echo "::group::Track the status of reservation job \$JOB_ID"
+        echo "::group::Track the status of reservation job ${{ env.JOB_ID }}"
         # specify file for capturing output and clear it
         CAPTURED_OUTPUT=output
         > "$CAPTURED_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -74,3 +74,12 @@ in any of the subsequent steps of the workflow:
         testflinger results ${{ steps.submit-job.outputs.id }}"
 ```
 In this example, `submit-job` is the step where the `submit` action is used.
+
+If the submitted job is a reservation job (i.e. includes `reserve_data`) then
+setting the `poll` input argument to `true` results in modified behaviour: the
+job is polled only until the reservation phase is complete, instead of waiting
+for the entire job to complete (which happens when the reservation timeout
+expires or the job is cancelled). There will be no output to record after the
+reservation so there is little point in polling and idly occupying the runner.
+However, please do remember to manually cancel the job after you are done with
+the reserved device.


### PR DESCRIPTION
## Description

When the Testflinger `submit` action is used to submit a reservation job, neither polling or not polling results in useful behaviour (please refer to #397 for details). 

This PR introduces a conditional step in the `submit` action that is executed _instead_ of regular polling when the submitted job is a reservation job. It performs one-shot polling until the reservation phase is complete and then considers that step of the action complete, i.e. it does not poll until the completion of the entire job. The IP of the reserved device is retrieved from the captured output and returned as the new `device-ip` output of the `submit` action.

Because of the length and complexity of the output generated by the `submit` action [workflow commands](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions) have also been introduced in order to group output into collapsible sections and highlight important information using "notices".

## Resolved issues

Resolves issue #397 and [CERTTF-452](https://warthogs.atlassian.net/browse/CERTTF-452).

## Documentation

The part of the main README that documents the `submit` action has been extended accordingly to describe the modified polling behaviour for reservation jobs.

## Tests

Multiple test workflow runs for reservation and non-reservation jobs. Some examples include:
- [Run](https://github.com/canonical/certification-lab-ci/actions/runs/11777494876/job/32802013387) of a reservation job (including provisioning), to test and demonstrate the modified polling behaviour for reservation jobs.
- [Run](https://github.com/canonical/certification-lab-ci/actions/runs/11777040259/job/32800630762) of a trivial test job (no provisioning), to demonstrate that polling for a non-reservation job still works as expected

In both cases, it is worth noticing how neatly the output is arranged because of grouping and how the job ID and device IP are highlighted and easily located using notices.

[CERTTF-452]: https://warthogs.atlassian.net/browse/CERTTF-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ