### PR TITLE
chore(agent): Use operator-libs-linux passwd in agent-host charm

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -15,7 +15,7 @@ from common import run_with_logged_errors
 from git import Repo, GitCommandError
 from jinja2 import Template
 
-from charms.operator_libs_linux.v0 import apt
+from charms.operator_libs_linux.v0 import apt, passwd
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import (
@@ -197,8 +197,8 @@ class TestflingerAgentHostCharm(CharmBase):
         run_with_logged_errors(["supervisorctl", "signal", "USR1", "all"])
 
     def setup_docker(self):
-        run_with_logged_errors(["groupadd", "docker"])
-        run_with_logged_errors(["gpasswd", "-a", "ubuntu", "docker"])
+        passwd.add_group("docker")
+        passwd.add_user_to_group("ubuntu", "docker")
 
     def write_file(self, location, contents):
         with open(location, "w", encoding="utf-8", errors="ignore") as out:


### PR DESCRIPTION
## Description

- We already have `passwd` as a `charm-libs` dependency and within the repository, so we should use it over our check_output wrapper

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
