### PR TITLE
Replace xdg with xdg-base-dirs

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "argcomplete",
 ]
 dynamic = ["version"]
+requires-python = ">= 3.10"
 
 [project.scripts]
 testflinger-cli = "testflinger_cli:cli"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.rst"
 dependencies = [
     "PyYAML",
     "requests",
-    "xdg<5.2",
+    "xdg-base-dirs",
     "argcomplete",
 ]
 dynamic = ["version"]

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -221,9 +221,7 @@ class TestflingerCli:
             help="Download a tarball of artifacts saved for a specified job",
         )
         parser.set_defaults(func=self.artifacts)
-        parser.add_argument(
-            "--filename", type=Path, default=Path("artifacts.tgz")
-        )
+        parser.add_argument("--filename", type=Path, default="artifacts.tgz")
         parser.add_argument("job_id").completer = partial(
             autocomplete.job_ids_completer, history=self.history
         )

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -187,6 +187,7 @@ class TestflingerCli:
         parser.add_argument(
             "-c",
             "--configfile",
+            type=Path,
             default=None,
             help="Configuration file to use",
         )

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -221,7 +221,9 @@ class TestflingerCli:
             help="Download a tarball of artifacts saved for a specified job",
         )
         parser.set_defaults(func=self.artifacts)
-        parser.add_argument("--filename", default="artifacts.tgz")
+        parser.add_argument(
+            "--filename", type=Path, default=Path("artifacts.tgz")
+        )
         parser.add_argument("job_id").completer = partial(
             autocomplete.job_ids_completer, history=self.history
         )
@@ -802,7 +804,7 @@ class TestflingerCli:
                 exc.status,
             )
             sys.exit(1)
-        print("Artifacts downloaded to {}".format(self.args.filename))
+        print(f"Artifacts downloaded to {self.args.filename}")
 
     def poll(self):
         """Poll for output from a job until it is completed"""

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -37,7 +37,6 @@ from typing import Optional
 import argcomplete
 import requests
 import yaml
-
 from testflinger_cli import autocomplete, client, config, history
 
 logger = logging.getLogger(__name__)
@@ -364,7 +363,7 @@ class TestflingerCli:
         parser.add_argument("--poll", "-p", action="store_true")
         parser.add_argument("--quiet", "-q", action="store_true")
         parser.add_argument("--wait-for-available-agents", action="store_true")
-        parser.add_argument("filename").completer = (
+        parser.add_argument("filename", type=Path).completer = (
             argcomplete.completers.FilesCompleter(
                 allowednames=("*.yaml", "*.yml", "*.json")
             )

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -18,15 +18,14 @@
 Testflinger client module
 """
 
+import base64
 import json
 import logging
-from pathlib import Path
 import sys
 import urllib.parse
-import base64
+from pathlib import Path
 
 import requests
-
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +218,7 @@ class Client:
         endpoint = "/v1/result/{}".format(job_id)
         return json.loads(self.get(endpoint))
 
-    def get_artifact(self, job_id, path):
+    def get_artifact(self, job_id, path: Path):
         """Get results for a specified test job
 
         :param job_id:
@@ -232,7 +231,7 @@ class Client:
         req = requests.get(uri, timeout=15, stream=True)
         if req.status_code != 200:
             raise HTTPError(req.status_code)
-        with open(path, "wb") as artifact:
+        with path.open("wb") as artifact:
             for chunk in req.raw.stream(4096, decode_content=False):
                 if chunk:
                     artifact.write(chunk)

--- a/cli/testflinger_cli/config.py
+++ b/cli/testflinger_cli/config.py
@@ -20,7 +20,6 @@ Testflinger config module
 
 import configparser
 from collections import OrderedDict
-from os import PathLike
 from pathlib import Path
 
 from xdg_base_dirs import xdg_config_home
@@ -29,18 +28,20 @@ from xdg_base_dirs import xdg_config_home
 class TestflingerCliConfig:
     """TestflingerCliConfig class load values from files, env, and params"""
 
-    def __init__(self, configfile: str | PathLike | None = None):
-        config = configparser.ConfigParser()
+    def __init__(self, configfile: Path | None = None):
         if configfile is None:
             config_home = xdg_config_home()
             config_home.mkdir(parents=True, exist_ok=True)
             configfile = config_home / "testflinger-cli.conf"
-        config.read(configfile)
-        # Default empty config in case there's no config file
-        self.data = OrderedDict()
-        if "testflinger-cli" in config.sections():
-            self.data = OrderedDict(config["testflinger-cli"])
         self.configfile = Path(configfile)
+
+        config = configparser.ConfigParser()
+        config.read(configfile)
+        try:
+            self.data = OrderedDict(config["testflinger-cli"])
+        except KeyError:
+            # Default empty config in case there's no config file
+            self.data = OrderedDict()
 
     def get(self, key, default=None):
         """Get config item"""

--- a/cli/testflinger_cli/config.py
+++ b/cli/testflinger_cli/config.py
@@ -19,27 +19,28 @@ Testflinger config module
 """
 
 import configparser
-import os
 from collections import OrderedDict
-import xdg
+from os import PathLike
+from pathlib import Path
+
+from xdg_base_dirs import xdg_config_home
 
 
 class TestflingerCliConfig:
     """TestflingerCliConfig class load values from files, env, and params"""
 
-    def __init__(self, configfile=None):
+    def __init__(self, configfile: str | PathLike | None = None):
         config = configparser.ConfigParser()
-        if not configfile:
-            os.makedirs(xdg.XDG_CONFIG_HOME, exist_ok=True)
-            configfile = os.path.join(
-                xdg.XDG_CONFIG_HOME, "testflinger-cli.conf"
-            )
+        if configfile is None:
+            config_home = xdg_config_home()
+            config_home.mkdir(parents=True, exist_ok=True)
+            configfile = config_home / "testflinger-cli.conf"
         config.read(configfile)
         # Default empty config in case there's no config file
         self.data = OrderedDict()
         if "testflinger-cli" in config.sections():
             self.data = OrderedDict(config["testflinger-cli"])
-        self.configfile = configfile
+        self.configfile = Path(configfile)
 
     def get(self, key, default=None):
         """Get config item"""
@@ -54,7 +55,7 @@ class TestflingerCliConfig:
         """Save config back to the config file"""
         config = configparser.ConfigParser()
         config.read_dict({"testflinger-cli": self.data})
-        with open(
-            self.configfile, "w", encoding="utf-8", errors="ignore"
+        with self.configfile.open(
+            "w", encoding="utf-8", errors="ignore"
         ) as config_file:
             config.write(config_file)

--- a/cli/testflinger_cli/history.py
+++ b/cli/testflinger_cli/history.py
@@ -60,7 +60,7 @@ class TestflingerCliHistory:
             ) as history_file:
                 self.history.update(json.load(history_file))
         except FileNotFoundError:
-            logging.error("History file %s not found", self.historyfile)
+            pass
         except (OSError, ValueError) as e:
             # If there's any error loading the history, ignore it
             logging.exception(e)

--- a/cli/testflinger_cli/history.py
+++ b/cli/testflinger_cli/history.py
@@ -60,8 +60,9 @@ class TestflingerCliHistory:
             ) as history_file:
                 try:
                     self.history.update(json.load(history_file))
-                except (OSError, ValueError):
+                except (OSError, ValueError) as e:
                     # If there's any error loading the history, ignore it
+                    logging.exception(e)
                     logger.error(
                         "Error loading history file from %s", self.historyfile
                     )

--- a/cli/testflinger_cli/history.py
+++ b/cli/testflinger_cli/history.py
@@ -35,6 +35,7 @@ class TestflingerCliHistory:
         config_home = xdg_config_home()
         config_home.mkdir(parents=True, exist_ok=True)
         self.historyfile = config_home / "testflinger-cli-history.json"
+        self.history = OrderedDict()
         self.load()
 
     def new(self, job_id, queue):
@@ -53,8 +54,6 @@ class TestflingerCliHistory:
 
     def load(self):
         """Load the history file"""
-        if not hasattr(self, "history"):
-            self.history = OrderedDict()
         if self.historyfile.exists():
             with self.historyfile.open(
                 encoding="utf-8", errors="ignore"

--- a/cli/testflinger_cli/history.py
+++ b/cli/testflinger_cli/history.py
@@ -20,11 +20,10 @@ Testflinger history module
 
 import json
 import logging
-import os
 from collections import OrderedDict
 from datetime import datetime
-import xdg
 
+from xdg_base_dirs import xdg_config_home
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +32,9 @@ class TestflingerCliHistory:
     """History class used for storing job history on a device"""
 
     def __init__(self):
-        os.makedirs(xdg.XDG_DATA_HOME, exist_ok=True)
-        self.historyfile = os.path.join(
-            xdg.XDG_DATA_HOME, "testflinger-cli-history.json"
-        )
+        config_home = xdg_config_home()
+        config_home.mkdir(parents=True, exist_ok=True)
+        self.historyfile = config_home / "testflinger-cli-history.json"
         self.load()
 
     def new(self, job_id, queue):
@@ -57,9 +55,9 @@ class TestflingerCliHistory:
         """Load the history file"""
         if not hasattr(self, "history"):
             self.history = OrderedDict()
-        if os.path.exists(self.historyfile):
-            with open(
-                self.historyfile, encoding="utf-8", errors="ignore"
+        if self.historyfile.exists():
+            with self.historyfile.open(
+                encoding="utf-8", errors="ignore"
             ) as history_file:
                 try:
                     self.history.update(json.load(history_file))
@@ -71,8 +69,8 @@ class TestflingerCliHistory:
 
     def save(self):
         """Save the history out to the history file"""
-        with open(
-            self.historyfile, "w", encoding="utf-8", errors="ignore"
+        with self.historyfile.open(
+            "w", encoding="utf-8", errors="ignore"
         ) as history_file:
             json.dump(self.history, history_file, indent=2)
 

--- a/cli/testflinger_cli/history.py
+++ b/cli/testflinger_cli/history.py
@@ -54,18 +54,19 @@ class TestflingerCliHistory:
 
     def load(self):
         """Load the history file"""
-        if self.historyfile.exists():
+        try:
             with self.historyfile.open(
                 encoding="utf-8", errors="ignore"
             ) as history_file:
-                try:
-                    self.history.update(json.load(history_file))
-                except (OSError, ValueError) as e:
-                    # If there's any error loading the history, ignore it
-                    logging.exception(e)
-                    logger.error(
-                        "Error loading history file from %s", self.historyfile
-                    )
+                self.history.update(json.load(history_file))
+        except FileNotFoundError:
+            logging.error("History file %s not found", self.historyfile)
+        except (OSError, ValueError) as e:
+            # If there's any error loading the history, ignore it
+            logging.exception(e)
+            logger.error(
+                "Error loading history file from %s", self.historyfile
+            )
 
     def save(self):
         """Save the history out to the history file"""

--- a/cli/testflinger_cli/history.py
+++ b/cli/testflinger_cli/history.py
@@ -73,7 +73,7 @@ class TestflingerCliHistory:
         with self.historyfile.open(
             "w", encoding="utf-8", errors="ignore"
         ) as history_file:
-            json.dump(self.history, history_file, indent=2)
+            json.dump(self.history, history_file)
 
     def update(self, job_id, state):
         """Update job state in the history file"""


### PR DESCRIPTION

## Description

- `xdg` is deprecated; it was renamed to `xdg-base-dirs` and it now uses `pathlib.Path`.
  - See https://pypi.org/project/xdg/
- Adopt `pathlib.Path` more in the CLI portions that relate to the `xdg` change above.

## Resolved issues

## Documentation

## Web service API changes

## Tests

Built the snap locally and tested the `testflinger-cli config ...` command to read and set values. Similarly, checked the `testflinger-cli jobs ...` to test the history.