### PR TITLE
chore: Add charm libs check/update CI

### DIFF
--- a/.github/workflows/charm-update-libs.yml
+++ b/.github/workflows/charm-update-libs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-lib:
     strategy:
+      # Can't parallelize because the action uses the same branch for all charms
+      max-parallel: 1
       matrix:
         path: [server/charm, agent/charms/testflinger-agent-host-charm]
     name: Check libraries

--- a/.github/workflows/charm-update-libs.yml
+++ b/.github/workflows/charm-update-libs.yml
@@ -1,0 +1,17 @@
+name: Auto-update Charm Libraries
+on:
+  workflow_dispatch:
+  schedule:
+    # Checks regularly the upstream every four hours
+    - cron: "0 */4 * * *"
+
+jobs:
+  update-lib:
+    strategy:
+      matrix:
+        path: [server/charm, agent/charms/testflinger-agent-host-charm]
+    name: Check libraries
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v1
+    secrets: inherit
+    with:
+      charm-path: ${{ matrix.path }}


### PR DESCRIPTION
## Description

~~I'm fairly certain that this depends on #518 and #519, which add the library definitions to the `charmcraft.yaml`.~~ The necessary changes to the `charmcraft.yaml` files have landed.

- Add CI to ensure the charm libs are up to date (see https://github.com/canonical/observability)

> checks whether the charm libraries are up-to-date or not: if there is a new major version for a charm library, a GitHub issue is opened; if there's minor version updates, a PR is automatically created and (eventually, when CI passes) auto-merged;

## Resolved issues

- Resolves [CERTTF-559](https://warthogs.atlassian.net/browse/CERTTF-559)

I noticed in my last PRs (#518 and #519) that the libraries were out of date; we should make sure the charm libraries are up to date in a similar way that we check other dependency updates (i.e., in an automated CI).

## Documentation

## Web service API changes

## Tests


[CERTTF-559]: https://warthogs.atlassian.net/browse/CERTTF-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ