### PR TITLE
Add "Circle of Friends" favicon

### DIFF
--- a/server/src/templates/base.html
+++ b/server/src/templates/base.html
@@ -14,8 +14,15 @@
     <!-- djlint:on -->
     <link rel="stylesheet"
           href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.13.0.min.css" />
-    <!-- Don't request favicon -->
-    <link rel="icon" href="data:,">
+    <!-- Circle of friends favicon -->
+    <link rel="shortcut icon"
+          None="image/png"
+          sizes="32x32"
+          href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" />
+    <link rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="https://assets.ubuntu.com/v1/16c27f81-COF%20favicon-16x16.png" />
     <!-- Page specific CSS Files -->
     {% block stylesheets %}
     {% endblock stylesheets %}


### PR DESCRIPTION
## Description

Adds the Ubuntu Circle of Friends as the favicon for Testflinger.

## Resolved issues

## Documentation

## Web service API changes

## Tests
