### PR TITLE
[Zapper-IOT] Not do the copy_ssh_id when using the console-conf

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -78,5 +78,16 @@ class DeviceConnector(ZapperConnector):
 
     def _post_run_actions(self, args):
         """Run further actions after Zapper API returns successfully."""
+        super()._post_run_actions(args)
 
-        self._copy_ssh_id()
+        do_copy_ssh_id = True
+        provision_plan = self.job_data["provision_data"].get("provision_plan")
+        if provision_plan:
+            run_stages = provision_plan["run_stage"]
+            for stage in run_stages:
+                if stage.type is dict and stage.key == "initial_login":
+                    if stage.get("method") == "console-conf":
+                        do_copy_ssh_id = False
+
+        if do_copy_ssh_id:
+            self._copy_ssh_id()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -85,9 +85,12 @@ class DeviceConnector(ZapperConnector):
         if provision_plan:
             run_stages = provision_plan["run_stage"]
             for stage in run_stages:
-                if stage.type is dict and stage.key == "initial_login":
-                    if stage.get("method") == "console-conf":
-                        do_copy_ssh_id = False
+                if (
+                    isinstance(stage, dict)
+                    and "initial_login" in stage.keys()
+                    and stage["initial_login"].get("method") == "console-conf"
+                ):
+                    do_copy_ssh_id = False
 
         if do_copy_ssh_id:
             self._copy_ssh_id()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.zapper_iot import DeviceConnector
@@ -123,7 +124,8 @@ class ZapperIoTTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
 
-    def test_post_run_actions_copy_ssh_id(self):
+    @patch.object(DeviceConnector, "_copy_ssh_id")
+    def test_post_run_actions_copy_ssh_id(self, mock_copy_ssh_id):
         """
         Test the function copies the ssh id if the
         initial login method is Not console-conf.
@@ -137,11 +139,12 @@ class ZapperIoTTests(unittest.TestCase):
                 }
             }
         }
-        device._post_run_actions()
+        device._post_run_actions(args=None)
 
-        self.assertEqual(device._copy_ssh_id.call_count, 1)
+        mock_copy_ssh_id.assert_called_once()
 
-    def test_post_run_actions_no_copy_ssh_id(self):
+    @patch.object(DeviceConnector, "_copy_ssh_id")
+    def test_post_run_actions_no_copy_ssh_id(self, mock_copy_ssh_id):
         """
         Test the function does not copy the ssh id if the
         initial login method is console-conf.
@@ -157,5 +160,5 @@ class ZapperIoTTests(unittest.TestCase):
                 }
             }
         }
-        device._post_run_actions()
-        self.assertEqual(device._copy_ssh_id.call_count, 0)
+        device._post_run_actions(args=None)
+        mock_copy_ssh_id.assert_not_called()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -132,7 +132,9 @@ class ZapperIoTTests(unittest.TestCase):
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
-                "provision_plan": {"run_stage": [{"initial_login": {"method": "system-user"}}]}
+                "provision_plan": {
+                    "run_stage": [{"initial_login": {"method": "system-user"}}]
+                }
             }
         }
         device._post_run_actions()
@@ -148,7 +150,11 @@ class ZapperIoTTests(unittest.TestCase):
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
-                "provision_plan": {"run_stage": [{"initial_login": {"method": "console-conf"}}]}
+                "provision_plan": {
+                    "run_stage": [
+                        {"initial_login": {"method": "console-conf"}}
+                    ]
+                }
             }
         }
         device._post_run_actions()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -122,3 +122,34 @@ class ZapperIoTTests(unittest.TestCase):
 
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
+
+    def test_post_run_actions_copy_ssh_id(self):
+        """
+        Test the function copies the ssh id if the
+        initial login method is Not console-conf.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "provision_plan": {"run_stage": [{"initial_login": {"method": "system-user"}}]}
+            }
+        }
+        device._post_run_actions()
+
+        self.assertEqual(device._copy_ssh_id.call_count, 1)
+
+    def test_post_run_actions_no_copy_ssh_id(self):
+        """
+        Test the function does not copy the ssh id if the
+        initial login method is console-conf.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "provision_plan": {"run_stage": [{"initial_login": {"method": "console-conf"}}]}
+            }
+        }
+        device._post_run_actions()
+        self.assertEqual(device._copy_ssh_id.call_count, 0)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -36,6 +36,34 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
+    def test_validate_configuration_ubuntu_sso_email(self):
+        """
+        Test the function username will be ubuntu_sso_email if it is provided.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "ubuntu_sso_email": "test@example.com",
+                "preset": "TestPreset",
+                "urls": ["http://test.tar.gz"],
+            }
+        }
+        device.config = {"reboot_script": ["cmd1", "cmd2"]}
+
+        args, kwargs = device._validate_configuration()
+
+        expected = {
+            "username": "test@example.com",
+            "password": "ubuntu",
+            "preset": "TestPreset",
+            "reboot_script": ["cmd1", "cmd2"],
+            "urls": ["http://test.tar.gz"],
+        }
+
+        self.assertEqual(args, ())
+        self.assertDictEqual(kwargs, expected)
+
     def test_validate_configuration_provision_plan(self):
         """
         Test the function validates a custom test plan
@@ -92,6 +120,93 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(expected, kwargs)
 
+    def test_validate_configuration_ubuntu_sso_email_provision_plan(self):
+        """
+        Test the function validates a custom test plan
+        when provided and an ubuntu_sso_email is provided.
+        The username should be overridden with the ubuntu_sso_email.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "ubuntu_sso_email": "test@example.com",
+                "provision_plan": {
+                    "config": {
+                        "project_name": "name",
+                        "serial_console": {
+                            "port": "/dev/ttySanity1",
+                            "baud_rate": 115200,
+                        },
+                        "network": "eth0",
+                    },
+                    "run_stage": [
+                        {"initial_login": {"method": "console-conf"}},
+                    ],
+                },
+            }
+        }
+        device.config = {"reboot_script": ["cmd1", "cmd2"]}
+
+        args, kwargs = device._validate_configuration()
+
+        expected = {
+            "username": "ubuntu",
+            "password": "ubuntu",
+            "custom_provision_plan": {
+                "config": {
+                    "project_name": "name",
+                    "username": "test@example.com",  # this gets overridden
+                    "password": "ubuntu",
+                    "serial_console": {
+                        "port": "/dev/ttySanity1",
+                        "baud_rate": 115200,
+                    },
+                    "network": "eth0",
+                },
+                "run_stage": [
+                    {"initial_login": {"method": "console-conf"}},
+                ],
+            },
+            "urls": [],
+            "reboot_script": ["cmd1", "cmd2"],
+            "preset": None,
+        }
+        self.maxDiff = None
+        self.assertEqual(args, ())
+        self.assertDictEqual(expected, kwargs)
+
+    def test_validate_configuration_ubuntu_sso_email_missing_provision_plan(
+        self,
+    ):
+        """
+        Test the function raises an exception if ubuntu_sso_email is not
+        provided and the initial login method is console-conf.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "provision_plan": {
+                    "config": {
+                        "project_name": "name",
+                        "serial_console": {
+                            "port": "/dev/ttySanity1",
+                            "baud_rate": 115200,
+                        },
+                        "network": "eth0",
+                    },
+                    "run_stage": [
+                        {"initial_login": {"method": "console-conf"}},
+                    ],
+                }
+            }
+        }
+        device.config = {"reboot_script": ["cmd1", "cmd2"]}
+
+        with self.assertRaises(ProvisioningError):
+            device._validate_configuration()
+
     def test_validate_configuration_invalid_url(self):
         """
         Test the function raises an exception if one of
@@ -109,7 +224,7 @@ class ZapperIoTTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
 
-    def test_validate_configuration_invalid_provision_plan(self):
+    def test_validate_configuration_invalid_provision_plan_key_error(self):
         """
         Test the function raises an exception if the
         provided custom testplan is not valid.
@@ -124,8 +239,61 @@ class ZapperIoTTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
 
+    def test_validate_configuration_invalid_provision_plan_value_error(self):
+        """
+        Test the function raises an exception if the
+        provided custom testplan is not valid.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "provision_plan": {
+                    "config": {"key1": "value1"},
+                }
+            }
+        }
+        device.config = {"reboot_script": []}
+
+        with self.assertRaises(ProvisioningError):
+            device._validate_configuration()
+
     @patch.object(DeviceConnector, "_copy_ssh_id")
-    def test_post_run_actions_copy_ssh_id(self, mock_copy_ssh_id):
+    def test_post_run_actions_copy_ssh_id_no_provision_plan(
+        self, mock_copy_ssh_id
+    ):
+        """
+        Test the function copy the ssh id if there is no provision plan
+        and without ubuntu_sso_email.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {"provision_data": {}}
+        device._post_run_actions(args=None)
+        mock_copy_ssh_id.assert_called_once()
+
+    @patch.object(DeviceConnector, "_copy_ssh_id")
+    def test_post_run_actions_not_copy_ssh_id_ubuntu_sso_email(
+        self, mock_copy_ssh_id
+    ):
+        """
+        Test the function does not copy the ssh id if there is
+        buntu_sso_email.
+        """
+
+        device = DeviceConnector()
+        device.job_data = {
+            "provision_data": {
+                "ubuntu_sso_email": "test@example.com",
+            }
+        }
+        device._post_run_actions(args=None)
+        mock_copy_ssh_id.assert_not_called()
+
+    @patch.object(DeviceConnector, "_copy_ssh_id")
+    def test_post_run_actions_copy_ssh_id_provision_plan(
+        self, mock_copy_ssh_id
+    ):
         """
         Test the function copies the ssh id if the
         initial login method is Not console-conf.
@@ -144,7 +312,9 @@ class ZapperIoTTests(unittest.TestCase):
         mock_copy_ssh_id.assert_called_once()
 
     @patch.object(DeviceConnector, "_copy_ssh_id")
-    def test_post_run_actions_no_copy_ssh_id(self, mock_copy_ssh_id):
+    def test_post_run_actions_no_copy_ssh_id_provision_plan(
+        self, mock_copy_ssh_id
+    ):
         """
         Test the function does not copy the ssh id if the
         initial login method is console-conf.
@@ -162,3 +332,7 @@ class ZapperIoTTests(unittest.TestCase):
         }
         device._post_run_actions(args=None)
         mock_copy_ssh_id.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -151,7 +151,7 @@ class ZapperIoTTests(unittest.TestCase):
         args, kwargs = device._validate_configuration()
 
         expected = {
-            "username": "ubuntu",
+            "username": "test@example.com",
             "password": "ubuntu",
             "custom_provision_plan": {
                 "config": {
@@ -310,28 +310,6 @@ class ZapperIoTTests(unittest.TestCase):
         device._post_run_actions(args=None)
 
         mock_copy_ssh_id.assert_called_once()
-
-    @patch.object(DeviceConnector, "_copy_ssh_id")
-    def test_post_run_actions_no_copy_ssh_id_provision_plan(
-        self, mock_copy_ssh_id
-    ):
-        """
-        Test the function does not copy the ssh id if the
-        initial login method is console-conf.
-        """
-
-        device = DeviceConnector()
-        device.job_data = {
-            "provision_data": {
-                "provision_plan": {
-                    "run_stage": [
-                        {"initial_login": {"method": "console-conf"}}
-                    ]
-                }
-            }
-        }
-        device._post_run_actions(args=None)
-        mock_copy_ssh_id.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This change is based on https://github.com/canonical/zapper/pull/450 and https://github.com/canonical/testflinger/pull/464 to do the initial login method check.

Add the `ubuntu_email_sso` key in provision_data, and it will overwrite the `test_username`.

```yaml
provision_data:
  # If provide the ubuntu_email_sso, it will overwrite the username which is used in the provisioning.
  ubuntu_email_sso: < ubuntu email sso >
  urls:
    - < URL 1 >
    - < URL 2 >
  provision_plan:
    config:
      project_name: < project name >
      serial_console:
        port: < port >
        baud_rate: < baud rate >
      network: <Eth interface name>
      hostname:  < Host name >
    run_stage:
      - deploy:
          utility: < utility >
          utility_extra_args: <utility extra args>
       - initial_login:
           method: < console-conf | builtin-account >
test_data: 
  # if using console-conf, we can leave it 
  test_username: <ubuntu | {or others}> 
  test_password: <ubuntu | {or others}>
```


## Resolved issues
#465 [Zapper IOT] should not apply ssh-copy-id for all zapper iot provision method


## Documentation



## Web service API changes



## Tests

