### PR TITLE
publish snap to edge/beta at the same time to avoid error

### DIFF
--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -20,10 +20,4 @@ jobs:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
       with:
         snap: ${{ steps.build.outputs.snap }}
-        release: edge
-    - uses: snapcore/action-publish@v1
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
-      with:
-        snap: ${{ steps.build.outputs.snap }}
-        release: beta
+        release: "edge,beta"


### PR DESCRIPTION
## Description

I noticed that some recent runs of this action worked when publishing to edge, but when it published to beta it failed a "uniqueness" test. I don't recall seeing this before, not sure if it's something new that was added or what. But it looks like specifying both channels on the same line will let it do the publish to both at once, so it doesn't think that it's a different snap.

## Tests

I tried it out here and it worked:
https://github.com/canonical/testflinger/actions/runs/12813101195/job/35726357684