### PR TITLE
Make agent-host ssh variables sensitive

### DIFF
--- a/agent/terraform/variables.tf
+++ b/agent/terraform/variables.tf
@@ -48,13 +48,13 @@ variable "config_dir" {
 }
 
 variable "ssh_public_key" {
+  sensitive   = true
   type        = string
   description = "base64 encoded ssh public key to use on the agent host"
 }
 
 variable "ssh_private_key" {
+  sensitive   = true
   type        = string
   description = "base64 encoded ssh private key to use on the agent host"
 }
-
-


### PR DESCRIPTION
## Description

- Make SSH public and private keys sensitive variables.
  - Technically the public one isn't "sensitive", but it makes the output of `terraform plan` less verbose

## Resolved issues

## Documentation

## Web service API changes

## Tests

