### PR TITLE
Fix MAAS spelling

### DIFF
--- a/device-connectors/README.rst
+++ b/device-connectors/README.rst
@@ -17,10 +17,10 @@ testing on other types of devices.
 - cm3 - Raspberry PI CM3 with a sidecar device and tools to support putting it in otg mode to flash an image
 - dragonboard - dragonboard with a stable image on usb and test images are flashed to a wiped sd with a dual boot process
 - fake_connector - fake device connector that can be used for testing
-- maas2 - Metal as a Service (MaaS) systems, which support additional features such as disk layouts. Images provisioned must be imported first!
+- maas2 - Metal as a Service (MAAS) systems, which support additional features such as disk layouts. Images provisioned must be imported first!
 - multi - multi-device connector used for provisioning jobs that span multiple devices at once
 - muxpi - muxpi/sdwire provisioned devices that utilize a device that can write to an sd the boot it on the DUT
-- netboot - minimal netboot initramfs process for a specific device that couldn't be provisioned with MaaS
+- netboot - minimal netboot initramfs process for a specific device that couldn't be provisioned with MAAS
 - noprovision - devices which need to run tests, but can't be provisioned (yet)
 - oemrecovery - anything (such as core fde images) that can't be provisioned but can run a set of commands to recover back to the initial state
 - oemscript - uses a script that supports some oem images and allows injection of an iso to the recovery partition to install that image

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Ubuntu MaaS 2.x CLI support code."""
+"""Ubuntu MAAS 2.x CLI support code."""
 
 import logging
 

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Ubuntu MaaS 2.x CLI support code."""
+"""Ubuntu MAAS 2.x CLI support code."""
 
 import base64
 import json
@@ -329,10 +329,10 @@ class Maas2:
             status = self.node_status()
 
             if status == "Failed deployment":
-                self._logger_error("MaaS reports Failed Deployment")
+                self._logger_error("MAAS reports Failed Deployment")
                 exception_msg = (
                     "Provisioning failed because "
-                    + "MaaS got unexpected or "
+                    + "MAAS got unexpected or "
                     + "deployment failure status signal."
                 )
                 raise ProvisioningError(exception_msg)

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Ubuntu MaaS 2.x storage provisioning code."""
+"""Ubuntu MAAS 2.x storage provisioning code."""
 
 import logging
 import subprocess

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -52,7 +52,6 @@ logfile
 LTS
 LVM
 MAAS
-MaaS
 maas
 Makefile
 microservice

--- a/docs/reference/device-connector-conf.rst
+++ b/docs/reference/device-connector-conf.rst
@@ -39,10 +39,10 @@ The configuration options listed below are available for all device connectors u
      - URL for the Testflinger server to connect to for creating subordinate test jobs used by a multi-job configuration
    * - ``maas_user``
      - maas
-     - MaaS profile ID configured on the agent host to use for controlling the agent
+     - MAAS profile ID configured on the agent host to use for controlling the agent
    * - ``node_id``
      - maas
-     - MaaS Node ID for the specific agent on the MaaS server associated with this test device
+     - MAAS Node ID for the specific agent on the MAAS server associated with this test device
    * - ``reset_efi``
      - maas
      - Attempt to reset EFI systems to boot from the network in order to work around issues with the boot order sometimes getting lost on systems that require USB Ethernet dongles

--- a/server/HACKING.md
+++ b/server/HACKING.md
@@ -57,7 +57,7 @@ be used with multipass to create a complete environment for demonstrating,
 testing, and developing on all parts of testflinger. This environment is
 self-contained, and automatically set up to point the command-line tools
 at a server running within this container. It also includes a deployment of
-MaaS with a pre-configured example node that runs in a VM, so you can use
+MAAS with a pre-configured example node that runs in a VM, so you can use
 this environment to run a full test job through the entire process, including
 provisioning.
 

--- a/server/devel/testflinger.yaml
+++ b/server/devel/testflinger.yaml
@@ -110,7 +110,7 @@ write_files:
   path: /home/ubuntu/example-job.yaml
 - content: |
     All testflinger components are running inside this container, and
-    a test VM has been created in MaaS which can be used to demonstrate
+    a test VM has been created in MAAS which can be used to demonstrate
     provisioning and test execution.  The testflinger CLI tool has
     also been configured to talk to the testflinger server running in this
     container.


### PR DESCRIPTION
## Description

MAAS is spelled with all capital letters. See https://maas.io/docs.

## Resolved issues

## Documentation

Documentation spell list updated to not accept MaaS.

## Web service API changes

None, all of the changes are just log messages, docs, or comments.

## Tests
