### PR TITLE
Add location to agents table

### DIFF
--- a/server/src/templates/_agents_table.html
+++ b/server/src/templates/_agents_table.html
@@ -18,6 +18,7 @@
         </span>
       </th>
       <th aria-sort="none" id="agentsNameHeader">Name</th>
+      <th aria-sort="none" id="agentsNameHeader">Location</th>
       <th aria-sort="none" id="agentsStateHeader">State</th>
       <th aria-sort="none" id="agentsUpdatedAtHeader">Updated At</th>
       <th>Job ID</th>
@@ -47,6 +48,7 @@
           <td>
             <a href="{{ url_for('testflinger.agent_detail', agent_id=agent.name) }}">{{ agent.name }}</a>
           </td>
+          <td>{{ agent.location or "unknown" }}</td>
           <td>{{ agent.state }}</td>
           <td>{{ agent.updated_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
           <td class="u-align--right u-truncate">


### PR DESCRIPTION
## Description

- Add `agent.location` to the agents table (used in the agents and queue detail pages).
  - If no location is defined, the field defaults to `unknown`
  - This field is sortable

## Resolved issues

## Documentation

## Web service API changes

## Tests
