### PR TITLE
Moved client_id and secret_key options to submit command

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -147,12 +147,12 @@ class TestflingerCli:
             or "https://testflinger.canonical.com"
         )
         self.client_id = (
-            self.args.client_id
+            getattr(self.args, "client_id", None)
             or self.config.get("client_id")
             or os.environ.get("TESTFLINGER_CLIENT_ID")
         )
         self.secret_key = (
-            self.args.secret_key
+            getattr(self.args, "secret_key", None)
             or self.config.get("secret_key")
             or os.environ.get("TESTFLINGER_SECRET_KEY")
         )
@@ -190,16 +190,6 @@ class TestflingerCli:
         )
         parser.add_argument(
             "--server", default=None, help="Testflinger server to use"
-        )
-        parser.add_argument(
-            "--client_id",
-            default=None,
-            help="Client ID to authenticate with Testflinger server",
-        )
-        parser.add_argument(
-            "--secret_key",
-            default=None,
-            help="Secret key to be used with client id for authentication",
         )
         subparsers = parser.add_subparsers()
         self._add_artifacts_args(subparsers)
@@ -348,6 +338,16 @@ class TestflingerCli:
             argcomplete.completers.FilesCompleter(
                 allowednames=("*.yaml", "*.yml", "*.json")
             )
+        )
+        parser.add_argument(
+            "--client_id",
+            default=None,
+            help="Client ID to authenticate with Testflinger server",
+        )
+        parser.add_argument(
+            "--secret_key",
+            default=None,
+            help="Secret key to be used with client id for authentication",
         )
         relative = parser.add_mutually_exclusive_group()
         relative.add_argument(


### PR DESCRIPTION
## Description

Minor change to move the client_id and secret_key arguments to the submit command ie.
`testflinger-cli --client_id myclientid --secret_key mysecretkey submit ...` >> 
`testflinger-cli submit --client_id myclientid --secret_key mysecretkey ...` 

This aligns with the documentation and makes more sense from a usability standpoint.