### PR TITLE
Add a github workflow to release testflinger-k8s charm to stable

### DIFF
--- a/.github/workflows/server-charm-promote-stable.yml
+++ b/.github/workflows/server-charm-promote-stable.yml
@@ -1,0 +1,17 @@
+name: Promote testflinger-k8s charm from edge to latest/stable
+
+on:
+  workflow_dispatch:
+jobs:
+  promote-charm:
+    name: Promote testflinger-k8s charm to stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Release testflinger-k8s charm to stable
+        uses: canonical/charming-actions/promote-charm@main
+        with:
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          destination-channel: latest/stable
+          origin-channel: latest/edge
+          charm-path: server/charm


### PR DESCRIPTION
## Description

Add a github workflow that can be used for promoting the version of testflinger-k8s charm in edge to stable

## Resolved issues
N/A

## Documentation
Once this lands, I'll update the howto for the release process, as this method is much simpler

## Web service API changes
N/A

## Tests
https://github.com/canonical/testflinger/actions/runs/11823043313/job/32942289691