### PR TITLE
Add links to agents and queues in details

### DIFF
--- a/server/src/templates/job_detail.html
+++ b/server/src/templates/job_detail.html
@@ -10,7 +10,9 @@
     <tbody>
       <tr>
         <td>Queue</td>
-        <td>{{ job.job_data.job_queue }}</td>
+        <td>
+          <a href="{{ url_for('testflinger.queue_detail', queue_name=job.job_data.job_queue) }}">{{ job.job_data.job_queue }}</a>
+        </td>
       </tr>
       <tr>
         <td>State</td>

--- a/server/src/templates/jobs.html
+++ b/server/src/templates/jobs.html
@@ -21,7 +21,9 @@
           <td>
             <a href="{{ url_for('testflinger.job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a>
           </td>
-          <td>{{ job.job_data.job_queue }}</td>
+          <td>
+            <a href="{{ url_for('testflinger.queue_detail', queue_name=job.job_data.job_queue) }}">{{ job.job_data.job_queue }}</a>
+          </td>
           <td>{{ job.result_data.job_state }}</td>
           <td>{{ job.created_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
         </tr>

--- a/server/src/templates/queue_detail.html
+++ b/server/src/templates/queue_detail.html
@@ -75,7 +75,9 @@
                 {{ agent.provision_streak_count }}
               {% endif %}
             </td>
-            <td>{{ agent.name }}</td>
+            <td>
+              <a href="{{ url_for('testflinger.agent_detail', agent_id=agent.name) }}">{{ agent.name }}</a>
+            </td>
             <td>{{ agent.state }}</td>
             <td>{{ agent.updated_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
             <td>{{ agent.job_id }}</td>


### PR DESCRIPTION
## Description

Adds links to the agents and queues shown in the jobs, job details, and queue details pages.

## Resolved issues

Resolves #460 
Resolves [CERTTF-499](https://warthogs.atlassian.net/browse/CERTTF-499)

## Documentation

## Web service API changes

## Tests


[CERTTF-499]: https://warthogs.atlassian.net/browse/CERTTF-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ