### PR TITLE
Update tf-cleanup to use environment variables provided by the charm

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
@@ -3,6 +3,16 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
-echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
-. /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE cleanup -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+# The following variables are set by the agent charm
+AGENT_CONFIGS_PATH={{ agent_configs_path }}
+CONFIG_DIR="{{ config_dir }}"
+VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
+
+if [ -d "$VIRTUAL_ENV_PATH" ]; then
+    echo Cleaning up container if it exists... && docker rm -f $agent_id || /bin/true
+    PYTHONUNBUFFERED=1 $VIRTUAL_ENV_PATH/bin/testflinger-device-connector $PROVISION_TYPE cleanup -c $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json
+else
+    echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+    . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE cleanup -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
+fi
 

--- a/agent/testflinger_agent/agent.py
+++ b/agent/testflinger_agent/agent.py
@@ -326,8 +326,12 @@ class TestflingerAgent:
             finally:
                 # Always run the cleanup, even if the job was cancelled
                 event_emitter.emit_event(TestEvent.CLEANUP_START)
-                job.run_test_phase(TestPhase.CLEANUP, rundir)
-                event_emitter.emit_event(TestEvent.CLEANUP_SUCCESS)
+                exit_code, _, _ = job.run_test_phase(TestPhase.CLEANUP, rundir)
+                if exit_code:
+                    logger.debug("Issue with cleanup phase")
+                    event_emitter.emit_event(TestEvent.CLEANUP_FAIL)
+                else:
+                    event_emitter.emit_event(TestEvent.CLEANUP_SUCCESS)
                 event_emitter.emit_event(TestEvent.JOB_END, job_end_reason)
                 # clear job id
                 self.client.post_agent_data({"job_id": ""})


### PR DESCRIPTION
## Description
This PR uses environment variables provided the agent charm to pass in the agent configuration to the device connector. This change was supposed to be included in #405, but it was seemingly accidentally dropped in #437. This prevents cleanup from knowing the provision type which means MAAS provisioned devices aren't being released during the cleanup phase.

This also includes a change to log errors with the cleanup phase in the agent.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves https://warthogs.atlassian.net/browse/CERTTF-518
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

