### PR TITLE
testflinger cli promote snap stable

### DIFF
--- a/.github/workflows/cli-promote-snap.yml
+++ b/.github/workflows/cli-promote-snap.yml
@@ -1,0 +1,30 @@
+name: Promote testflinger-cli snap to stable
+on:
+  workflow_dispatch:
+    inputs:
+      snap:
+        description: 'Snap name'
+        default: 'testflinger-cli'
+        required: true
+        type: string
+      from-channel:
+        description: 'Channel to promote from'
+        default: 'latest/beta'
+        required: true
+        type: string
+      to-channel:
+        description: 'Channel to promote to'
+        default: 'latest/stable'
+        required: true
+        type: string
+
+jobs:
+  promote-snap:
+    runs-on: ubuntu-latest
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+    steps:
+      - name: Install Snapcraft
+        run: sudo snap install snapcraft --classic
+      - name: Promote testflinger-cli beta to stable
+        run: snapcraft promote ${{ inputs.snap }} --from-channel ${{ inputs.from-channel }} --to-channel ${{ inputs.to-channel }} --yes

--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -1,4 +1,4 @@
-name: Publish Testflinger CLI snap to edge
+name: Publish Testflinger CLI snap to edge and beta
 on:
   push:
     branches: ["main"]
@@ -21,3 +21,9 @@ jobs:
       with:
         snap: ${{ steps.build.outputs.snap }}
         release: edge
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: beta


### PR DESCRIPTION
- **Add a github workflow to promote testflinger-cli snap from beta to stable**
- **When originally publishing the snap, push it to both edge and beta**

## Description

This introduces a workflow that allows promoting the testflinger-cli snap to stable.

We already have a workflow that publishes the snap to edge, but this modifies it slightly to also publish to beta. This is because the `snapcraft promote` command doesn't allow you to start on edge for some reason. So the only way to promote it, is to start on some channel other than edge.

I made this flexible, so that you *can* specify the channels if you want, or just in case we ever want to reuse it.

## Resolved issues
N/A

## Documentation
N/A

## Web service API changes
N/A

## Tests
https://github.com/canonical/testflinger/actions/runs/12242201005
