### PR TITLE
Fix type error during check initial log method

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -74,7 +74,7 @@ class DeviceConnector(ZapperConnector):
                 # Validate that it was provided.
                 run_stages = provision_plan["run_stage"]
                 for stage in run_stages:
-                    with contextlib.suppress(KeyError):
+                    with contextlib.suppress(KeyError, TypeError):
                         if (
                             stage["initial_login"].get("method")
                             == "console-conf"


### PR DESCRIPTION

## Description
Add TypeError to suppress due to not all
our stage is dict, some of them is string

## Resolved issues

Fix type error during check initial log method

## Documentation


## Web service API changes


## Tests
1. provision device with seed_override successfully 
2. provision device with uuu successfully 
