### PR TITLE
fix: test in `submit` action hits `/v1/` instead of `v1`

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -39,7 +39,7 @@ runs:
         REQUEST_ID: ${{ github.run_id }}
       run: |
         echo "::group::Test connection to Testflinger server"
-        STATUS=$(curl --stderr error.log -Ivw "%{http_code}\n" -o /dev/null $SERVER/v1 -H "X-Request-ID: $REQUEST_ID")
+        STATUS=$(curl --stderr error.log -Ivw "%{http_code}\n" -o /dev/null $SERVER/v1/ -H "X-Request-ID: $REQUEST_ID")
         ERROR=$?
         if [ ! $ERROR -eq 0 ]; then
           echo "Unable to ping Testflinger server at $SERVER"


### PR DESCRIPTION
## Description

The Testflinger submit action contains a step that checks the connection to the Testflinger server. For some yet unknown reason this test is now broken and this PR provides a fix. Specifically hitting the Testflinger `/v1` used to work but now leads to a redirect (308) error. The fix hits now hits `/v1/`. 

## Tests

Workflow run [failing](https://github.com/canonical/certification-lab-ci/actions/runs/13761866509/job/38479612666).
Workflow run using the submit action from this branch [succeeding](https://github.com/canonical/certification-lab-ci/actions/runs/13762360144).