### PR TITLE
Remove python 3.8 from the CI test matrix for the agent

### DIFF
--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     strategy:
       matrix:
-        python: ["3.8.12", "3.10"]
+        python: ["3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     strategy:
       matrix:
-        python: ["3.8", "3.10"]
+        python: ["3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
## Description

Because the agents have all been moved to newer systems, I believe we can remove 3.8 (Python version from focal) from the test matrix that we run in the GitHub workflow. NOTE: We should still keep 3.8 testing for the device-connectors since they currently still run under a focal OCI container (though it might be possibile to easily bump this up to jammy, at least). While I'm writing this, I'm realizing that it should be safe to do for the CLI as well, since the snap is based on core22. So I'll add that too.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

(just reduces the test matrix slightly, and should speed it up as a result)
