### PR TITLE
[CERTTF-458] feat: use agent config in reimplemented log truncation

### DIFF
--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -16,7 +16,6 @@ import json
 import logging
 import os
 import time
-from typing import Optional
 
 from testflinger_agent.errors import TFServerError
 from .runner import CommandRunner, RunnerEvents
@@ -249,7 +248,7 @@ class TestflingerJob:
         yield "*" * (len(line) + 4)
 
 
-def read_truncated(filename: str, size: Optional[int]) -> str:
+def read_truncated(filename: str, size: int) -> str:
     """Return a string corresponding to the last bytes of a text file.
 
     Include a warning message at the end of the returned value if the file

--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -229,6 +229,8 @@ class TestflingerJob:
             (overrides default `output_bytes` value in the agent config)
         """
         if size is None:
+            # the default for `output_bytes` when it is not explicitly set
+            # in the agent config is specified in the config schema
             size = self.client.config["output_bytes"]
         with open(filename, "r", encoding="utf-8", errors="ignore") as file:
             end = file.seek(0, 2)

--- a/agent/testflinger_agent/job.py
+++ b/agent/testflinger_agent/job.py
@@ -12,7 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-import fcntl
 import json
 import logging
 import os
@@ -274,16 +273,3 @@ class TestflingerJob:
         yield "*" * (len(line) + 4)
         yield "* {} *".format(line)
         yield "*" * (len(line) + 4)
-
-
-def set_nonblock(fd):
-    """Set the specified fd to nonblocking output
-
-    :param fd:
-        File descriptor that should be set to nonblocking mode
-    """
-
-    # XXX: This is only used in one place right now, may want to consider
-    # moving it if it gets wider use in the future
-    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)

--- a/agent/testflinger_agent/schema.py
+++ b/agent/testflinger_agent/schema.py
@@ -45,6 +45,9 @@ SCHEMA_V1 = {
     voluptuous.Optional("output_timeout"): int,
     voluptuous.Optional("advertised_queues"): dict,
     voluptuous.Optional("advertised_images"): dict,
+    # only the last `output_bytes` of the log will be included
+    # in the results submitted to the server (default: 1MB)
+    voluptuous.Optional("output_bytes", default=1024 * 1024): int,
 }
 
 

--- a/agent/testflinger_agent/schema.py
+++ b/agent/testflinger_agent/schema.py
@@ -46,8 +46,8 @@ SCHEMA_V1 = {
     voluptuous.Optional("advertised_queues"): dict,
     voluptuous.Optional("advertised_images"): dict,
     # only the last `output_bytes` of the log will be included
-    # in the results submitted to the server (default: 1MB)
-    voluptuous.Optional("output_bytes", default=1024 * 1024): int,
+    # in the results submitted to the server (default: 10MB)
+    voluptuous.Optional("output_bytes", default=10 * 1024 * 1024): int,
 }
 
 

--- a/agent/testflinger_agent/tests/test_job.py
+++ b/agent/testflinger_agent/tests/test_job.py
@@ -11,6 +11,7 @@ from testflinger_agent.client import TestflingerClient as _TestflingerClient
 from testflinger_agent.job import TestflingerJob as _TestflingerJob
 from testflinger_agent.runner import CommandRunner
 from testflinger_agent.handlers import LogUpdateHandler
+from testflinger_agent.schema import validate
 from testflinger_agent.stop_condition_checkers import (
     GlobalTimeoutChecker,
     OutputTimeoutChecker,
@@ -22,15 +23,17 @@ class TestJob:
     @pytest.fixture
     def client(self):
         self.tmpdir = tempfile.mkdtemp()
-        self.config = {
-            "agent_id": "test01",
-            "polling_interval": "2",
-            "server_address": "127.0.0.1:8000",
-            "job_queues": ["test"],
-            "execution_basedir": self.tmpdir,
-            "logging_basedir": self.tmpdir,
-            "results_basedir": os.path.join(self.tmpdir, "results"),
-        }
+        self.config = validate(
+            {
+                "agent_id": "test01",
+                "polling_interval": 2,
+                "server_address": "127.0.0.1:8000",
+                "job_queues": ["test"],
+                "execution_basedir": self.tmpdir,
+                "logging_basedir": self.tmpdir,
+                "results_basedir": os.path.join(self.tmpdir, "results"),
+            }
+        )
         testflinger_agent.configure_logging(self.config)
         yield _TestflingerClient(self.config)
         shutil.rmtree(self.tmpdir)
@@ -173,24 +176,31 @@ class TestJob:
         assert exit_event == "setup_fail"
         assert exit_reason == "failed"
 
-    def test_set_truncate(self, client):
-        """Test the _set_truncate method of TestflingerJob"""
+    def test_read_truncated(self, client, tmp_path):
+        """Test the _read_truncated method of TestflingerJob"""
         job = _TestflingerJob({}, client)
-        with tempfile.TemporaryFile(mode="r+") as f:
-            # First check that a small file doesn't get truncated
-            f.write("x" * 100)
-            job._set_truncate(f, size=100)
-            contents = f.read()
-            assert len(contents) == 100
-            assert "WARNING" not in contents
 
-            # Now check that a larger file does get truncated
-            f.write("x" * 100)
-            job._set_truncate(f, size=100)
-            contents = f.read()
-            # It won't be exactly 100 bytes, because a warning is added
-            assert len(contents) < 150
-            assert "WARNING" in contents
+        # First check that a small file doesn't get truncated
+        short_file = tmp_path / "short"
+        short_file.write_text("x" * 100)
+        contents = job._read_truncated(short_file, size=100)
+        assert len(contents) == 100
+        assert "WARNING" not in contents
+
+        # Now check that a larger file does get truncated
+        long_file = tmp_path / "long"
+        long_file.write_text("x" * 200)
+        contents = job._read_truncated(long_file, size=100)
+        # It won't be exactly 100 bytes, because a warning is added
+        assert len(contents) < 150
+        assert "WARNING" in contents
+
+        # Check that the config value is used when not overriden
+        # (i.e. the short file should get truncated)
+        client.config["output_bytes"] = 50
+        contents = job._read_truncated(short_file)
+        assert len(contents) < 100
+        assert "WARNING" in contents
 
     @pytest.mark.timeout(1)
     def test_wait_for_completion(self, client):

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -212,6 +212,11 @@ In some cases, you might want to check the device output to know how each job ph
 
 Besides the output from the provisioning and testing commands, the returned data also includes an exit code of each phase and output from the Testflinger agent. This information is very useful for troubleshooting testing issues.
 
+Note: Testflinger agents truncate the `*_output` fields when submitting job results to the server,
+keeping only the last section of the output log if it exceeds a certain threshold. This threshold
+can be set through the `output_bytes` field of the agent configuration file and its default value
+is 10 MB.
+
 ---------
 
 Congratulations! You've successfully set up the Testflinger CLI, created and submitted your first test job, and checked its status. You can now create more complex jobs and manage your test jobs efficiently using the command line tool. Happy testing!


### PR DESCRIPTION
## Description

Log files are currently truncated to their last 1MB of data and that limit is hard-coded. This PR introduces a slight re-implementation of the way log files are truncated and allows the size of the truncated output log to be specified through the `output_bytes` agent configuration field.

The default for `output_bytes` when not explicitly set in the agent config is now 10MB.

## Resolved issues

Resolves [CERTTF-484](https://warthogs.atlassian.net/browse/CERTTF-484). Note that the original task was to remove truncation altogether but making the limit parametric was deemed to be safer and more flexible.

## Documentation

A paragraph was added to the section in the tutorial that discussed retrieving results. It is now explicitly stated that the results might be truncated and how the size of the truncated output log is set through the agent configuration.

## Tests

Tested locally with different values for `output_bytes` using (variations of) this Testflinger job, which outputs random 100-character lines of output:
```
job_queue: myqueue
test_data:
  test_cmds: |
    for i in {1..10000}; do
        # print a random 100-character line
        tr -dc 'A-Za-z0-9!"#$%&'\''()*+,-./:;<=>?@[\]^_`{|}~' < /dev/urandom | head -c 100
        echo
    done
```

[CERTTF-484]: https://warthogs.atlassian.net/browse/CERTTF-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ