### PR TITLE
Fix tab title

### DIFF
--- a/server/src/templates/agent_detail.html
+++ b/server/src/templates/agent_detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set active_page = "agents" %}
+{% set title = "Agent" %}
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="row">

--- a/server/src/templates/agent_not_found.html
+++ b/server/src/templates/agent_not_found.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set active_page = "agents" %}
+{% set title = "Agent Not Found" %}
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="row">

--- a/server/src/templates/agents.html
+++ b/server/src/templates/agents.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set active_page = "agents" %}
+{% set title = "Agents" %}
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="row">

--- a/server/src/templates/base.html
+++ b/server/src/templates/base.html
@@ -5,9 +5,9 @@
     <meta name="description" content="Canonical Testflinger server" />
     <meta name="keywords" content="test, test orchestration, testflinger" />
     <title>
-      {% block title %}
-      {% endblock title %}
-    - Testflinger</title>
+      {% if title %}{{ title }} |{% endif %}
+      Testflinger
+    </title>
     <!-- Site CSS Files -->
     <link href="{{ url_for('static', filename='assets/css/testflinger.css') }}"
           rel="stylesheet" />

--- a/server/src/templates/job_detail.html
+++ b/server/src/templates/job_detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set active_page = "jobs" %}
+{% set title = "Job" %}
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="row">

--- a/server/src/templates/job_not_found.html
+++ b/server/src/templates/job_not_found.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set active_page = "jobs" %}
+{% set title = "Job Not Found" %}
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="row">

--- a/server/src/templates/jobs.html
+++ b/server/src/templates/jobs.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set active_page = "jobs" %}
+{% set title = "Jobs" %}
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="row">

--- a/server/src/templates/queue_detail.html
+++ b/server/src/templates/queue_detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set active_page = "queues" %}
+{% set title = "Queue" %}
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="row">

--- a/server/src/templates/queues.html
+++ b/server/src/templates/queues.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set active_page = "queues" %}
+{% set title = "Queues" %}
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="row">


### PR DESCRIPTION
## Description

The `title` block was not used before. This PR adds a page title for each page we serve.

## Resolved issues

## Documentation

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/96e44936-9b89-493c-b6d9-e56175fafd4f)


After:
![image](https://github.com/user-attachments/assets/49b693e2-62c1-4a42-8c17-cf8d8dd30021)


## Web service API changes

## Tests
