### PR TITLE
[CERTTF-388] [CERTTF-443] Implement masking on the agent

### DIFF
--- a/agent/testflinger_agent/masking.py
+++ b/agent/testflinger_agent/masking.py
@@ -1,0 +1,42 @@
+"""
+Text masking for sensitive information.
+
+This module provides functionality to mask sensitive information in text.
+Each matched pattern is replaced with a deterministic hash, ensuring that
+the same sensitive information is always replaced by the same mask.
+"""
+
+import hashlib
+import re
+from typing import List, Optional
+
+
+class Masker:
+    """
+    A class for masking sensitive information in text.
+
+    Example:
+        >>> masker = Masker(['\\d{3}-\\d{2}-\\d{4}'], hash_length=6)
+        >>> masker.apply("SSN: 123-45-6789")
+        'SSN: **01a546**'
+    """
+
+    def __init__(self, patterns: List[str], hash_length: Optional[int] = None):
+        # join all patterns into a single combined pattern and compile it
+        combined = "|".join(f"({pattern})" for pattern in patterns)
+        self.pattern = re.compile(combined)
+        # the length of the hash to be used for masking
+        # (a value of `None` results in the full hash length)
+        self.hash_length = hash_length
+
+    def hash(self, text: str) -> str:
+        """Return a hash of appropriate length for the giver `text`"""
+        return hashlib.sha256(text.encode()).hexdigest()[: self.hash_length]
+
+    def mask(self, match: re.Match) -> str:
+        """Return a string with a mask applied on a pattern `match`"""
+        return f"**{self.hash(match.group())}**"
+
+    def apply(self, text: str) -> str:
+        """Return a string with all pattern matches in `text` masked"""
+        return self.pattern.sub(self.mask, text)

--- a/agent/testflinger_agent/runner.py
+++ b/agent/testflinger_agent/runner.py
@@ -26,6 +26,8 @@ from enum import Enum
 from typing import Callable, List, Optional, Tuple
 
 from testflinger_common.enums import TestEvent
+from testflinger_agent.masking import Masker
+
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +157,19 @@ class CommandRunner:
             stop_reason = get_stop_reason(self.process.returncode, "")
 
         return self.process.returncode, stop_event, stop_reason
+
+
+class MaskingCommandRunner(CommandRunner):
+    """A CommandRunner that masks sensitive information in the output"""
+
+    def __init__(self, *args, masker: Masker, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.masker = masker
+
+    def post_output(self, data: str):
+        # mask sensitive information before posting output data
+        data = self.masker.apply(data)
+        super().post_output(data)
 
 
 def get_stop_reason(returncode: int, stop_reason: str) -> str:

--- a/agent/testflinger_agent/schema.py
+++ b/agent/testflinger_agent/schema.py
@@ -45,6 +45,7 @@ SCHEMA_V1 = {
     voluptuous.Optional("output_timeout"): int,
     voluptuous.Optional("advertised_queues"): dict,
     voluptuous.Optional("advertised_images"): dict,
+    voluptuous.Optional("sensitive_patterns"): list,
 }
 
 

--- a/agent/testflinger_agent/tests/test_masker.py
+++ b/agent/testflinger_agent/tests/test_masker.py
@@ -1,0 +1,69 @@
+from testflinger_agent.masking import Masker
+
+
+def test_hash_consistency():
+    hash_length = 12
+    masker = Masker([], hash_length=hash_length)
+    text = "123 testflinger-456 no-secret"
+    # hash same text twice and compare hashes
+    hash1 = masker.hash(text)
+    hash2 = masker.hash(text)
+    assert hash1 == hash2
+    assert len(hash1) == hash_length
+
+
+def test_no_matches():
+    # masker for numerical values
+    masker = Masker([r"\d+"])
+    # input text has no numerical values
+    text = "testflinger"
+    # there should be no masking
+    masked = masker.apply(text)
+    assert masked == text
+
+
+def test_no_hash_length():
+    # masker for numerical values, no hash length
+    # (expected hash length is the full SHA-256 hash, i.e. 64 characters)
+    masker = Masker([r"\d+"])
+    # input text is numerical
+    text = "123456"
+    hash_value = masker.hash(text)
+    assert len(hash_value) == 64
+
+
+def test_mask_format():
+    hash_length = 12
+    text = "123456"
+    masker = Masker([r"\d+"], hash_length=hash_length)
+    masked = masker.apply(text)
+    print(masked)
+    assert masked.startswith("**")
+    assert masked.endswith("**")
+    assert len(masked) == hash_length + 4
+
+
+def test_apply_with_single_pattern():
+    hash_length = 12
+    text = "SSN: 123-45-6789"
+    masker = Masker([r"\b\d{3}-\d{2}-\d{4}\b"], hash_length=hash_length)
+    masked = masker.apply(text)
+    assert "123-45-6789" not in masked
+    assert masked.startswith("SSN: **")
+    assert masked.endswith("**")
+
+
+def test_apply_with_multiple_matches():
+    hash_length = 12
+    text = "Contact: john@example.com, SSN: 123-45-6789"
+    masker = Masker(
+        [
+            r"\b\d{3}-\d{2}-\d{4}\b",
+            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
+        ],
+        hash_length=hash_length,
+    )
+    masked = masker.apply(text)
+    assert "john@example.com" not in masked
+    assert "123-45-6789" not in masked
+    assert masked.count("**") == 4

--- a/agent/testflinger_agent/tests/test_runner.py
+++ b/agent/testflinger_agent/tests/test_runner.py
@@ -1,0 +1,70 @@
+from testflinger_agent.handlers import LogUpdateHandler
+from testflinger_agent.masking import Masker
+from testflinger_agent.runner import CommandRunner, MaskingCommandRunner
+
+
+def test_runner(tmp_path):
+    """Check that runner output is as expected"""
+    logfile = tmp_path / "testlog"
+    log_handler = LogUpdateHandler(logfile)
+    runner = CommandRunner(tmp_path, env={})
+    runner.register_output_handler(log_handler)
+    exit_code, _, _ = runner.run("echo -n Message")
+    with open(logfile) as log:
+        log_data = log.read()
+    assert exit_code == 0
+    assert log_data == "Message"
+
+
+def test_runner_environment(tmp_path):
+    """Check injection of environment variables"""
+    logfile = tmp_path / "testlog"
+    log_handler = LogUpdateHandler(logfile)
+    runner = CommandRunner(tmp_path, env={"MESSAGE": "Message"})
+    runner.register_output_handler(log_handler)
+    exit_code, _, _ = runner.run("echo -n $MESSAGE")
+    with open(logfile) as log:
+        log_data = log.read()
+    assert exit_code == 0
+    assert log_data == "Message"
+
+
+def test_masking_runner(tmp_path):
+    """Check masking"""
+    logfile = tmp_path / "testlog"
+    log_handler = LogUpdateHandler(logfile)
+    hash_length = 24
+    non_sensitive = "Message: "
+    sensitive = "Sensitive"
+    masker = Masker([sensitive], hash_length=hash_length)
+    runner = MaskingCommandRunner(tmp_path, env={}, masker=masker)
+    runner.register_output_handler(log_handler)
+    exit_code, _, _ = runner.run(f"echo -n {non_sensitive}{sensitive}")
+    with open(logfile) as log:
+        log_data = log.read()
+    assert exit_code == 0
+    assert log_data.startswith("Message: ")
+    assert "Sensitive" not in log_data
+    assert len(log_data) == len(non_sensitive) + hash_length + 4
+
+
+def test_masking_runner_environment(tmp_path):
+    """Check masking of sensitive environment variables"""
+    logfile = tmp_path / "testlog"
+    log_handler = LogUpdateHandler(logfile)
+    hash_length = 24
+    non_sensitive = "Message: "
+    sensitive = {"SECRET1": "secret", "SECRET2": "another_secret"}
+    masker = Masker(list(sensitive.values()), hash_length=hash_length)
+    runner = MaskingCommandRunner(tmp_path, env=sensitive, masker=masker)
+    runner.register_output_handler(log_handler)
+    exit_code, _, _ = runner.run(
+        f"echo -n {non_sensitive}{sensitive['SECRET1']}{sensitive['SECRET2']}"
+    )
+    with open(logfile) as log:
+        log_data = log.read()
+    assert exit_code == 0
+    assert log_data.startswith("Message: ")
+    assert "secret" not in log_data
+    assert "another_secret" not in log_data
+    assert len(log_data) == len(non_sensitive) + 2 * (hash_length + 4)

--- a/agent/tox.ini
+++ b/agent/tox.ini
@@ -16,6 +16,7 @@ deps =
     pytest-timeout
     requests-mock
 commands =
+    {envbindir}/pip install -e ../device-connectors
     {envbindir}/pip install -e .
     {envbindir}/python -m black --check testflinger_agent
     {envbindir}/python -m flake8 testflinger_agent


### PR DESCRIPTION
## Description

As described in [CR080 - Handling secrets and sensitive information in Testflinger](https://docs.google.com/document/d/1ATsqtCAytZJrWFenELCsY9LK80iyZspXalH4Dlvscd4/edit?usp=sharing), one of the tasks involved in supporting secrets in Testflinger is implementing functionality for masking sensitive information in the output generated by the Testflinger agent.

This PR:
- Introduces a standalone generic `Masker` class for masking sensitive information in text. What is considered sensitive is specified through a list of regular expressions.
- Introduces the `MaskingCommandRunner` class, derived from the regular `CommandRunner`. Their only difference lies in the `post_output` method, where the masking variant of the runner employs a `Masker` to the output before posting it. The `Masker` to be used is actually provided to the runner upon its construction, so the runner itself is not aware of the specifics, i.e. it is not aware of the kind of information that is considered sensitive.
- Extends the `TestflingerJob` class to check if "sensitive patterns" are specified in the agent's configuration file or if secrets are included in the job data. In any of these cases, it employs a `MaskingCommandRunner` instead of a regular `CommandRunner`, to make sure that sensitive information is masked in the output. In the case of secrets, it also injects them into the corresponding environment variables of the runner ([CERTTF-443](https://warthogs.atlassian.net/browse/CERTTF-443)).

## Resolved issues

Resolves [CERTTF-388](https://warthogs.atlassian.net/browse/CERTTF-388) and [CERTTF-443](https://warthogs.atlassian.net/browse/CERTTF-443).

Some (reasonable) assumptions have been made regarding the way the server will pass secrets onto the agent along with other job data. This is separate work to be undertaken within [CERTTF-441](https://warthogs.atlassian.net/browse/CERTTF-441) and possibly [CERTTF-444](https://warthogs.atlassian.net/browse/CERTTF-444), so some minor modifications might be necessary when these tasks are also completed. 

## Documentation

## Tests

Tests have been included for all the newly introduced classes and functionality, including integration-style tests that use the `fake_connector` device connector to run `test_cmds` that include sensitive information and/or secrets.