### PR TITLE
FIx typo to trigger build pipeline

### DIFF
--- a/server/README.rst
+++ b/server/README.rst
@@ -399,7 +399,7 @@ The job_status_webhook parameter is required for this endpoint. Other parameters
 
     $ curl http://localhost:8000/v1/queues/wait_times?queue=foo\&queue=bar
 
-** [GET] /v1/queues/<queue_name>/agents** - Get the list of agents listening to a specified queue
+**[GET] /v1/queues/<queue_name>/agents** - Get the list of agents listening to a specified queue
 
 - Parameters:
 


### PR DESCRIPTION
## Description

This change fixes a small typo so that we trigger the build pipelines

## Resolved issues

No issues

## Documentation

No relevant documentation

## Web service API changes

No changes

## Tests
No tests, just verifying that the charm builds
