### PR TITLE
Add: concept of preset to zapper-iot connector

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -52,33 +52,24 @@ class DeviceConnector(ZapperConnector):
             "reboot_script": self.config["reboot_script"],
         }
 
-        test_plan = self.job_data["provision_data"].get("tplan")
-        if test_plan:
+        provision_plan = self.job_data["provision_data"].get("provision_plan")
+        if provision_plan:
 
             try:
-                validate_tplan(test_plan)
+                validate_provision_plan(test_plan)
 
                 # Make sure the user created at provision time is
                 # the same used during the test phase.
-                test_plan["config"]["username"] = username
-                test_plan["config"]["password"] = password
+                provision_plan["config"]["username"] = username
+                provision_plan["config"]["password"] = password
 
-                provisioning_data["custom_testplan"] = test_plan
+                provisioning_data["custom_testplan"] = provision_plan
             except ValueError as e:
                 raise ProvisioningError from e
 
-        urls = self.job_data["provision_data"].get("urls", [])
-        try:
-            provision_plan = self.job_data["provision_data"]["provision_plan"]
-            validate_provision_plan(provision_plan)
-        except KeyError as e:
-            raise ProvisioningError from e
 
-        try:
-            urls = self.job_data["provision_data"]["urls"]
-            validate_urls(urls)
-        except KeyError:
-            urls = []
+        urls = self.job_data["provision_data"].get("urls", [])
+        validate_urls(urls)
         provisioning_data["urls"] = urls
 
         return ((), provisioning_data)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -56,20 +56,22 @@ class DeviceConnector(ZapperConnector):
         if provision_plan:
 
             try:
-                validate_provision_plan(test_plan)
+                validate_provision_plan(provision_plan)
 
                 # Make sure the user created at provision time is
                 # the same used during the test phase.
                 provision_plan["config"]["username"] = username
                 provision_plan["config"]["password"] = password
 
-                provisioning_data["custom_testplan"] = provision_plan
+                provisioning_data["custom_provision_plan"] = provision_plan
             except ValueError as e:
                 raise ProvisioningError from e
 
-
         urls = self.job_data["provision_data"].get("urls", [])
-        validate_urls(urls)
+        try:
+            validate_urls(urls)
+        except ValueError as e:
+            raise ProvisioningError from e
         provisioning_data["urls"] = urls
 
         return ((), provisioning_data)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
@@ -8,7 +8,7 @@ from typing import List
 
 logger = logging.getLogger(__name__)
 
-TPLAN_SCHEMA = {
+TESTPLAN_SCHEMA = {
     "type": "object",
     "properties": {
         "config": {
@@ -203,7 +203,7 @@ def validate_provision_plan(data):
     is valid in terms of schema.
     """
     try:
-        validate(instance=data, schema=TPLAN_SCHEMA)
+        validate(instance=data, schema=TESTPLAN_SCHEMA)
         logger.info("the JSON data is valid")
     except jsonschema.exceptions.ValidationError as err:
         raise ValueError("the JSON data is invalid") from err

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
@@ -4,6 +4,7 @@ import logging
 import validators
 import jsonschema
 from jsonschema import validate
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -197,7 +198,10 @@ TPLAN_SCHEMA = {
 
 
 def validate_provision_plan(data):
-    """for verify provision yaml"""
+    """
+    Validate whether the provided custom testplan
+    is valid in terms of schema.
+    """
     try:
         validate(instance=data, schema=TPLAN_SCHEMA)
         logger.info("the JSON data is valid")
@@ -205,8 +209,14 @@ def validate_provision_plan(data):
         raise ValueError("the JSON data is invalid") from err
 
 
-def validate_url(url):
-    """for verify url"""
-    for link in url:
-        if not validators.url(link):
+def validate_urls(urls: List[str]):
+    """
+    Validate whether the provided URL
+    is valid in terms of format.
+
+    We cannot assert for resource availability here,
+    since this is not the host downloading the content.
+    """
+    for url in urls:
+        if not validators.url(url):
             raise ValueError("url format is not correct")

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -37,14 +37,14 @@ class ZapperIoTTests(unittest.TestCase):
 
     def test_validate_configuration_tplan(self):
         """
-        Test the function validates a custom tplan
+        Test the function validates a custom test plan
         when provided.
         """
 
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
-                "tplan": {
+                "test_plan": {
                     "config": {
                         "project_name": "name",
                         "username": "admin",
@@ -110,14 +110,14 @@ class ZapperIoTTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
 
-    def test_validate_configuration_invalid_tplan(self):
+    def test_validate_configuration_invalid_test_plan(self):
         """
         Test the function raises an exception if the
         provided custom testplan is not valid.
         """
 
         device = DeviceConnector()
-        device.job_data = {"provision_data": {"tplan": {"key1": "value1"}}}
+        device.job_data = {"provision_data": {"test_plan": {"key1": "value1"}}}
         device.config = {"reboot_script": []}
 
         with self.assertRaises(ProvisioningError):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -117,7 +117,9 @@ class ZapperIoTTests(unittest.TestCase):
         """
 
         device = DeviceConnector()
-        device.job_data = {"provision_data": {"provision_plan": {"key1": "value1"}}}
+        device.job_data = {
+            "provision_data": {"provision_plan": {"key1": "value1"}}
+        }
         device.config = {"reboot_script": []}
 
         with self.assertRaises(ProvisioningError):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -1,0 +1,124 @@
+import unittest
+
+from testflinger_device_connectors.devices import ProvisioningError
+from testflinger_device_connectors.devices.zapper_iot import DeviceConnector
+
+
+class ZapperIoTTests(unittest.TestCase):
+    """Test Cases for the Zapper IoT class."""
+
+    def test_validate_configuration(self):
+        """
+        Test the function creates a proper provision_data
+        dictionary when valid data are provided.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "preset": "TestPreset",
+                "urls": ["http://test.tar.gz"],
+            }
+        }
+        device.config = {"reboot_script": ["cmd1", "cmd2"]}
+
+        args, kwargs = device._validate_configuration()
+
+        expected = {
+            "username": "ubuntu",
+            "password": "ubuntu",
+            "preset": "TestPreset",
+            "reboot_script": ["cmd1", "cmd2"],
+            "urls": ["http://test.tar.gz"],
+        }
+
+        self.assertEqual(args, ())
+        self.assertDictEqual(kwargs, expected)
+
+    def test_validate_configuration_tplan(self):
+        """
+        Test the function validates a custom tplan
+        when provided.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "tplan": {
+                    "config": {
+                        "project_name": "name",
+                        "username": "admin",
+                        "password": "admin",
+                        "serial_console": {
+                            "port": "/dev/ttySanity1",
+                            "baud_rate": 115200,
+                        },
+                        "network": "eth0",
+                        "hostname": "C031051825-00136",
+                    },
+                    "run_stage": [
+                        {"initial_login": {"method": "system-user"}},
+                    ],
+                }
+            }
+        }
+        device.config = {"reboot_script": ["cmd1", "cmd2"]}
+
+        args, kwargs = device._validate_configuration()
+
+        expected = {
+            "username": "ubuntu",
+            "password": "ubuntu",
+            "custom_testplan": {
+                "config": {
+                    "project_name": "name",
+                    "username": "ubuntu",  # this gets overridden
+                    "password": "ubuntu",
+                    "serial_console": {
+                        "port": "/dev/ttySanity1",
+                        "baud_rate": 115200,
+                    },
+                    "network": "eth0",
+                    "hostname": "C031051825-00136",
+                },
+                "run_stage": [
+                    {"initial_login": {"method": "system-user"}},
+                ],
+            },
+            "urls": [],
+            "reboot_script": ["cmd1", "cmd2"],
+            "preset": None,
+        }
+        self.maxDiff = None
+        self.assertEqual(args, ())
+        self.assertDictEqual(expected, kwargs)
+
+    def test_validate_configuration_invalid_url(self):
+        """
+        Test the function raises an exception if one of
+        the url is not valid.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "urls": ["not-a-url"],
+            }
+        }
+        device.config = {"reboot_script": ["cmd1", "cmd2"]}
+
+        with self.assertRaises(ProvisioningError):
+            device._validate_configuration()
+
+    def test_validate_configuration_invalid_tplan(self):
+        """
+        Test the function raises an exception if the
+        provided custom testplan is not valid.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {"provision_data": {"tplan": {"key1": "value1"}}}
+        device.config = {"reboot_script": []}
+
+        with self.assertRaises(ProvisioningError):
+            device._validate_configuration()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -35,7 +35,7 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
-    def test_validate_configuration_tplan(self):
+    def test_validate_configuration_provision_plan(self):
         """
         Test the function validates a custom test plan
         when provided.
@@ -44,7 +44,7 @@ class ZapperIoTTests(unittest.TestCase):
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
-                "test_plan": {
+                "provision_plan": {
                     "config": {
                         "project_name": "name",
                         "username": "admin",
@@ -69,7 +69,7 @@ class ZapperIoTTests(unittest.TestCase):
         expected = {
             "username": "ubuntu",
             "password": "ubuntu",
-            "custom_testplan": {
+            "custom_provision_plan": {
                 "config": {
                     "project_name": "name",
                     "username": "ubuntu",  # this gets overridden
@@ -110,14 +110,14 @@ class ZapperIoTTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
 
-    def test_validate_configuration_invalid_test_plan(self):
+    def test_validate_configuration_invalid_provision_plan(self):
         """
         Test the function raises an exception if the
         provided custom testplan is not valid.
         """
 
         device = DeviceConnector()
-        device.job_data = {"provision_data": {"test_plan": {"key1": "value1"}}}
+        device.job_data = {"provision_data": {"provision_plan": {"key1": "value1"}}}
         device.config = {"reboot_script": []}
 
         with self.assertRaises(ProvisioningError):


### PR DESCRIPTION
## Description

This PR adds support for the `preset` key in the provision_data for zapper-iot connector.

Some minor changes:
- renamed `url` to `urls`
- overwrite the username/password
- passing `reboot_script` from config

## Resolved issues

Part of [ZAP-998](https://warthogs.atlassian.net/browse/ZAP-998)

## Documentation

N/A

## Web service API changes

N/A

## Tests

Tested running `testflinger-device-connector zapper_iot provision --config config.yaml  job.json` with 

```
# config.yaml
device_ip: 10.102.162.85
control_host: 10.102.242.85
reboot_script:
  - snmpset -c private -v2c 10.102.196.146 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.8 i 0
  - sleep 30
  - snmpset -c private -v2c 10.102.196.146 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.8 i 1
  
# job.json
  {
    "provision_data": {
        "preset": "Tillamook",
        "urls": [
            "https://tel-image-cache.canonical.com/oem-share/tillamook/uc20/uc20-gm/tillamook-core-20-gm-20230905-16.tar.gz"
        ]
    },
    "test_data": {
        "test_username": "admin",
        "test_password": "admin"
    }
}
```


[ZAP-998]: https://warthogs.atlassian.net/browse/ZAP-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ