### PR TITLE
rename tplan to more appropriate name "provision_plan"

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Tuple
 from testflinger_device_connectors.devices.zapper import ZapperConnector
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.zapper_iot.parser import (
-    validate_tplan,
+    validate_provision_plan,
     validate_url,
 )
 
@@ -38,8 +38,8 @@ class DeviceConnector(ZapperConnector):
         for the Zapper `provision` API.
         """
         try:
-            tplan = self.job_data["provision_data"]["tplan"]
-            validate_tplan(tplan)
+            provision_plan = self.job_data["provision_data"]["provision_plan"]
+            validate_provision_plan(provision_plan)
         except KeyError as e:
             raise ProvisioningError from e
 
@@ -49,4 +49,4 @@ class DeviceConnector(ZapperConnector):
         except KeyError:
             url = []
 
-        return ((tplan, url), {})
+        return ((provision_plan, url), {})

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
@@ -196,7 +196,7 @@ TPLAN_SCHEMA = {
 }
 
 
-def validate_tplan(data):
+def validate_provision_plan(data):
     """for verify provision yaml"""
     try:
         validate(instance=data, schema=TPLAN_SCHEMA)


### PR DESCRIPTION
## Description
rename tplan to provision_plan to avoid confusion

## Resolved issues



## Documentation


## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Update task.yaml for x8high-pdk and med-pdk and provision successfully 
