### PR TITLE
Fix for Testflinger `submit` action

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -101,7 +101,8 @@ runs:
       shell: bash
       run: |
         echo "::group::Install prerequisites"
-        sudo snap install testflinger-cli jq
+        sudo snap install testflinger-cli
+        sudo snap install jq
         echo "::endgroup::"
 
     - name: Submit job to the Testflinger server

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -116,7 +116,7 @@ runs:
         if [ -n "$RELATIVE_TO" ]; then
           RELATIVE="--attachments-relative-to $RELATIVE_TO"
         fi
-        JOB_ID=$(testflinger --server $SERVER submit --quiet "$RELATIVE" "$JOB")
+        JOB_ID=$(testflinger --server $SERVER submit --quiet $RELATIVE "$JOB")
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
         echo "::endgroup::"
         echo "::notice::Submitted job $JOB_ID"


### PR DESCRIPTION
## Description

Following recent changes to the `testflinger-cli` snap, a problem with the `submit` action surfaced: a pair of quotes were erroneously used around the `$RELATIVE` variable. 

During testing, it was also determined that the pre-requisite snaps for the workflow should be installed separately, because a possible failure to install for one of them (e.g. because it has already been installed) would prevent the rest from installing as well.

This PR implements these two fixes.

## Resolved issues

This is a hotfix, not tracked with a JIRA issue.

## Documentation

N/A

## Tests

Multiple jobs were deployed from this branch, e.g. see [this run](https://github.com/canonical/sqa-cloud-deployment-pipeline/actions/runs/12259828532/job/34202939932#step:13:123).