### PR TITLE
Update tf-cleanup for this branch to keep current with PR#382 that was just merged

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
@@ -2,11 +2,17 @@
 
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
+
+# The following variables are set by the agent charm
+AGENT_CONFIGS_PATH={{ agent_configs_path }}
+CONFIG_DIR="{{ config_dir }}"
 VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
 if [ -d "$VIRTUAL_ENV_PATH" ]; then
     echo Cleaning up container if it exists... && docker rm -f $agent_id || /bin/true
+    PYTHONUNBUFFERED=1 $VIRTUAL_ENV_PATH/bin/testflinger-device-connector $PROVISION_TYPE cleanup -c $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json
 else
     echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+    . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE cleanup -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
 fi
 


### PR DESCRIPTION
## Description

Now that we merged support for releasing maas devices after the run is complete, we need to ensure that the cleanup step actually runs properly.  Previously it was just removing the test container if it exists, but now we need to have it call `testflinger-device-connectors cleanup` in case there's something to do for the phase.

This has already been fixed in the tf-cleanup script for main, but we need to fix it here too for the newer style agent hosts. This is just so that things don't revert back to an older version of this script that lacks this support once we do merge this branch into main.

## Resolved issues
N/A

## Documentation
N/A

## Web service API changes
N/A

## Tests
I tested this in an environment that uses the newer agent hosts and it worked. I have already deployed the change for releasing maas nodes in the server lab so I updated this script there already and it correctly releases the system at the end of the job.