### PR TITLE
update: Increase the timeout to 5400 seconds.

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
@@ -160,7 +160,7 @@ class OemScript:
         logger.info("Checking to see if the device is available.")
         started = time.time()
         # Wait for provisioning to complete - can take a very long time
-        while time.time() - started < 3600:
+        while time.time() - started < 5400:
             try:
                 time.sleep(90)
                 self.copy_ssh_id()


### PR DESCRIPTION
## Description

The current timeout for oemscript is 3600 seconds, however we have observed more and more machines hit the timeout, this might due to the slow network speeds or the machines still use spinning disk.
To reduce the failure rate for provisioning phase, we propose extending the timeout to 5400 seconds. 