### PR TITLE
Fix links for agents and queues docs

### DIFF
--- a/server/src/templates/agents.html
+++ b/server/src/templates/agents.html
@@ -5,7 +5,7 @@
     <div class="row">
       <h1 class="p-heading--3">
         Agents
-        <a href="https://testflinger.readthedocs.io/en/latest/explanation/agents/"
+        <a href="https://testflinger.readthedocs.io/en/latest/explanation/agents.html"
            target="_blank">
           <i class="p-icon--help"></i>
         </a>

--- a/server/src/templates/queues.html
+++ b/server/src/templates/queues.html
@@ -5,7 +5,7 @@
     <div class="row">
       <h1 class="p-heading--3">
         Queues
-        <a href="https://testflinger.readthedocs.io/en/latest/explanation/queues/"
+        <a href="https://testflinger.readthedocs.io/en/latest/explanation/queues.html"
            target="_blank">
           <i class="p-icon--help"></i>
         </a>


### PR DESCRIPTION
## Description

The help links for the agents and queues pages seem to be broken. This PR fixes that.

## Resolved issues

## Documentation

## Web service API changes

## Tests
