### PR TITLE
minor pyupdate improvements

### DIFF
--- a/agent/testflinger_agent/tests/test_agent.py
+++ b/agent/testflinger_agent/tests/test_agent.py
@@ -6,10 +6,10 @@ import shutil
 import tarfile
 import tempfile
 import uuid
+from unittest.mock import patch
+
 import requests_mock as rmock
 import pytest
-
-from mock import patch
 
 import testflinger_agent
 from testflinger_agent.config import ATTACHMENTS_DIR

--- a/agent/testflinger_agent/tests/test_client.py
+++ b/agent/testflinger_agent/tests/test_client.py
@@ -15,8 +15,8 @@
 import json
 import pytest
 import uuid
+from unittest.mock import patch
 
-from mock import patch
 import requests_mock as rmock
 
 from testflinger_agent.client import TestflingerClient as _TestflingerClient

--- a/agent/tox.ini
+++ b/agent/tox.ini
@@ -6,7 +6,6 @@ skipsdist = true
 deps =
     black
     flake8
-    mock
     pytest
     pylint
     pytest-mock

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -64,7 +64,7 @@ def get_version():
         version = pkg_resources.get_distribution("testflinger").version
     except pkg_resources.DistributionNotFound:
         version = "devel"
-    return "Testflinger Server v{}".format(version)
+    return f"Testflinger Server v{version}"
 
 
 @v1.post("/job")
@@ -699,7 +699,7 @@ def job_position_get(job_id):
     try:
         queue = job_data.json.get("job_queue")
     except (AttributeError, TypeError):
-        return "Invalid json returned for id: {}\n".format(job_id), 400
+        return f"Invalid json returned for id: {job_id}\n", 400
     # Get all jobs with job_queue=queue and return only the _id
     jobs = database.mongo.db.jobs.find(
         {"job_data.job_queue": queue, "result_data.job_state": "waiting"},

--- a/server/src/application.py
+++ b/server/src/application.py
@@ -70,7 +70,7 @@ def create_flask_app(config=None):
     @tf_app.errorhandler(NotFound)
     def handle_404(exc):
         tf_log.error("[404] Not found: %s", request.url)
-        return "Not found: {}\n".format(exc), 404
+        return f"Not found: {exc}\n", 404
 
     @tf_app.errorhandler(ConnectionFailure)
     def handle_timeout(exc):
@@ -80,7 +80,7 @@ def create_flask_app(config=None):
     @tf_app.errorhandler(Exception)
     def unhandled_exception(exc):
         tf_log.exception("Unhandled Exception: %s", (exc))
-        return "Unhandled Exception: {}\n".format(exc), 500
+        return f"Unhandled Exception: {exc}\n", 500
 
     tf_app.register_blueprint(views)
     tf_app.register_blueprint(v1, url_prefix="/v1")

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -160,7 +160,7 @@ def test_initial_job_state(mongo_app):
     # Place a job on the queue
     output = app.post("/v1/job", json=job_data)
     job_id = output.json.get("job_id")
-    result_url = "/v1/result/{}".format(job_id)
+    result_url = f"/v1/result/{job_id}"
     response = app.get(result_url)
     assert "waiting" == response.json.get("job_state")
 
@@ -175,7 +175,7 @@ def test_resubmit_job_state(mongo_app):
     job_id = output.json.get("job_id")
     job_data["job_id"] = job_id
     output = app.post("/v1/job", json=job_data)
-    result_url = "/v1/result/{}".format(job_id)
+    result_url = f"/v1/result/{job_id}"
     updated_data = app.get(result_url).json
     assert "waiting" == updated_data.get("job_state")
 
@@ -345,7 +345,7 @@ def test_job_get_id_with_data(mongo_app):
     # Place a job on the queue
     output = app.post("/v1/job", json=job_data)
     job_id = output.json.get("job_id")
-    job_url = "/v1/job/{}".format(job_id)
+    job_url = f"/v1/job/{job_id}"
     # Request the original json for the job
     app.get(job_url)
     output = app.get(job_url)
@@ -365,7 +365,7 @@ def test_job_position(mongo_app):
     for pos in range(3):
         output = app.post("/v1/job", json=job_data)
         job_id.append(output.json.get("job_id"))
-        output = app.get("/v1/job/{}/position".format(job_id[pos]))
+        output = app.get(f"/v1/job/{job_id[pos]}/position")
         # Initial position should increment for each job as we add them
         assert output.text == str(pos)
 
@@ -374,11 +374,11 @@ def test_job_position(mongo_app):
     # The job we get should be the first one that was added
     assert output.json.get("job_id") == job_id[0]
     # The position of the remaining jobs should decrement
-    assert app.get("/v1/job/{}/position".format(job_id[2])).text == "1"
+    assert app.get(f"/v1/job/{job_id[2]}/position").text == "1"
     # Cancel the next job in the queue
     output = app.post(f"/v1/job/{job_id[1]}/action", json={"action": "cancel"})
     # The position of the remaining job should decrement again
-    assert app.get("/v1/job/{}/position".format(job_id[2])).text == "0"
+    assert app.get(f"/v1/job/{job_id[2]}/position").text == "0"
 
 
 def test_action_post(mongo_app):

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -19,8 +19,8 @@ Unit tests for Testflinger views
 
 from datetime import datetime
 import re
+from unittest.mock import patch
 import mongomock
-from mock import patch
 from src.views import job_detail, queues_data, agent_detail
 
 

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -11,10 +11,8 @@ deps =
     black
     flake8
     pylint
-    mock
     mongomock
     pytest
-    pytest-mock
     pytest-cov
     requests
     requests-mock


### PR DESCRIPTION
- **Use unittest.mock instead of mock and remove deprecated import**
- **Use fstrings for server code**

## Description

Some minor cleanups which should definitely be safe. We *technically* still support python3.8 for the agent and device connectors, but I'm not sure we really need to since pretty much everything is on Jammy now, but I'll confirm with Taipei before going too far with that.

## Resolved issues

N/A

## Documentation


## Web service API changes

N/A

## Tests

Unit tests all still pass (and was even able to remove some deprecated imports during testing)
