### PR TITLE
Fix authentication how-to link

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -617,7 +617,7 @@ class TestflingerCli:
                             "that requires client authorisation "
                             "without using client credentials. "
                             "See https://testflinger.readthedocs.io/en/latest"
-                            "/how-to/authentication/ for more details"
+                            "/how-to/authentication.html for more details"
                         )
                 else:
                     # This shouldn't happen, so let's get more information


### PR DESCRIPTION
## Description

Fix the link to the how-to doc on authentication

## Resolved issues

* Resolves CERTTF-497

## Documentation

## Web service API changes

## Tests
