### PR TITLE
Show all the agents serving a queue on the queue details page

### DIFF
--- a/server/src/templates/queue_detail.html
+++ b/server/src/templates/queue_detail.html
@@ -8,7 +8,7 @@
         </h1>
     </div>
 </div>
-<table aria-label="Agent table" class="p-table--mobile-card">
+<table aria-label="Queue Details table" class="p-table--mobile-card">
     <tbody>
         <tr>
             <td>Description</td>
@@ -21,7 +21,7 @@
         <h2 class="p-heading--4">Jobs</h2>
     </div>
 </div>
-<table aria-label="Agents table" class="p-table--mobile-card">
+<table aria-label="Jobs table" class="p-table--mobile-card">
     <thead>
         <tr>
             <th>Job ID</th>
@@ -39,6 +39,51 @@
         {% endfor %}
     </tbody>
 </table>
+
+<div class="p-strip is-shallow" style="margin-top: 1rem;">
+    <div class="row">
+        <h2 class="p-heading--4">Agents</h2>
+    </div>
+</div>
+<table aria-label="Jobs table" class="p-table--mobile-card">
+    <thead>
+        <tr>
+            <th class="has-overflow" style="width: 40pt"></th>
+            <th>Name</th>
+            <th style="width: 100pt">State</th>
+            <th style="width: 150pt">Updated At</th>
+            <th>Job ID</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for agent in agents %}
+        <tr class="tr-highlight">
+            <td class="has-overflow">
+                {% if agent.provision_streak_type == "fail" and agent.provision_streak_count > 0 %}
+                <span class="p-tooltip--right" aria-describedby="tooltip">
+                    <i class="p-icon--warning"></i>
+                    <span class="p-tooltip__message" role="tooltip" id="tooltip">This agent has failed the last {{
+                        agent.provision_streak_count }} provision attempts</span>
+                </span>
+                {{ agent.provision_streak_count }}
+                {% elif agent.provision_streak_type == "pass" and agent.provision_streak_count > 0 %}
+                <span class="p-tooltip--right" aria-describedby="tooltip">
+                    <i class="p-icon--success"></i>
+                    <span class="p-tooltip__message" role="tooltip" id="tooltip">This agent has passed the last {{
+                        agent.provision_streak_count }} provision attempts</span>
+                </span>
+                {{ agent.provision_streak_count }}
+                {% endif %}
+            </td>
+            <td><a href="/agents/{{ agent.name }}">{{ agent.name }}</a></td>
+            <td>{{ agent.state }}</td>
+            <td>{{ agent.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+            <td><a href="/jobs/{{ agent.job_id }}">{{ agent.job_id }}</a></td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
 <div class="p-strip is-shallow">
     <div class="row">
         <h2 class="p-heading--4">Wait Time Percentiles</h2>

--- a/server/src/templates/queue_detail.html
+++ b/server/src/templates/queue_detail.html
@@ -56,6 +56,7 @@
         </tr>
     </thead>
     <tbody>
+        {% if agents %}
         {% for agent in agents %}
         <tr class="tr-highlight">
             <td class="has-overflow">
@@ -75,12 +76,19 @@
                 {{ agent.provision_streak_count }}
                 {% endif %}
             </td>
-            <td><a href="/agents/{{ agent.name }}">{{ agent.name }}</a></td>
+            <td>{{ agent.name }}</td>
             <td>{{ agent.state }}</td>
             <td>{{ agent.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
-            <td><a href="/jobs/{{ agent.job_id }}">{{ agent.job_id }}</a></td>
+            <td>{{ agent.job_id }}</td>
         </tr>
         {% endfor %}
+        {% else %}
+        <tr>
+            <td colspan="5" class="u-align--center">
+                No agents detected that serve this queue. Please check the spelling of the queue name.
+            </td>
+        </tr>
+        {% endif %}
     </tbody>
 </table>
 


### PR DESCRIPTION
## Description
This adds information about the agents that are serving a queue to the queue_detail page. The format is very similar to the agents overview page which shows information about the provision history, state, last updated time, and currently running job.

![image](https://github.com/user-attachments/assets/64af0231-cd6f-4f27-8232-5549a0ec66b5)

## Resolved issues
CERTTF-451

## Documentation
N/A

## Web service API changes
N/A

## Tests
Ran locally to view the output on the queue_detail page

