### PR TITLE
Add builtin account support for Classic image

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
@@ -190,6 +190,7 @@ TESTPLAN_SCHEMA = {
                 "cloud-init",
                 "console-conf",
                 "system-user",
+                "builtin-account",
             ],
         },
     },


### PR DESCRIPTION
## Description
Add builtin account support for Classic image
This change require another change
https://github.com/canonical/zapper/pull/453

## Resolved issues
we have some classic images have builtin account
need to handle this case

## Documentation


## Web service API changes


## Tests

