### PR TITLE
Check for online agents when submitting a job

### DIFF
--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -273,3 +273,9 @@ class Client:
             return json.loads(data)
         except ValueError:
             return {}
+
+    def get_agents_on_queue(self, queue):
+        """Get the list of all agents listening to a specified queue"""
+        endpoint = f"/v1/queues/{queue}/agents"
+        data = self.get(endpoint)
+        return json.loads(data)

--- a/server/README.rst
+++ b/server/README.rst
@@ -399,6 +399,22 @@ The job_status_webhook parameter is required for this endpoint. Other parameters
 
     $ curl http://localhost:8000/v1/queues/wait_times?queue=foo\&queue=bar
 
+** [GET] /v1/queues/<queue_name>/agents** - Get the list of agents listening to a specified queue
+
+- Parameters:
+
+  - queue_name (string): name of the queue for which to get the agents that are listening to it
+
+- Returns:
+
+  JSON array of agents listening to the specified queue
+
+- Example:
+
+  .. code-block:: console
+
+    $ curl http://localhost:8000/v1/queues/foo/agents
+
 **[POST] /v1/oauth2/token** - Authenticate client key and return JWT with permissions
 
 - Headers:

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -57,8 +57,9 @@ class AgentIn(Schema):
 
 
 class AgentOut(Schema):
-    """Agent data input schema"""
+    """Agent data output schema"""
 
+    name = fields.String(required=True)
     state = fields.String(required=False)
     queues = fields.List(fields.String(), required=False)
     location = fields.String(required=False)

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -553,7 +553,7 @@ def images_post():
 
 
 @v1.get("/agents/data")
-@v1.output(schemas.AgentOut)
+@v1.output(schemas.AgentOut(many=True))
 def agents_get_all():
     """Get all agent data"""
     agents = database.mongo.db.agents.find({}, {"_id": False, "log": False})
@@ -745,6 +745,13 @@ def queue_wait_time_percentiles_get():
             queue["wait_times"]
         )
     return queue_percentile_data
+
+
+@v1.get("/queues/<queue_name>/agents")
+@v1.output(schemas.AgentOut(many=True))
+def get_agents_on_queue(queue_name):
+    """Get the list of all data for agents listening to a specified queue"""
+    return database.get_agents_on_queue(queue_name)
 
 
 def generate_token(allowed_resources, secret_key):

--- a/server/src/database.py
+++ b/server/src/database.py
@@ -251,6 +251,15 @@ def get_queue_wait_times(queues: list[str] | None = None) -> list[dict]:
     return list(wait_times)
 
 
+def get_agents_on_queue(queue: str) -> list[dict]:
+    """Get the agents that are listening on the specified queue"""
+    agents = mongo.db.agents.find(
+        {"queues": {"$in": [queue]}},
+        {"_id": 0},
+    )
+    return list(agents)
+
+
 def calculate_percentiles(data: list) -> dict:
     """
     Calculate the percentiles of the wait times for each queue

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -725,3 +725,23 @@ def test_get_queue_wait_times(mongo_app):
     assert len(output.json) == 2
     assert output.json["queue1"]["50"] == 3.0
     assert output.json["queue2"]["50"] == 30.0
+
+
+def test_get_agents_on_queue(mongo_app):
+    """Test api to get agents on a queue"""
+    app, _ = mongo_app
+    agent_name = "agent1"
+    agent_data = {"state": "provision", "queues": ["q1", "q2"]}
+    output = app.post(f"/v1/agents/data/{agent_name}", json=agent_data)
+    assert 200 == output.status_code
+
+    # Get the agents on the queue
+    output = app.get("/v1/queues/q1/agents")
+    assert 200 == output.status_code
+    assert len(output.json) == 1
+    assert output.json[0]["name"] == agent_name
+
+    # Should get an empty list if there are no agents on the queue
+    output = app.get("/v1/queues/q3/agents")
+    assert 200 == output.status_code
+    assert len(output.json) == 0


### PR DESCRIPTION
## Description

This implements a new server API to get a list of the agents listening on a queue. That's used by the CLI to figure out if any of them are online before submitting a job. If there are no agents listening on the specified queue, or if all of them are offline, then it uses a new parameter to the CLI to determine what to do: `--wait-for-available-agents`

If that flag is used, then it will warn the user that no agents seem to be listening, and wait for the job to run anyway. Otherwise, the default behavior is to print an error and exit, failing to submit the job.

## Resolved issues

CERTTF-338

## Documentation

Added API documentation to the server README.rst and also extended the schema so that the /docs API reference is updated.

## Web service API changes

This is detailed in the API reference (/docs path on the server) as well as in the README.rst for the server:

** [GET] /v1/queues/<queue_name>/agents** - Get the list of agents listening to a specified queue
- Parameters:
  - queue_name (string): name of the queue for which to get the agents that are listening to it
- Returns: 
  - JSON array of agents listening to the specified queue
- Example:
```
$ curl http://localhost:8000/v1/queues/foo/agents
```

## Tests

Tested locally and with added unit tests
