### PR TITLE
Add extended reservation checks in the server

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -276,12 +276,6 @@ class DefaultDevice:
                     logger.error("Failed to copy ssh key: %s", key)
         # default reservation timeout is 1 hour
         timeout = int(reserve_data.get("timeout", "3600"))
-        # If max_reserve_timeout isn't specified, default to 6 hours
-        max_reserve_timeout = int(
-            config.get("max_reserve_timeout", 6 * 60 * 60)
-        )
-        if timeout > max_reserve_timeout:
-            timeout = max_reserve_timeout
         serial_host = config.get("serial_host")
         serial_port = config.get("serial_port")
         print("*** TESTFLINGER SYSTEM RESERVED ***")

--- a/docs/explanation/extended-reservation.rst
+++ b/docs/explanation/extended-reservation.rst
@@ -1,0 +1,10 @@
+Extended Reservation
+============
+
+Normal users can reserve a machine with Testflinger for a maximum of 6 hours.
+However, for certain use cases this is limiting. Testflinger has the ability
+to allow authorised clients to request longer reservation times. See the Reserve
+section of the :doc:`Test Phase <../reference/test-phases>` documentation for more
+information on how to set reservation times.
+Using this feature requires :doc:`authenticating <./authentication>` with
+Testflinger server.

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -10,4 +10,5 @@ This section covers conceptual questions about Testflinger.
     queues
     job-priority
     restricted-queues
+    extended-reservation
     authentication

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -178,6 +178,7 @@ Variables in ``reserve_data``:
 
 * ``ssh_keys``: The list of public SSH keys to use for reserving the device. Each line includes an identity provider name and your username on the provider's system. Testflinger uses the ``ssh-import-id`` command to import public SSH keys from trusted, online identity. Supported identities are Launchpad (``lp``) and GitHub (``gh``).
 * ``timeout``: Reservation time in seconds. The default is one hour (3600), and you can request a reservation for up to 6 hours (21600).
+  Authenticated clients can request longer :doc:`reservation times <../explanation/extended-reservation>` with prior authorisation.
   
 If either ``reserve_command`` is missing from the agent configuration, or the the ``reserve_data`` section is missing from the job, this phase will be skipped.
 

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -170,7 +170,9 @@ def check_token_reservation_timeout(
         return True
     decoded_jwt = decode_jwt_token(auth_token, secret_key)
     max_reservation_time_dict = decoded_jwt.get("max_reservation_time", {})
-    max_reservation_time = max_reservation_time_dict.get(queue, 0)
+    queue_reservation_time = max_reservation_time_dict.get(queue, 0)
+    star_reservation_time = max_reservation_time_dict.get("*", 0)
+    max_reservation_time = max(queue_reservation_time, star_reservation_time)
     return reservation_timeout <= max_reservation_time
 
 

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -806,9 +806,8 @@ def generate_token(allowed_resources, secret_key):
         "exp": expiration_time,
         "iat": datetime.now(timezone.utc),  # Issued at time
         "sub": "access_token",
-        "permissions": {},
+        "permissions": allowed_resources,
     }
-    token_payload.get("permissions").update(allowed_resources)
     token = jwt.encode(token_payload, secret_key, algorithm="HS256")
     return token
 

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -784,7 +784,11 @@ def get_agents_on_queue(queue_name):
 
 
 def generate_token(allowed_resources, secret_key):
-    """Generates JWT token with queue permission given a secret key"""
+    """
+    Generates JWT token with queue permission given a secret key
+    See retrieve_token for more information on the contents of
+    the token payload
+    """
     expiration_time = datetime.utcnow() + timedelta(seconds=2)
     token_payload = {
         "exp": expiration_time,

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -832,6 +832,7 @@ def validate_client_key_pair(client_id: str, client_key: str):
     ):
         return None
     client_permissions_entry.pop("_id", None)
+    client_permissions_entry.pop("client_secret_hash", None)
     return client_permissions_entry
 
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -84,12 +84,14 @@ def mongo_app_with_permissions(mongo_app):
         "myqueue2": 200,
     }
     allowed_queues = ["rqueue1", "rqueue2"]
+    max_reservation_time = {"myqueue": 30000}
     mongo.client_permissions.insert_one(
         {
             "client_id": client_id,
             "client_secret_hash": client_key_hash,
             "max_priority": max_priority,
             "allowed_queues": allowed_queues,
+            "max_reservation_time": max_reservation_time,
         }
     )
     restricted_queues = [

--- a/server/tests/test_v1_authorization.py
+++ b/server/tests/test_v1_authorization.py
@@ -50,9 +50,9 @@ def test_retrieve_token(mongo_app_with_permissions):
         token,
         os.environ.get("JWT_SIGNING_KEY"),
         algorithms="HS256",
-        options={"require": ["exp", "iat", "sub", "max_priority"]},
+        options={"require": ["exp", "iat", "sub", "permissions"]},
     )
-    assert decoded_token["max_priority"] == max_priority
+    assert decoded_token["permissions"]["max_priority"] == max_priority
 
 
 def test_retrieve_token_invalid_client_id(mongo_app_with_permissions):
@@ -147,7 +147,9 @@ def test_priority_expired_token(mongo_app_with_permissions):
         "exp": datetime.utcnow() - timedelta(seconds=2),
         "iat": datetime.utcnow() - timedelta(seconds=4),
         "sub": "access_token",
-        "max_priority": {},
+        "permissions": {
+            "max_priority": {},
+        },
     }
     token = jwt.encode(expired_token_payload, secret_key, algorithm="HS256")
     job = {"job_queue": "myqueue", "job_priority": 100}
@@ -163,7 +165,9 @@ def test_missing_fields_in_token(mongo_app_with_permissions):
     app, _, _, _, _ = mongo_app_with_permissions
     secret_key = os.environ.get("JWT_SIGNING_KEY")
     incomplete_token_payload = {
-        "max_priority": {},
+        "permissions": {
+            "max_priority": {},
+        }
     }
     token = jwt.encode(incomplete_token_payload, secret_key, algorithm="HS256")
     job = {"job_queue": "myqueue", "job_priority": 100}


### PR DESCRIPTION
## Description
This PR adds support for extended reservation times in Testflinger Server. Certain users need longer reservation times than the maximum 6 hours, so this provides this ability for authorized clients. The server rejects jobs with higher than 6 hours of requested reservation time if they do not provide credentials or if their credentials do not provide them the authorization. The authentication flow is similar to that of job priority and restricted queues.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves https://warthogs.atlassian.net/browse/CERTTF-458
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
Documentation was added to the docs/ folder.
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
No new endpoints, but jobs that have longer than 6 hours requested of reservation times will be rejected without prior authorization.
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Unit tests were added to test_v1_authorization.py
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
