### PR TITLE
Use url_for in templates

### DIFF
--- a/server/src/templates/agent_detail.html
+++ b/server/src/templates/agent_detail.html
@@ -30,9 +30,7 @@
   <ul>
     {% for queue in agent.queues %}
       <li>
-        <!-- djlint:off J018 -->
-        <a href="/queues/{{ queue }}">{{ queue }}</a>
-        <!-- djlint:on -->
+        <a href="{{ url_for('testflinger.queue_detail', queue_name=queue) }}">{{ queue }}</a>
       </li>
     {% endfor %}
   </ul>
@@ -74,9 +72,7 @@
           <tr>
             <td>{{ log.timestamp.strftime("%Y-%m-%d %H:%M:%S") }}</td>
             <td>
-              <!-- djlint:off J018 -->
-              <a href="/jobs/{{ log.job_id }}">{{ log.job_id }}</a>
-              <!-- djlint:on -->
+              <a href="{{ url_for('testflinger.job_detail', job_id=log.job_id) }}">{{ log.job_id }}</a>
             </td>
             <td class="u-align--right p-table__cell--icon-placeholder">
               <i class="{{ 'p-icon--success' if log.exit_code==0 else 'p-icon--error' }}"></i>{{ log.exit_code }}

--- a/server/src/templates/agents.html
+++ b/server/src/templates/agents.html
@@ -73,16 +73,12 @@
             {% endif %}
           </td>
           <td>
-            <!-- djlint:off J018 -->
-            <a href="/agents/{{ agent.name }}">{{ agent.name }}</a>
-            <!-- djlint:on -->
+            <a href="{{ url_for('testflinger.agent_detail', agent_id=agent.name) }}">{{ agent.name }}</a>
           </td>
           <td>{{ agent.state }}</td>
           <td>{{ agent.updated_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
           <td class="u-align--right u-truncate">
-            <!-- djlint:off J018 -->
-            <a href="/jobs/{{ agent.job_id }}">{{ agent.job_id }}</a>
-            <!-- djlint:on -->
+            <a href="{{ url_for('testflinger.job_detail', job_id=agent.job_id) }}">{{ agent.job_id }}</a>
           </td>
         </tr>
       {% endfor %}

--- a/server/src/templates/base.html
+++ b/server/src/templates/base.html
@@ -9,7 +9,8 @@
       {% endblock title %}
     - Testflinger</title>
     <!-- Site CSS Files -->
-    <link href="{{ url_for('static', filename='assets/css/testflinger.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('static', filename='assets/css/testflinger.css') }}"
+          rel="stylesheet" />
     <link rel="stylesheet"
           href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.13.0.min.css" />
     <!-- Don't request favicon -->
@@ -20,23 +21,23 @@
   </head>
   <body>
     {%- set nav_bar = [
-      {
+        {
         "name": "Agents",
         "url": url_for("testflinger.agents")
-      },
-      {
+        },
+        {
         "name": "Jobs",
         "url": url_for("testflinger.jobs")
-      },
-      {
+        },
+        {
         "name": "Queues",
         "url": url_for("testflinger.queues")
-      },
-      {
+        },
+        {
         "name": "Documentation",
         "url": "https://canonical-testflinger.readthedocs-hosted.com"
-      }
-    ] -%}
+        }
+        ] -%}
     {%- set active_page = active_page|default('agents') %}
     <header id="navigation" class="p-navigation is-dark">
       <div class="p-navigation__row">
@@ -90,6 +91,7 @@
         </ul>
       </div>
     </footer>
-    <script type="text/javascript" src="{{ url_for('static', filename='assets/js/filter.js') }}"></script>
+    <script type="text/javascript"
+            src="{{ url_for('static', filename='assets/js/filter.js') }}"></script>
   </body>
 </html>

--- a/server/src/templates/base.html
+++ b/server/src/templates/base.html
@@ -9,9 +9,7 @@
       {% endblock title %}
     - Testflinger</title>
     <!-- Site CSS Files -->
-    <!-- djlint:off J004 -->
-    <link href="/static/assets/css/testflinger.css" rel="stylesheet" />
-    <!-- djlint:on -->
+    <link href="{{ url_for('static', filename='assets/css/testflinger.css') }}" rel="stylesheet" />
     <link rel="stylesheet"
           href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.13.0.min.css" />
     <!-- Don't request favicon -->
@@ -24,15 +22,15 @@
     {%- set nav_bar = [
       {
         "name": "Agents",
-        "url": "/agents"
+        "url": url_for("testflinger.agents")
       },
       {
         "name": "Jobs",
-        "url": "/jobs"
+        "url": url_for("testflinger.jobs")
       },
       {
         "name": "Queues",
-        "url": "/queues"
+        "url": url_for("testflinger.queues")
       },
       {
         "name": "Documentation",
@@ -44,9 +42,7 @@
       <div class="p-navigation__row">
         <div class="p-navigation__banner">
           <div class="p-navigation__tagged-logo">
-            <!-- djlint:off J018 -->
-            <a class="p-navigation__link" href="/">
-              <!-- djlint:on -->
+            <a class="p-navigation__link" href="{{ url_for('testflinger.home') }}">
               <div class="p-navigation__logo-tag">
                 <!-- djlint:off H006 -->
                 <img class="p-navigation__logo-icon"
@@ -94,8 +90,6 @@
         </ul>
       </div>
     </footer>
-    <!-- djlint:off J004 -->
-    <script type="text/javascript" src="/static/assets/js/filter.js"></script>
-    <!-- djlint:on -->
+    <script type="text/javascript" src="{{ url_for('static', filename='assets/js/filter.js') }}"></script>
   </body>
 </html>

--- a/server/src/templates/jobs.html
+++ b/server/src/templates/jobs.html
@@ -19,9 +19,7 @@
       {% for job in jobs %}
         <tr>
           <td>
-            <!-- djlint:off J018 -->
-            <a href="/jobs/{{ job.job_id }}">{{ job.job_id }}</a>
-            <!-- djlint:on -->
+            <a href="{{ url_for('testflinger.job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a>
           </td>
           <td>{{ job.job_data.job_queue }}</td>
           <td>{{ job.result_data.job_state }}</td>

--- a/server/src/templates/queue_detail.html
+++ b/server/src/templates/queue_detail.html
@@ -31,9 +31,7 @@
       {% for job in jobs %}
         <tr class="tr-highlight">
           <td>
-            <!-- djlint:off J018 -->
-            <a href="/jobs/{{ job.job_id }}">{{ job.job_id }}</a>
-            <!-- djlint:on -->
+            <a href="{{ url_for('testflinger.job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a>
           </td>
           <td>{{ job.result_data.job_state }}</td>
           <td>{{ job.created_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>

--- a/server/src/templates/queues.html
+++ b/server/src/templates/queues.html
@@ -39,9 +39,7 @@
       {% for queue in queues %}
         <tr class="searchable-row">
           <td>
-            <!-- djlint:off J018 -->
-            <a href="/queues/{{ queue.name }}">{{ queue.name }}</a>
-            <!-- djlint:on -->
+            <a href="{{ url_for('testflinger.queue_detail', queue_name=queue.name) }}">{{ queue.name }}</a>
           </td>
           <td>{{ queue.numjobs }}</td>
           <td>{{ queue.description }}</td>


### PR DESCRIPTION
## Description

I believe I have found the issue with `url_for`. The application's blueprints are under the name of `testflinger`, so I had to prepend all the arguments for the view with `testflinger.`.

I didn't catch this because the test deployment I had locally didn't reload the templates.

## Resolved issues

## Documentation

## Web service API changes

## Tests
