### PR TITLE
Add data headings to cards

### DIFF
--- a/server/src/templates/_agents_table.html
+++ b/server/src/templates/_agents_table.html
@@ -28,7 +28,7 @@
     {% if agents %}
       {% for agent in agents %}
         <tr class="searchable-row">
-          <td class="has-overflow">
+          <td class="has-overflow" data-heading="Outcome">
             {% if agent.provision_streak_type == "fail" and agent.provision_streak_count > 0 %}
               <span class="p-tooltip--right" aria-describedby="tooltip">
                 <i class="p-icon--warning"></i>
@@ -45,13 +45,13 @@
               <span class="provision-streak">{{ agent.provision_streak_count }}</span>
             {% endif %}
           </td>
-          <td>
+          <td data-heading="Name">
             <a href="{{ url_for('testflinger.agent_detail', agent_id=agent.name) }}">{{ agent.name }}</a>
           </td>
-          <td>{{ agent.location or "unknown" }}</td>
-          <td>{{ agent.state }}</td>
-          <td>{{ agent.updated_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
-          <td class="u-align--right u-truncate">
+          <td data-heading="Location">{{ agent.location or "unknown" }}</td>
+          <td data-heading="State">{{ agent.state }}</td>
+          <td data-heading="Updated At">{{ agent.updated_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+          <td class="u-align--right u-truncate" data-heading="Job ID">
             <a href="{{ url_for('testflinger.job_detail', job_id=agent.job_id) }}">{{ agent.job_id }}</a>
           </td>
         </tr>

--- a/server/src/templates/agent_detail.html
+++ b/server/src/templates/agent_detail.html
@@ -10,19 +10,19 @@
   <table aria-label="Agent table" class="p-table--mobile-card">
     <tbody>
       <tr>
-        <td>State</td>
+        <th scope="row">State</th>
         <td>{{ agent.state }}</td>
       </tr>
       <tr>
-        <td>Location</td>
+        <th scope="row">Location</th>
         <td>{{ agent.location }}</td>
       </tr>
       <tr>
-        <td>Provision Type</td>
+        <th scope="row">Provision Type</th>
         <td>{{ agent.provision_type }}</td>
       </tr>
       <tr>
-        <td>Last updated</td>
+        <th scope="row">Last updated</th>
         <td>{{ agent.updated_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
       </tr>
     </tbody>

--- a/server/src/templates/job_detail.html
+++ b/server/src/templates/job_detail.html
@@ -10,17 +10,17 @@
   <table aria-label="Agent table" class="p-table--mobile-card">
     <tbody>
       <tr>
-        <td>Queue</td>
+        <th scope="row">Queue</th>
         <td>
           <a href="{{ url_for('testflinger.queue_detail', queue_name=job.job_data.job_queue) }}">{{ job.job_data.job_queue }}</a>
         </td>
       </tr>
       <tr>
-        <td>State</td>
+        <th scope="row">State</th>
         <td>{{ job.result_data.job_state }}</td>
       </tr>
       <tr>
-        <td>Created At</td>
+        <th scope="row">Created At</th>
         <td>{{ job.created_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
       </tr>
     </tbody>

--- a/server/src/templates/jobs.html
+++ b/server/src/templates/jobs.html
@@ -13,20 +13,20 @@
         <th>Job ID</th>
         <th>Queue</th>
         <th style="width: 100pt">State</th>
-        <th style="width: 150pt">Created at</th>
+        <th style="width: 150pt">Created At</th>
       </tr>
     </thead>
     <tbody>
       {% for job in jobs %}
         <tr>
-          <td>
+          <td data-heading="Job ID">
             <a href="{{ url_for('testflinger.job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a>
           </td>
-          <td>
+          <td data-heading="Queue">
             <a href="{{ url_for('testflinger.queue_detail', queue_name=job.job_data.job_queue) }}">{{ job.job_data.job_queue }}</a>
           </td>
-          <td>{{ job.result_data.job_state }}</td>
-          <td>{{ job.created_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+          <td data-heading="State">{{ job.result_data.job_state }}</td>
+          <td data-heading="Created At">{{ job.created_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/server/src/templates/queue_detail.html
+++ b/server/src/templates/queue_detail.html
@@ -10,7 +10,7 @@
   <table aria-label="Queue Details table" class="p-table--mobile-card">
     <tbody>
       <tr>
-        <td>Description</td>
+        <th scope="row">Description</th>
         <td>{{ queue.description }}</td>
       </tr>
     </tbody>

--- a/server/src/templates/queue_detail.html
+++ b/server/src/templates/queue_detail.html
@@ -31,11 +31,11 @@
     <tbody>
       {% for job in jobs %}
         <tr class="tr-highlight">
-          <td>
+          <td data-heading="Job ID">
             <a href="{{ url_for('testflinger.job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a>
           </td>
-          <td>{{ job.result_data.job_state }}</td>
-          <td>{{ job.created_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+          <td data-heading="State">{{ job.result_data.job_state }}</td>
+          <td data-heading="Created At">{{ job.created_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/server/src/templates/queues.html
+++ b/server/src/templates/queues.html
@@ -39,11 +39,11 @@
     <tbody>
       {% for queue in queues %}
         <tr class="searchable-row">
-          <td>
+          <td data-heading="Name">
             <a href="{{ url_for('testflinger.queue_detail', queue_name=queue.name) }}">{{ queue.name }}</a>
           </td>
-          <td>{{ queue.numjobs }}</td>
-          <td>{{ queue.description }}</td>
+          <td data-heading="Number of Jobs">{{ queue.numjobs }}</td>
+          <td data-heading="Description">{{ queue.description }}</td>
         </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Description

- This adds the heading to the mobile cards when the screen is too small for the full table.
- Fix cases where we had a row header, but we didn't use the `<th scope="row">...</th>` element

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

## Screenshots

For example:
![image](https://github.com/user-attachments/assets/b0118d89-60bf-46a6-a84d-cf4fd1d3d8c0)

## Web service API changes

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
