### PR TITLE
fix(agent): Update tf-test to use ghcr.io testenv image

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -3,6 +3,12 @@
 AGENT=$(echo $agent_id | sed 's/-\([0-9]*\)$/\1/g')
 PROVISION_TYPE="$provision_type"
 
+# Variables for docker image
+REGISTRY=ghcr.io
+NAMESPACE=canonical/testflinger
+IMAGE_TAG=jammy
+IMAGE=testflinger-testenv
+
 # The following variables are set by the agent charm
 AGENT_CONFIGS_PATH={{ agent_configs_path }}
 CONFIG_DIR="{{ config_dir }}"
@@ -14,8 +20,13 @@ if [ -d "$VIRTUAL_ENV_PATH" ]; then
         -v ~/.ssh:/home/ubuntu/.ssh:ro \
         -v /srv/testflinger:/srv/testflinger \
         -v $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id:$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id \
-        plars/testflinger-testenv-focal \
+        $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \
         bash -c "(cd /srv/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json"
 else
-    docker run -t --name $AGENT -v $PWD:/home/ubuntu -v ~/.ssh:/home/ubuntu/.ssh:ro -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT plars/testflinger-testenv-focal bash -c "(cd /srv/testflinger-agent/$AGENT/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json"
+    docker run -t --name $AGENT \
+        -v $PWD:/home/ubuntu \
+        -v ~/.ssh:/home/ubuntu/.ssh:ro \
+        -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT \
+        $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \
+        bash -c "(cd /srv/testflinger-agent/$AGENT/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json"
 fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -5,9 +5,9 @@ PROVISION_TYPE="$provision_type"
 
 # Variables for docker image
 REGISTRY=ghcr.io
-NAMESPACE=canonical/testflinger
+NAMESPACE=canonical
 IMAGE_TAG=jammy
-IMAGE=testflinger-testenv
+IMAGE=testflinger/testflinger-testenv
 
 # The following variables are set by the agent charm
 AGENT_CONFIGS_PATH={{ agent_configs_path }}

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -6,7 +6,7 @@ PROVISION_TYPE="$provision_type"
 # Variables for docker image
 REGISTRY=ghcr.io
 NAMESPACE=canonical
-IMAGE_TAG=jammy
+IMAGE_TAG=focal
 IMAGE=testflinger/testflinger-testenv
 
 # The following variables are set by the agent charm


### PR DESCRIPTION
## Description

- The agent host charm's `tf-test` script still uses the old focal testenv image under Paul's name; this PR updates the script to use the focal image from the ghcr.io container registry.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

- Mock test by running the script in a VM (to make sure we can pull and run the image at the very least):

```
ubuntu@zealous-mongrel:~/testflinger/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts$ sudo ./tf-test
./tf-test: line 13: agent_configs_path: command not found
Unable to find image 'ghcr.io/canonical/testflinger/testflinger-testenv:focal' locally
focal: Pulling from canonical/testflinger/testflinger-testenv
d9802f032d67: Pull complete
5fe955cbf23a: Pull complete
4f0a521e827d: Pull complete
d1f780c54225: Pull complete
425813a827d8: Pull complete
4f4fb700ef54: Pull complete
Digest: sha256:1fdc5dca645676ab35af6e8f8941c573274d1ef06416ab54af0e59d6dcd7d0b4
Status: Downloaded newer image for ghcr.io/canonical/testflinger/testflinger-testenv:focal
hello
```

<details>
<summary>Modified script for test</summary>
<br />

```shell
#!/bin/bash

AGENT=test_agent
PROVISION_TYPE="$provision_type"

# Variables for docker image
REGISTRY=ghcr.io
NAMESPACE=canonical
IMAGE_TAG=focal
IMAGE=testflinger/testflinger-testenv

# The following variables are set by the agent charm
AGENT_CONFIGS_PATH={{ agent_configs_path }}
CONFIG_DIR="{{ config_dir }}"
VIRTUAL_ENV_PATH="{{ virtual_env_path }}"

if [ -d "$VIRTUAL_ENV_PATH" ]; then
    docker run -t --name test_agent \
        -v $PWD:/home/ubuntu \
        -v ~/.ssh:/home/ubuntu/.ssh:ro \
        $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \
        bash -c "echo hello"
else
    docker run -t --name $AGENT \
        -v $PWD:/home/ubuntu \
        -v ~/.ssh:/home/ubuntu/.ssh:ro \
        -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT \
        $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \
        bash -c "echo hello"
fi
```

</details>

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
