### PR TITLE
Docs: Add documentation on provision_data/kernel parameter, and make lp username format in reserve_data more explicit

### DIFF
--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -208,8 +208,10 @@ If either ``reserve_command`` is missing from the agent configuration, or the th
       url: <url>
     reserve_data:
       ssh_keys:
-        - lp:user1
+        - "lp:user1"
       timeout: 4800
+
+ Note: "lp:user1" is a string in the job definition yaml, not a yaml key-value pair, so there should be no space between the colon and the username.
 
 Cleanup 
 ~~~~~~~~~

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -52,7 +52,7 @@ If either ``provision_command`` is missing from the agent configuration, or the 
 
 The `kernel` field can be included in provision_data to select an alternate kernel to install during provisioning. The accepted values for this field correspond to the kernel names that the connected MAAS instance is aware of. (These can be found under the "Deploy" menu's "Kernel" dropdown on the corresponding MAAS instance.)
 
-* Example job definition with hwe kernel:
+* Example job definition with ``hwe`` kernel:
 
   .. code-block:: yaml
 

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -211,7 +211,7 @@ If either ``reserve_command`` is missing from the agent configuration, or the th
         - "lp:user1"
       timeout: 4800
 
- Note: "lp:user1" is a string in the job definition yaml, not a yaml key-value pair, so there should be no space between the colon and the username.
+Note: ``lp:user1`` is a string in the job definition YAML, not a YAML key-value pair, so there should be no space between the colon and the username.
 
 Cleanup 
 ~~~~~~~~~

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -50,6 +50,16 @@ If either ``provision_command`` is missing from the agent configuration, or the 
     provision_data:
       url: http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/image.img.xz    # Data to pass to the provisioning step
 
+The `kernel` field can be included in provision_data to select an alternate kernel to install during provisioning. The accepted values for this field correspond to the kernel names that the connected MAAS instance is aware of. (These can be found under the "Deploy" menu's "Kernel" dropdown on the corresponding MAAS instance.)
+
+* Example job definition with hwe kernel:
+
+  .. code-block:: yaml
+
+    job_queue: example-queue
+    provision_data:
+      distro: jammy
+      kernel: hwe-22.04
 
 
 Firmware update

--- a/docs/reference/test-phases.rst
+++ b/docs/reference/test-phases.rst
@@ -50,7 +50,7 @@ If either ``provision_command`` is missing from the agent configuration, or the 
     provision_data:
       url: http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/image.img.xz    # Data to pass to the provisioning step
 
-The `kernel` field can be included in provision_data to select an alternate kernel to install during provisioning. The accepted values for this field correspond to the kernel names that the connected MAAS instance is aware of. (These can be found under the "Deploy" menu's "Kernel" dropdown on the corresponding MAAS instance.)
+The ``kernel`` field can be included in provision_data to select an alternate kernel to install during provisioning. The accepted values for this field correspond to the kernel names that the connected MAAS instance is aware of. (These can be found under the "Deploy" menu's "Kernel" dropdown on the corresponding MAAS instance.)
 
 * Example job definition with ``hwe`` kernel:
 


### PR DESCRIPTION
## Description

### provision_data/kernel:

The valid data for the provision_data/kernel is not documented anywhere that I was able to find, so commit 1 of this series adds an explanation of its intended use to the relevant doc section.

### lp username format:

The format of the ssh_keys list entries are strings, but the "lp:<user>" format without quotes looks very similar to a yaml key/value pair. Since the reservation will not work as expected if there is a space between "lp:" and "<user>", I propose that we update the docs to have quotes around the full string, to make it more obvious to the reader that this is a string and not a yaml k-v pair.

## Tests

None necessary, documentation update only.