### PR TITLE
fix: default error threshold

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -156,8 +156,8 @@ class TestflingerCli:
             or self.config.get("secret_key")
             or os.environ.get("TESTFLINGER_SECRET_KEY")
         )
-        error_threshold = self.config.get(
-            "error_threshold"
+        error_threshold = (
+            self.config.get("error_threshold")
             or os.environ.get("TESTFLINGER_ERROR_THRESHOLD")
             or 3
         )


### PR DESCRIPTION
## Description

Minor fix to how the default value for the "error threshold" is retrieved in the CLI tool.

The current code mistakenly uses `os.environ.get("TESTFLINGER_ERROR_THRESHOLD")` and `3` as alternative _keys_ to access `self.config` rather than alternative values, in case `self.config` doesn't contain an `error_threshold` key.
```python
error_threshold = self.config.get(
    "error_threshold"
    or os.environ.get("TESTFLINGER_ERROR_THRESHOLD")
    or 3
)
```

## Resolved issues

Not tracked.

## Tests

Tested locally: during development, the CLI failed to submit jobs, with an error indicating that the `error_threshold` was `None`. The change in this PR overcomes this issue.