### PR TITLE
Fix warning in the docs (missing equals)

### DIFF
--- a/docs/explanation/extended-reservation.rst
+++ b/docs/explanation/extended-reservation.rst
@@ -1,5 +1,5 @@
 Extended Reservation
-============
+====================
 
 Normal users can reserve a machine with Testflinger for a maximum of 6 hours.
 However, for certain use cases this is limiting. Testflinger has the ability


### PR DESCRIPTION
## Description

Some equals were missing, this adds them

## Resolved issues

Fixes: https://github.com/canonical/testflinger/actions/runs/12938956749/job/36090243013#step:5:43

## Documentation

N./A

## Web service API changes

N/A

## Tests

N/A
