### PR TITLE
Add a variable for the charm revision, such that it takes precedence over channel

### DIFF
--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -7,7 +7,8 @@ resource "juju_application" "testflinger" {
   charm {
     name    = "testflinger-k8s"
     base    = "ubuntu@22.04"
-    channel = var.environment == "production" ? "latest/stable" : "latest/edge"
+    channel = var.revision == "" ? (var.environment == "production" ? "latest/stable" : "latest/edge") : null
+    revision = var.revision != "" ? var.revision : null
   }
 
   config = {

--- a/server/terraform/variables.tf
+++ b/server/terraform/variables.tf
@@ -1,7 +1,13 @@
 variable "environment" {
-  description = "The environment to deploy to (dev, staging, prod)"
+  description = "The environment to deploy to (dev, staging, prod). When the \"revision\" variable is not set, the value of \"environment\" determines the channel to deploy from, either \"latest/stable\" (for production) or \"latest/edge\" channel otherwise."
   type        = string
   default     = "dev"
+}
+
+variable "revision" {
+  description = "The revision of the API server charm to deploy"
+  type        = string
+  default     = null
 }
 
 variable "external_ingress_hostname" {


### PR DESCRIPTION
## Description

The terraform module for the API server right now maps the "environment" variable to the charm channel to use. It is preferrable to have in this module also optionally control over the exact revision (for reproducible deploys): when `revision` is set, it takes precdence.

## Resolved issues

None, noticed this as a side effect of an incident. Preparing for implementing consistent CD practices.

## Documentation

Terraform module description fields updated

## Web service API changes

None

## Tests

To be tested by using the revision key in the terraform plan that uses this module, on staging.