### PR TITLE
RTD sphinx settings, don't fail on warning

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,9 +24,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  builder: dirhtml
   configuration: docs/conf.py
-  fail_on_warning: true
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # Uncomment the following lines to enable PDF generation


### PR DESCRIPTION
## Description

Change the sphinx section of the readthedocs settings to not fail on warnings which is currently causing build failures. Although we could/should fix the source of the warning, escalating these to errors seems unnecessary and not a setting that is applied in other projects maintained by Canonical

## Resolved issues

RTD docs build failures 


