### PR TITLE
fix(server): Add reserve_data schema in server

### DIFF
--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -18,8 +18,7 @@ Testflinger v1 OpenAPI schemas
 """
 
 from apiflask import Schema, fields
-from apiflask.validators import OneOf
-
+from apiflask.validators import OneOf, Regexp
 
 ValidJobStates = (
     "setup",
@@ -95,6 +94,15 @@ class TestData(Schema):
     test_password = fields.String(required=False)
 
 
+class ReserveData(Schema):
+    """Schema for the `reserve_data` section of a Testflinger job."""
+
+    ssh_keys = fields.List(
+        fields.String(validate=Regexp(r"^(lp|gh):(\S+)$")), required=False
+    )
+    timeout = fields.Integer(required=False)
+
+
 class Job(Schema):
     """Job schema"""
 
@@ -114,7 +122,7 @@ class Job(Schema):
     firmware_update_data = fields.Dict(required=False)
     test_data = fields.Nested(TestData, required=False)
     allocate_data = fields.Dict(required=False)
-    reserve_data = fields.Dict(required=False)
+    reserve_data = fields.Nested(ReserveData, required=False)
     job_status_webhook = fields.String(required=False)
     job_priority = fields.Integer(required=False)
 


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
