### PR TITLE
fix(cli): Add removable-media plug

### DIFF
--- a/cli/README.rst
+++ b/cli/README.rst
@@ -21,6 +21,13 @@ To install testflinger using the snap:
 
   $ sudo snap install testflinger-cli
 
+In order for Testflinger to see files/directories in removable media, you will
+need to connect the ``removable-media`` interface manually:
+
+.. code-block:: console
+
+  $ sudo snap connect testflinger-cli:removable-media
+
 When changes are made to the CLI, the snap is automatically built and uploaded
 to the `edge` channel. Once sufficient testing has been performed, this snap
 is also published to the `stable` channel. If you prefer to use the latest

--- a/cli/snapcraft.yaml
+++ b/cli/snapcraft.yaml
@@ -32,6 +32,7 @@ apps:
       XDG_STATE_HOME: $SNAP_USER_DATA/.local/state
     plugs:
       - home
+      - removable-media
       - network
 
 parts:

--- a/docs/how-to/install-cli.rst
+++ b/docs/how-to/install-cli.rst
@@ -14,6 +14,12 @@ The most convenient way to get the CLI tool is via snap:
 
     $ sudo snap install testflinger-cli
 
+In order for Testflinger to see files/directories in removable media, you will
+need to connect the ``removable-media`` interface manually:
+
+.. code-block:: console
+
+  $ sudo snap connect testflinger-cli:removable-media
 
 Install in virtual environment
 -------------------------------


### PR DESCRIPTION
## Description

- Add [`removable-media`](https://snapcraft.io/docs/removable-media-interface) interface to the CLI
  - This needs to be manually connected
  - The interface allows the CLI to read/write files in removable media (e.g., USBs, disks, etc.)

## Resolved issues

## Documentation

- Updated installation instructions

## Web service API changes

## Tests

Tested locally by building and installing the snap