### PR TITLE
Fix bad output with ssh keys in testflinger reserve command

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -291,6 +291,12 @@ class TestflingerCli:
             "reserve", help="Install and reserve a system"
         )
         parser.set_defaults(func=self.reserve)
+        parser.add_argument(
+            "--dry-run",
+            "-d",
+            action="store_true",
+            help="Only show the job data, don't submit it",
+        )
         parser.add_argument("--queue", "-q", help="Name of the queue to use")
         parser.add_argument(
             "--image", "-i", help="Name of the image to use for provisioning"
@@ -907,10 +913,12 @@ class TestflingerCli:
                                         ssh_keys:"""
         )
         for ssh_key in ssh_keys:
-            template += "\n    - {}".format(ssh_key)
+            template += "\n      - {}".format(ssh_key)
         job_data = template.format(queue=queue, image=image)
         print("\nThe following yaml will be submitted:")
         print(job_data)
+        if self.args.dry_run:
+            return
         answer = input("Proceed? (Y/n) ")
         if answer in ("Y", "y", ""):
             job_id = self.submit_job_data(job_data)

--- a/cli/testflinger_cli/tests/test_cli.py
+++ b/cli/testflinger_cli/tests/test_cli.py
@@ -610,3 +610,32 @@ def test_submit_no_agents_wait(capsys, tmp_path, requests_mock):
         "WARNING: No online agents available for queue fake"
         in capsys.readouterr().out
     )
+
+
+def test_reserve(capsys, requests_mock):
+    """ensure reserve command generates correct yaml"""
+    requests_mock.get(URL + "/v1/agents/queues", json={})
+    requests_mock.get(URL + "/v1/agents/images/fake", json={})
+    expected_yaml = (
+        "job_queue: fake\n"
+        "provision_data:\n"
+        "    url: http://face_image.xz\n"
+        "reserve_data:\n"
+        "    ssh_keys:\n"
+        "      - lp:fakeuser"
+    )
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "-i",
+        "http://face_image.xz",
+        "-k",
+        "lp:fakeuser",
+        "-d",
+    ]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.reserve()
+    std = capsys.readouterr()
+    assert expected_yaml in std.out


### PR DESCRIPTION
## Description
testflinger reserve command could generate improperly formatted yaml
this fixes that and also adds a test for it

## Resolved issues

CERTTF-461
https://github.com/canonical/testflinger/issues/422

## Documentation
N/A

## Web service API changes
N/A

## Tests
Added a new unit test
