### PR TITLE
Add retries to the maas device connector to mitigate timeout issues

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -260,7 +260,7 @@ class Maas2:
             )
             if proc.returncode == 0:
                 return proc
-            
+
             if retry_count > max_retries:
                 self._logger_error(
                     (

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -258,27 +258,27 @@ class Maas2:
                 stderr=subprocess.STDOUT,
                 check=False,
             )
-            if proc.returncode:
-                if retry_count > max_retries:
-                    self._logger_error(
-                        (
-                            f"maas error running: {' '.join(cmd)}"
-                            "maximum retries reached"
-                        )
-                    )
-                    raise ProvisioningError(proc.stdout.decode())
-
-                timeout = backoff_start * 2**retry_count
-                self._logger_warning(
+            if proc.returncode == 0:
+                return proc
+            
+            if retry_count > max_retries:
+                self._logger_error(
                     (
                         f"maas error running: {' '.join(cmd)}"
-                        f"trying again in {timeout} seconds"
+                        "maximum retries reached"
                     )
                 )
-                time.sleep(timeout)
-                retry_count += 1
-            else:
-                return proc
+                raise ProvisioningError(proc.stdout.decode())
+
+            timeout = backoff_start * 2**retry_count
+            self._logger_warning(
+                (
+                    f"maas error running: {' '.join(cmd)}"
+                    f"trying again in {timeout} seconds"
+                )
+            )
+            time.sleep(timeout)
+            retry_count += 1
 
     def deploy_node(
         self, distro="bionic", kernel=None, user_data=None, storage_data=None

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -239,6 +239,39 @@ class Maas2:
             return True
         return False
 
+    def run_maas_cmd_with_retry(self, cmd):
+        """Run maas command up to 3 times on failure"""
+        retry_count = 0
+        while True:
+            proc = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+            if proc.returncode:
+                if retry_count > 5:
+                    self._logger_error(
+                        (
+                            f"maas error running: {' '.join(cmd)}",
+                            "maximum retries reached",
+                        )
+                    )
+                    raise ProvisioningError(proc.stdout.decode())
+                else:
+                    # Exponential backoff starting with 1 minute
+                    timeout = 60 * 2**retry_count
+                    self._logger_warning(
+                        (
+                            f"maas error running: {' '.join(cmd)}",
+                            f"trying again in {timeout} seconds",
+                        )
+                    )
+                    time.sleep(timeout)
+                    retry_count += 1
+            else:
+                return proc
+
     def deploy_node(
         self, distro="bionic", kernel=None, user_data=None, storage_data=None
     ):
@@ -285,12 +318,7 @@ class Maas2:
             "system_id={}".format(self.node_id),
         ]
         # Do not use runcmd for this - we need the output, not the end user
-        proc = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
-        )
-        if proc.returncode:
-            self._logger_error(f"maas error running: {' '.join(cmd)}")
-            raise ProvisioningError(proc.stdout.decode())
+        proc = self.run_maas_cmd_with_retry(cmd)
         self._logger_info(
             "Starting node {} "
             "with distro {}".format(self.agent_name, distro)
@@ -308,12 +336,7 @@ class Maas2:
         if user_data:
             data = base64.b64encode(user_data.encode()).decode()
             cmd.append("user_data={}".format(data))
-        proc = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
-        )
-        if proc.returncode:
-            self._logger_error(f"maas-cli error running: {' '.join(cmd)}")
-            raise ProvisioningError(proc.stdout.decode())
+        proc = self.run_maas_cmd_with_retry(cmd)
 
         # Make sure the device is available before returning
         minutes_spent = 0
@@ -384,12 +407,7 @@ class Maas2:
         """
         cmd = ["maas", self.maas_user, "machine", "read", self.node_id]
         # Do not use runcmd for this - we need the output, not the end user
-        proc = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
-        )
-        if proc.returncode:
-            self._logger_error(f"maas error running: {' '.join(cmd)}")
-            raise ProvisioningError(proc.stdout.decode())
+        proc = self.run_maas_cmd_with_retry(cmd)
         data = json.loads(proc.stdout.decode())
         return data.get("status_name")
 

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
@@ -46,7 +46,7 @@ def test_maas2_agent_invalid_storage(tmp_path):
 
 def test_maas_cmd_retry(tmp_path):
     """
-    Test that maas commands get retried 6 times when the command returns an
+    Test that maas commands get retried when the command returns an
     exit code
     """
     Process = namedtuple("Process", ["returncode", "stdout"])

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
@@ -72,7 +72,6 @@ class TestLVFSDevice(unittest.TestCase):
 
     def test_check_results_mismatched_version(self):
         """Validate version check in check_results"""
-        global device_results
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
         ) as mock_path:


### PR DESCRIPTION
## Description
This PR adds a new function to run maas commands that retry with an exponential backoff. It will retry commands up to 6 times, with timeouts of 1, 2, 4, 8, 16, and 32 minutes.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves https://warthogs.atlassian.net/browse/CERTTF-514
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Unit tests were added to test_maas.py
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
