### PR TITLE
Update vanilla framework design of Testflinger server

### DIFF
--- a/server/src/templates/_footer.html
+++ b/server/src/templates/_footer.html
@@ -1,0 +1,18 @@
+<footer id="footer" class="l-footer--sticky p-strip--highlighted is-dark">
+  <nav id="copyright" class="row" aria-label="footer">
+    <div class="has-cookie">
+      <p>&copy;2023 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+      <ul class="p-inline-list--middot">
+        <li class="p-inline-list__item">
+          <a href="https://www.ubuntu.com/legal">Legal information</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="https://ubuntu.com/legal/data-privacy">Data privacy</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="https://github.com/canonical/testflinger/issues">Report a bug on this site</a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</footer>

--- a/server/src/templates/_header.html
+++ b/server/src/templates/_header.html
@@ -1,0 +1,54 @@
+{%- set nav_bar = [
+{
+"name": "Agents",
+"url": url_for("testflinger.agents")
+},
+{
+"name": "Jobs",
+"url": url_for("testflinger.jobs")
+},
+{
+"name": "Queues",
+"url": url_for("testflinger.queues")
+},
+{
+"name": "Documentation",
+"url": "https://canonical-testflinger.readthedocs-hosted.com"
+}
+] -%}
+{%- set active_page = active_page|default('agents') %}
+<header id="navigation" class="p-navigation is-dark">
+  <div class="p-navigation__row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__tagged-logo">
+        <a class="p-navigation__link" href="{{ url_for('testflinger.home') }}">
+          <div class="p-navigation__logo-tag">
+            <!-- djlint:off H006 -->
+            <img class="p-navigation__logo-icon"
+                 src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
+                 alt="ubuntu circle of friends logo">
+            <!-- djlint:on -->
+          </div>
+          <span class="p-navigation__logo-title">Testflinger</span>
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed"
+         class="p-navigation__toggle--close"
+         title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav u-image-position"
+         aria-label="Main navigation">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__items">
+        {%- for item in nav_bar %}
+          <li class="p-navigation__item {% if item.name|lower==active_page %}is-selected{% endif %}">
+            <a class="p-navigation__link" href="{{ item.url }}">{{ item.name }}</a>
+          </li>
+        {%- endfor %}
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/server/src/templates/base.html
+++ b/server/src/templates/base.html
@@ -12,7 +12,7 @@
     <link href="{{ url_for('static', filename='assets/css/testflinger.css') }}"
           rel="stylesheet" />
     <link rel="stylesheet"
-          href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.13.0.min.css" />
+          href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.21.1.min.css" />
     <!-- Circle of friends favicon -->
     <link rel="shortcut icon"
           None="image/png"

--- a/server/src/templates/base.html
+++ b/server/src/templates/base.html
@@ -26,78 +26,15 @@
     {% block stylesheets %}
     {% endblock stylesheets %}
   </head>
-  <body>
-    {%- set nav_bar = [
-        {
-        "name": "Agents",
-        "url": url_for("testflinger.agents")
-        },
-        {
-        "name": "Jobs",
-        "url": url_for("testflinger.jobs")
-        },
-        {
-        "name": "Queues",
-        "url": url_for("testflinger.queues")
-        },
-        {
-        "name": "Documentation",
-        "url": "https://canonical-testflinger.readthedocs-hosted.com"
-        }
-        ] -%}
-    {%- set active_page = active_page|default('agents') %}
-    <header id="navigation" class="p-navigation is-dark">
-      <div class="p-navigation__row">
-        <div class="p-navigation__banner">
-          <div class="p-navigation__tagged-logo">
-            <a class="p-navigation__link" href="{{ url_for('testflinger.home') }}">
-              <div class="p-navigation__logo-tag">
-                <!-- djlint:off H006 -->
-                <img class="p-navigation__logo-icon"
-                     src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
-                     alt="ubuntu circle of friends logo">
-                <!-- djlint:on -->
-              </div>
-              <span class="p-navigation__logo-title">Testflinger</span>
-            </a>
-          </div>
-          <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-          <a href="#navigation-closed"
-             class="p-navigation__toggle--close"
-             title="close menu">Close menu</a>
-        </div>
-        <nav class="p-navigation__nav u-image-position" aria-label="Example main">
-          <span class="u-off-screen">
-            <a href="#main-content">Jump to main content</a>
-          </span>
-          <ul class="p-navigation__items">
-            {%- for item in nav_bar %}
-              <li class="p-navigation__item {% if item.name|lower==active_page %}is-selected{% endif %}">
-                <a class="p-navigation__link" href="{{ item.url }}">{{ item.name }}</a>
-              </li>
-            {%- endfor %}
-          </ul>
-        </nav>
+  <body class="is-paper">
+    <div class="l-site">
+      {% include "_header.html" %}
+      <div class="row">
+        {% block content %}
+        {% endblock content %}
       </div>
-    </header>
-    <div class="row">
-      {% block content %}
-      {% endblock content %}
+      {% include "_footer.html" %}
     </div>
-    <hr>
-    <footer id="footer" class="p-strip" role="contentinfo">
-      <div id="copyright" class="row">
-        <p>&copy;2023 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-        <ul class="p-inline-list--middot">
-          <li class="p-inline-list__item">
-            <a href="https://www.ubuntu.com/legal">Legal information</a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="https://ubuntu.com/legal/data-privacy">Data privacy</a>
-          </li>
-        </ul>
-      </div>
-    </footer>
     <script type="text/javascript"
             src="{{ url_for('static', filename='assets/js/filter.js') }}"></script>
   </body>


### PR DESCRIPTION
## Description

* Update Vanilla Framework from 4.13.0 to latest stable 4.21.1.
* Extract header and footer into their own templates for readability
* Add Report bug link to footer
* Update page design to paper theme (similar to light)
* Update footer design to dark theme

## Resolved issues

## Documentation

## Screenshots

![image](https://github.com/user-attachments/assets/afe1575b-a6c4-4b46-b574-b25cb6ac4bf0)

## Web service API changes

## Tests
