### PR TITLE
job-schema: clarify output timeout

### DIFF
--- a/docs/reference/job-schema.rst
+++ b/docs/reference/job-schema.rst
@@ -31,7 +31,7 @@ The following table lists the key elements that a job definition file should con
     - integer
     - | 900
       | (15 minutes)
-    - (Optional) Maximum time (in seconds) Testflinger should wait in the ``test`` phase to get output from the job. If the timeout is reached before the test phase has any output, Testflinger will cancel the job. This value should be smaller than, or equal to, the ``global_timeout``. 
+    - (Optional) Maximum time (in seconds) Testflinger should wait in the ``test`` phase to get output from the job. If the timeout is reached before the test phase has any output, Testflinger will cancel the job. This is meant to protect from individual commands being stuck vs the ``global_timeout`` doing the same for the whole job. Any new output, even a single character, by any of the ``test_cmds`` will reset this timer. This value should be smaller than, or equal to, the ``global_timeout``. 
   * - ``allocation_timeout``
     - integer
     - | 7200

--- a/docs/reference/job-schema.rst
+++ b/docs/reference/job-schema.rst
@@ -31,7 +31,7 @@ The following table lists the key elements that a job definition file should con
     - integer
     - | 900
       | (15 minutes)
-    - (Optional) Maximum time (in seconds) Testflinger should wait in the ``test`` phase to get output from the job. If the timeout is reached before the test phase has any output, Testflinger will cancel the job. This is meant to protect from individual commands being stuck vs the ``global_timeout`` doing the same for the whole job. Any new output, even a single character, by any of the ``test_cmds`` will reset this timer. This value should be smaller than, or equal to, the ``global_timeout``. 
+    - (Optional) Maximum time (in seconds) Testflinger should wait in the ``test`` phase to get output from the job. If the timeout is reached before the test phase has any output, Testflinger will cancel the job. This is meant to prevent individual commands from becoming stuck, while the ``global_timeout`` does the same for the whole job. Any new output, even a single character, by any of the ``test_cmds`` will reset this timer. This value should be smaller than, or equal to, the ``global_timeout``. 
   * - ``allocation_timeout``
     - integer
     - | 7200


### PR DESCRIPTION
Convert a helpful explanation in Mattermost into a clarifying documentation entry.

## Description

I was not clear when reading the docs, got help and want to ensure everybody else does not need to ask again.

## Resolved issues

when does output_timeout trigger exactly

## Documentation

This change is documentation only

## Web service API changes

n/a

## Tests

n/a