### PR TITLE
Add: copy SSH keys at the end of zapper_iot provisioning

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -131,7 +131,7 @@ class ZapperConnector(ABC, DefaultDevice):
             "UserKnownHostsFile=/dev/null",
             f"{test_username}@{self.config['device_ip']}",
         ]
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=60)
+        subprocess.check_call(cmd, timeout=60)
 
     @abstractmethod
     def _post_run_actions(self, args):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -23,6 +23,7 @@ validating the configuration and preparing the API arguments.
 
 import json
 import logging
+import subprocess
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Tuple
 
@@ -103,5 +104,35 @@ class ZapperConnector(ABC, DefaultDevice):
             **kwargs,
         )
 
+    def _copy_ssh_id(self):
+        """Copy the ssh id to the device"""
+
+        logger.info("Copying the agent's SSH public key to the DUT.")
+
+        try:
+            test_username = self.job_data.get("test_data", {}).get(
+                "test_username", "ubuntu"
+            )
+            test_password = self.job_data.get("test_data", {}).get(
+                "test_password", "ubuntu"
+            )
+        except AttributeError:
+            test_username = "ubuntu"
+            test_password = "ubuntu"
+
+        cmd = [
+            "sshpass",
+            "-p",
+            test_password,
+            "ssh-copy-id",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            f"{test_username}@{self.config['device_ip']}",
+        ]
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=60)
+
+    @abstractmethod
     def _post_run_actions(self, args):
         """Run further actions after Zapper API returns successfully."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -28,6 +28,9 @@ class MockConnector(ZapperConnector):
     def _validate_configuration(self):
         return (), {}
 
+    def _post_run_actions(self, args):
+        pass
+
 
 class ZapperConnectorTests(unittest.TestCase):
     """Unit tests for ZapperConnector class."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -75,3 +75,8 @@ class DeviceConnector(ZapperConnector):
         provisioning_data["urls"] = urls
 
         return ((), provisioning_data)
+
+    def _post_run_actions(self, args):
+        """Run further actions after Zapper API returns successfully."""
+
+        self._copy_ssh_id()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -185,35 +185,6 @@ class DeviceConnector(ZapperConnector):
 
         oemscript.provision()
 
-    def _copy_ssh_id(self):
-        """Copy the ssh id to the device"""
-
-        logger.info("Copying the agent's SSH public key to the DUT.")
-
-        try:
-            test_username = self.job_data.get("test_data", {}).get(
-                "test_username", "ubuntu"
-            )
-            test_password = self.job_data.get("test_data", {}).get(
-                "test_password", "ubuntu"
-            )
-        except AttributeError:
-            test_username = "ubuntu"
-            test_password = "ubuntu"
-
-        cmd = [
-            "sshpass",
-            "-p",
-            test_password,
-            "ssh-copy-id",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            f"{test_username}@{self.config['device_ip']}",
-        ]
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=60)
-
     def _change_password(self, username, orig_password):
         """Change password via SSH to the one specified in the job data."""
 


### PR DESCRIPTION
## Description

Copy the agent SSH keys at the end of `zapper_iot` provisioning.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

https://testflinger.canonical.com/jobs/5dcf9f9f-982b-4722-96e0-daa0ed691eca
