### PR TITLE
fix(cli): Fix stdin filename argument for submit

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -363,10 +363,12 @@ class TestflingerCli:
         parser.add_argument("--poll", "-p", action="store_true")
         parser.add_argument("--quiet", "-q", action="store_true")
         parser.add_argument("--wait-for-available-agents", action="store_true")
-        parser.add_argument("filename", type=Path).completer = (
-            argcomplete.completers.FilesCompleter(
-                allowednames=("*.yaml", "*.yml", "*.json")
-            )
+        parser.add_argument(
+            "filename",
+            type=str,
+            help="YAML or JSON file with your job definition, '-' for stdin",
+        ).completer = argcomplete.completers.FilesCompleter(
+            allowednames=("*.yaml", "*.yml", "*.json")
         )
         parser.add_argument(
             "--client_id",
@@ -521,13 +523,13 @@ class TestflingerCli:
         if self.args.filename == "-":
             data = sys.stdin.read()
         else:
+            path = Path(self.args.filename)
             try:
-                with open(
-                    self.args.filename, encoding="utf-8", errors="ignore"
-                ) as job_file:
-                    data = job_file.read()
+                data = path.read_text(encoding="utf-8", errors="ignore")
+            except PermissionError:
+                sys.exit(f"File not readable: {path}")
             except FileNotFoundError:
-                sys.exit(f"File not found: {self.args.filename}")
+                sys.exit(f"File not found: {path}")
         job_dict = yaml.safe_load(data)
 
         # Check if agents are available to handle this queue

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -523,9 +523,10 @@ class TestflingerCli:
         if self.args.filename.name == "-":
             data = sys.stdin.read()
         else:
-            filename = Path(self.args.filename)
             try:
-                data = filename.read_text(encoding="utf-8", errors="ignore")
+                data = self.args.filename.read_text(
+                    encoding="utf-8", errors="ignore"
+                )
             except (PermissionError, FileNotFoundError) as error:
                 logger.exception(error)
                 sys.exit(1)

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -365,7 +365,7 @@ class TestflingerCli:
         parser.add_argument("--wait-for-available-agents", action="store_true")
         parser.add_argument(
             "filename",
-            type=str,
+            type=Path,
             help="YAML or JSON file with your job definition, '-' for stdin",
         ).completer = argcomplete.completers.FilesCompleter(
             allowednames=("*.yaml", "*.yml", "*.json")
@@ -520,7 +520,7 @@ class TestflingerCli:
 
     def submit(self):
         """Submit a new test job to the server"""
-        if self.args.filename == "-":
+        if self.args.filename.name == "-":
             data = sys.stdin.read()
         else:
             filename = Path(self.args.filename)

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -526,10 +526,9 @@ class TestflingerCli:
             filename = Path(self.args.filename)
             try:
                 data = filename.read_text(encoding="utf-8", errors="ignore")
-            except PermissionError:
-                sys.exit(f"File not readable: {filename}")
-            except FileNotFoundError:
-                sys.exit(f"File not found: {filename}")
+            except (PermissionError, FileNotFoundError) as error:
+                logger.exception(error)
+                sys.exit(1)
         job_dict = yaml.safe_load(data)
 
         # Check if agents are available to handle this queue

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -523,13 +523,13 @@ class TestflingerCli:
         if self.args.filename == "-":
             data = sys.stdin.read()
         else:
-            path = Path(self.args.filename)
+            filename = Path(self.args.filename)
             try:
-                data = path.read_text(encoding="utf-8", errors="ignore")
+                data = filename.read_text(encoding="utf-8", errors="ignore")
             except PermissionError:
-                sys.exit(f"File not readable: {path}")
+                sys.exit(f"File not readable: {filename}")
             except FileNotFoundError:
-                sys.exit(f"File not found: {path}")
+                sys.exit(f"File not found: {filename}")
         job_dict = yaml.safe_load(data)
 
         # Check if agents are available to handle this queue


### PR DESCRIPTION
## Description

Follow-up from #503.

It seems `-` is a valid argument for `testflinger-cli submit -`. This PR changes the argument type and adds some more error-handling to the `submit` function.

## Resolved issues

## Documentation

## Web service API changes

## Tests
