### PR TITLE
add `assets` as optional key to zapper provisioning API

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -129,6 +129,7 @@ class DeviceConnector(ZapperConnector):
             "wait_until_ssh",
             "live_image",
             "ubuntu_sso_email",
+            "assets",
         ]
         provisioning_data.update(
             {


### PR DESCRIPTION
These assets are urls to files that Zapper will place onto an ISO before booting from it. Goes hand in hand with an ongoing PR, introducing this functionality.

## Description

Allow a new optional key for the zapper provisioning API

## Resolved issues

None

## Documentation

N/A

## Web service API changes

N/A

## Tests

N/A
