### PR TITLE
Add testflinger-testenv container

### DIFF
--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -19,6 +19,10 @@ jobs:
       contents: read
       packages: write
 
+    strategy:
+      matrix:
+        version: [focal, jammy, noble]
+
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -42,6 +46,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.base_version }}
 
       - name: Build and push backend Docker image
         uses: docker/build-push-action@v6
@@ -50,3 +56,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=ubuntu:${{ matrix.version }}

--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - agent/extra/testflinger-testenv/**
+      - .github/workflows/build-testflinger-testenv-container.yml
   workflow_dispatch:
 
 env:
@@ -46,8 +47,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.base_version }}
+          tags: ${{ matrix.version }}
 
       - name: Build and push backend Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -1,0 +1,52 @@
+name: Build testflinger-testenv container image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - agent/extra/testflinger-testenv/**
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/testflinger-testenv
+
+jobs:
+  build-testflinger-testenv:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          config-inline: |
+            [registry."docker.io"]
+              mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push backend Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./agent/extra/testflinger-testenv
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/agent/extra/testflinger-testenv/Dockerfile
+++ b/agent/extra/testflinger-testenv/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_IMAGE=ubuntu:20.04
 FROM ${BASE_IMAGE}
-ENV container docker
+ENV container=docker
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common expect sudo openssh-client virtualenv curl wget build-essential python3-setuptools python3-dev python3-pip python3-requests python3-psutil git
-RUN adduser -u 1000 --disabled-password ubuntu
+RUN adduser -u 1000 --disabled-password ubuntu || /bin/true
 RUN echo "ubuntu ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu && \
     chmod 0440 /etc/sudoers.d/ubuntu
 #Avoid sudo rlimit error

--- a/agent/extra/testflinger-testenv/Dockerfile
+++ b/agent/extra/testflinger-testenv/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04
+ARG BASE_IMAGE=ubuntu:20.04
+FROM ${BASE_IMAGE}
 ENV container docker
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common expect sudo openssh-client virtualenv curl wget build-essential python3-setuptools python3-dev python3-pip python3-requests python3-psutil git
 RUN pip3 install PyYaml netifaces

--- a/agent/extra/testflinger-testenv/Dockerfile
+++ b/agent/extra/testflinger-testenv/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=ubuntu:20.04
 FROM ${BASE_IMAGE}
 ENV container=docker
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common expect sudo openssh-client virtualenv curl wget build-essential python3-setuptools python3-dev python3-pip python3-requests python3-psutil git
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y expect build-essential curl jq gettext git openssh-client pipx python3-dev python3-pip python3-psutil python3-requests python3-setuptools python3-venv software-properties-common sudo sshpass virtualenv wget 
 RUN adduser -u 1000 --disabled-password ubuntu || /bin/true
 RUN echo "ubuntu ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu && \
     chmod 0440 /etc/sudoers.d/ubuntu

--- a/agent/extra/testflinger-testenv/Dockerfile
+++ b/agent/extra/testflinger-testenv/Dockerfile
@@ -2,7 +2,6 @@ ARG BASE_IMAGE=ubuntu:20.04
 FROM ${BASE_IMAGE}
 ENV container docker
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common expect sudo openssh-client virtualenv curl wget build-essential python3-setuptools python3-dev python3-pip python3-requests python3-psutil git
-RUN pip3 install PyYaml netifaces
 RUN adduser -u 1000 --disabled-password ubuntu
 RUN echo "ubuntu ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu && \
     chmod 0440 /etc/sudoers.d/ubuntu

--- a/agent/extra/testflinger-testenv/Dockerfile
+++ b/agent/extra/testflinger-testenv/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+ENV container docker
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common expect sudo openssh-client virtualenv curl wget build-essential python3-setuptools python3-dev python3-pip python3-requests python3-psutil git
+RUN pip3 install PyYaml netifaces
+RUN adduser -u 1000 --disabled-password ubuntu
+RUN echo "ubuntu ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu && \
+    chmod 0440 /etc/sudoers.d/ubuntu
+#Avoid sudo rlimit error
+RUN echo "Set disable_coredump false" >> /etc/sudo.conf
+USER ubuntu
+WORKDIR /home/ubuntu
+CMD [ "/bin/bash" ]

--- a/agent/extra/testflinger-testenv/README
+++ b/agent/extra/testflinger-testenv/README
@@ -1,0 +1,1 @@
+This Dockerfile creates a basic test environment for running the test phase of testflinger agents in a Docker container.


### PR DESCRIPTION
## Description

When running the test phase for agents, we currently have it run under a docker image pulled from dockerhub at plars/testflinger-testenv-focal (don't be too bothered that it's focal based, it's just to give some working env on the agent-host and this one is well tested).

Now that we're on GH for everything, we should just use ghcr.io, so that nobody has to switch it over to a new location when that bus hits me some day :)

This is the first step in resolving this. I intentionally didn't change the path pointed to by the tf-test script that the agent calls **yet**, because we need to make sure firewall rules are all adjusted and everything before rolling this out in production.

## Resolved issues
N/A

## Documentation
There's a small README there just saying what it is, but this doesn't really do anything different, just moves the location

## Web service API changes
N/A

## Tests
Successful action run: https://github.com/canonical/testflinger/actions/runs/11961073449
Published container image: https://github.com/canonical/testflinger/pkgs/container/testflinger%2Ftestflinger-testenv

I also tried pulling this container image and running it locally.
