### PR TITLE
feat: use unique identifier as a header when pinging testflinger

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -36,9 +36,10 @@ runs:
       shell: bash {0}  # allow curl to fail
       env:
         SERVER: https://${{ inputs.server }}
+        REQUEST_ID: ${{ github.run_id }}
       run: |
         echo "::group::Test connection to Testflinger server"
-        STATUS=$(curl --stderr error.log -Ivw "%{http_code}\n" -o /dev/null $SERVER/jobs)
+        STATUS=$(curl --stderr error.log -Ivw "%{http_code}\n" -o /dev/null $SERVER/v1 -H "X-Request-ID: $REQUEST_ID")
         ERROR=$?
         if [ ! $ERROR -eq 0 ]; then
           echo "Unable to ping Testflinger server at $SERVER"


### PR DESCRIPTION
## Description

The `submit` action includes a step that hits the Testflinger API `/jobs` endpoint in order to test if Testflinger is accesible. This PR switches to simply hitting the `/v1` root but, most importantly, includes a unique request ID in the header (the run ID of the Github workflow) so that the request is traceable in the Testflinger ingress logs.

## Resolved issues

Not tracked, a simple refinement.

## Documentation

N/A

## Tests

This is a [workflow run](https://github.com/canonical/certification-lab-ci/actions/runs/13724870134) with run ID `13724870134` that uses the `submit` action from this branch. And this is how the corresponding request appears in the ingress log (with the run ID appearing right at the end of the log entry):
```
10.141.84.170 - - [07/Mar/2025:16:24:10 +0000] "HEAD /v1 HTTP/2.0" 403 0 "-" "curl/7.81.0" 66 0.000 [testflinger-production-relation-12-testflinger-service-5000] [] - - - - 13724870134
```