### PR TITLE
Add jwt_signing_key as a supported terraform variable

### DIFF
--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -13,6 +13,7 @@ resource "juju_application" "testflinger" {
   config = {
     external_hostname = var.external_ingress_hostname
     max_pool_size = var.max_pool_size
+    jwt_signing_key = var.jwt_signing_key
   }
 }
 

--- a/server/terraform/variables.tf
+++ b/server/terraform/variables.tf
@@ -42,6 +42,12 @@ variable "max_pool_size" {
   default     = 100
 }
 
+variable "jwt_signing_key" {
+  description = "The signing key for JWT tokens"
+  sensitive   = true
+  type        = string
+}
+
 locals {
   app_model = "testflinger-${var.environment}"
 }


### PR DESCRIPTION
## Description
We need to pull the jwt signing key from vault, but first we need it to be something that can be applied with terraform.

## Resolved issues
N/A

## Documentation
N/A - but it's got a good description in the terraform variables.tf

## Web service API changes
N/A

## Tests
None - won't do anything on it's own. The other piece of this will be to add it to certification ops and have it pull from vault.
