### PR TITLE
Remvoe method from deploy in schema check.

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
@@ -69,7 +69,6 @@ TESTPLAN_SCHEMA = {
                                             "seed_override_lk",
                                         ],
                                     },
-                                    "method": {"$ref": "#/$defs/method"},
                                     "extra_provision_tool_args": {
                                         "type": "string"
                                     },
@@ -79,7 +78,7 @@ TESTPLAN_SCHEMA = {
                                     },
                                     "update_boot_assets": {"type": "boolean"},
                                 },
-                                "required": ["utility", "method"],
+                                "required": ["utility"],
                             },
                             "checkbox": {
                                 "type": "object",


### PR DESCRIPTION
We dont support method in deploy anymore

## Description

Remvoe method from deploy in schema check.
We dont support method in deploy anymore

## Resolved issues


## Documentation

The Doc is in zapper repo

## Web service API changes


## Tests
provision x8high-pdk with uuu and seed_override successfully 
