### PR TITLE
feat(server): Define `provision_data` schema

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "requests>=2.31.0",
     "sentry-sdk>= 2.0.1",
     "urllib3>=2.2.1",
+    "marshmallow-oneofschema>=3.1.1",
 ]
 
 [project.scripts]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -30,9 +30,7 @@ dependencies = [
 client_credentials_admin = "testflinger.tools.client_credentials_admin:main"
 
 [dependency-groups]
-charm = [
-    "ops>=2.2.0",
-]
+charm = ["ops>=2.2.0"]
 dev = [
     "black>=24.8.0",
     "cosl>=0.0.57",

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -83,6 +83,60 @@ class Attachment(Schema):
     device = fields.String(required=False)
 
 
+class ProvisionData(Schema):
+    """Schema for the `provision_data` section of a Testflinger job."""
+
+    url = fields.URL(required=False)
+    distro = fields.String(required=False)
+    kernel = fields.String(required=False)
+
+    attachments = fields.List(fields.Nested(Attachment), required=False)
+    use_attachment = fields.String(required=False)
+
+    user_data = fields.String(required=False)
+    ubuntu_sso_email = fields.Email(required=False)
+
+    # OEM Autoinstall specific fields
+    authorized_keys = fields.String(required=False)
+    redeploy_cfg = fields.String(required=False)
+    token_file = fields.String(required=False)
+
+    # MuxPi specific fields
+    boot_check_url = fields.String(required=False)
+    create_user = fields.Boolean(required=False)
+    media = fields.String(required=False)
+
+    # MAAS specific fields
+    # [TODO] Specify Nested schema to improve validation
+    disks = fields.List(fields.Dict(), required=False)
+
+    # Multi-device specific fields
+    # [TODO] Specify Nested schema to improve validation
+    jobs = fields.List(fields.Dict(), required=False)
+
+    # Zapper specific fields
+    zapper_provisioning_timeout = fields.Integer(required=False)
+
+    # Zapper IOT specific fields
+    preset = fields.String(required=False)
+    # [TODO] Specify Nested schema to improve validation
+    provision_plan = fields.Dict(required=False)
+    urls = fields.List(fields.URL(), required=False)
+
+    # Zapper KVM specific fields
+    alloem_url = fields.URL(required=False)
+    autoinstall_base_user_data = fields.String(required=False)
+    autoinstall_oem = fields.Boolean(required=False)
+    autoinstall_storage_layout = fields.String(required=False)
+    cmdline_append = fields.String(required=False)
+    live_image = fields.Boolean(required=False)
+    oem = fields.String(required=False)
+    robot_retries = fields.Integer(required=False)
+    robot_tasks = fields.List(fields.String(), required=False)
+    skip_download = fields.Boolean(required=False)
+    wait_until_ssh = fields.Boolean(required=False)
+
+
 class TestData(Schema):
     """Schema for the `test_data` section of a testflinger job"""
 
@@ -114,9 +168,7 @@ class Job(Schema):
     global_timeout = fields.Integer(required=False)
     output_timeout = fields.Integer(required=False)
     allocation_timeout = fields.Integer(required=False)
-    # [TODO] specify Nested schema to improve validation,
-    # i.e. expected fields within `provision_data`
-    provision_data = fields.Dict(required=False)
+    provision_data = fields.Nested(ProvisionData, required=False)
     # [TODO] specify Nested schema to improve validation,
     # i.e. expected fields within `firmware_update_data`
     firmware_update_data = fields.Dict(required=False)

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -240,9 +240,11 @@ class ProvisionData(OneOfSchema):
                 continue
         raise ValidationError("Invalid provision data schema.")
 
-    def _dump(self, obj, *, update_fields=True, **kwargs):
-        """Removes the type field from the result."""
-        result = super()._dump(obj, update_fields=update_fields, **kwargs)
+    def _dump(self, obj, **kwargs):
+        result = super()._dump(obj, **kwargs)
+        # Parent dump injects the type field:
+        #   result[self.type_field] = self.get_obj_type(obj)
+        # So we need to remove it
         result.pop(self.type_field)
         return result
 

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -154,7 +154,7 @@ class ZapperIoTPresetProvisionData(BaseZapperProvisionData):
     This schema is used when using a preset for provisioning.
     """
 
-    urls = fields.List(fields.URL(), required=True)
+    urls = fields.List(fields.URL(), required=True, validate=Length(min=1))
     preset = fields.String(required=True)
 
 
@@ -164,7 +164,7 @@ class ZapperIoTCustomProvisionData(BaseZapperProvisionData):
     This schema is used when using a custom plan for provisioning.
     """
 
-    urls = fields.List(fields.URL(), required=True)
+    urls = fields.List(fields.URL(), required=True, validate=Length(min=1))
     ubuntu_sso_email = fields.Email(required=False)
     # [TODO] Specify Nested schema to improve validation
     provision_plan = fields.Dict(required=True)

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -120,7 +120,7 @@ class MuxPiProvisionData(Schema):
     @validates_schema
     def validate_image(self, data, **_):
         """Validate that either `url` or `use_attachment` is provided."""
-        if not data.get("url") and not data.get("use_attachment"):
+        if "url" not in data and "use_attachment" not in data:
             raise ValidationError(
                 "Either 'url' or 'use_attachment' must be provided."
             )

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -113,6 +113,7 @@ class MuxPiProvisionData(Schema):
 
     url = fields.URL(required=False)
     use_attachment = fields.String(required=False)
+    attachments = fields.List(fields.Nested(Attachment), required=False)
     create_user = fields.Boolean(required=False)
     boot_check_url = fields.String(required=False)
     media = fields.String(validate=OneOf(["sd", "usb"]), required=False)

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -421,7 +421,10 @@ def test_job_get_result_no_data(mongo_app):
 def test_job_get_id_with_data(mongo_app):
     """Test getting the json for a job that has been submitted"""
     app, _ = mongo_app
-    job_data = {"job_queue": "test", "provision_data": {"url": "test"}}
+    job_data = {
+        "job_queue": "test",
+        "provision_data": {"url": "https://example.com/image.img.xz"},
+    }
     # Place a job on the queue
     output = app.post("/v1/job", json=job_data)
     job_id = output.json.get("job_id")

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -117,20 +117,20 @@ def test_add_job_valid_reserve_data(mongo_app):
 def test_add_job_invalid_provision_data(mongo_app):
     """Test that a job with an invalid provision_data field fails"""
     # Invalid URL fails
-    reserve_data = {"url": "invalid_url"}
-    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    provision_data = {"url": "invalid_url"}
+    job_data = {"job_queue": "test", "reserve_data": provision_data}
     app, _ = mongo_app
     output = app.post("/v1/job", json=job_data)
     assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
     # Invalid email fails
-    reserve_data = {"ubuntu_sso_email": "invalid_email"}
-    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    provision_data = {"ubuntu_sso_email": "invalid_email"}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
     app, _ = mongo_app
     output = app.post("/v1/job", json=job_data)
     assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
     # Invalid attachments fails
-    reserve_data = {"attachments": [{"invalid": "filename"}]}
-    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    provision_data = {"attachments": [{"invalid": "filename"}]}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
     app, _ = mongo_app
     output = app.post("/v1/job", json=job_data)
     assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
@@ -139,23 +139,23 @@ def test_add_job_invalid_provision_data(mongo_app):
 def test_add_job_valid_provision_data(mongo_app):
     """Test that a job with a valid provision_data field works"""
     # Valid URL succeeds
-    reserve_data = {"url": "http://example.com/image.img.xz"}
-    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    provision_data = {"url": "http://example.com/image.img.xz"}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
     app, _ = mongo_app
     output = app.post("/v1/job", json=job_data)
-    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    assert HTTPStatus.OK == output.status_code
     # Valid email succeeds
-    reserve_data = {"ubuntu_sso_email": "noreply@ubuntu.com"}
-    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    provision_data = {"ubuntu_sso_email": "noreply@ubuntu.com"}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
     app, _ = mongo_app
     output = app.post("/v1/job", json=job_data)
-    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    assert HTTPStatus.OK == output.status_code
     # Valid attachments succeeds
-    reserve_data = {"attachments": [{"agent": "filename"}]}
-    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    provision_data = {"attachments": [{"agent": "filename"}]}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
     app, _ = mongo_app
     output = app.post("/v1/job", json=job_data)
-    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    assert HTTPStatus.OK == output.status_code
 
 
 def test_add_job_good(mongo_app):

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+# pylint: disable=C0302
 """
 Unit tests for Testflinger v1 API
 """

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -222,6 +222,163 @@ def test_add_job_muxpi_provision_data(mongo_app):
     assert HTTPStatus.OK == output.status_code
 
 
+def test_add_job_oem_autoinstall_provision_data(mongo_app):
+    """Test that a job with oem_autoinstall provision_data works."""
+    # Invalid URL fails
+    provision_data = {"url": "invalid", "token_file": "file"}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Valid URL fails
+    provision_data = {
+        "url": "http://example.com/image.img.xz",
+        "token_file": "file",
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+
+
+def test_add_job_oem_script_provision_data(mongo_app):
+    """Test that a job with oem_script provision_data works."""
+    # Invalid URL fails
+    provision_data = {"url": "invalid"}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Valid URL fails
+    provision_data = {"url": "http://example.com/image.img.xz"}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+
+
+def test_add_job_zapper_iot_preset_provision_data(mongo_app):
+    """Test that a job with zapper_iot_preset provision_data works."""
+    # Empty URLs fails
+    provision_data = {"urls": [], "preset": ""}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Invalid URLs fails
+    provision_data = {"urls": ["invalid"], "preset": ""}
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Valid provision_data works
+    provision_data = {
+        "urls": ["http://example.com/image.img.xz"],
+        "preset": "fake",
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+
+
+def test_add_job_zapper_iot_custom_provision_data(mongo_app):
+    """Test that a job with zapper_iot_custom provision_data works."""
+    # Empty URLs fails
+    provision_data = {
+        "urls": [],
+        "provision_plan": {},
+        "ubuntu_sso_email": "test@example.com",
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # [TODO] Add validation for provision_plan
+    # Valid job works
+    provision_data = {
+        "urls": ["http://example.com/image.img.xz"],
+        "provision_plan": {},
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+
+
+def test_add_job_zapper_kvm_autoinstall_provision_data(mongo_app):
+    """Test that a job with zapper_kvm_autoinstall provision_data works."""
+    # Invalid URL fails
+    provision_data = {
+        "url": "invalid",
+        "robot_tasks": ["task"],
+        "autoinstall_storage_layout": "lvm",
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Valid provision_data works
+    provision_data = {
+        "url": "http://example.com/image.img.xz",
+        "robot_tasks": ["task"],
+        "autoinstall_storage_layout": "lvm",
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+
+
+def test_add_job_zapper_kvm_oem_2204_provision_data(mongo_app):
+    """Test that a job with zapper_kvm_oem_2204 provision_data works."""
+    # Invalid URL fails
+    provision_data = {
+        "alloem_url": "invalid",
+        "robot_tasks": ["task"],
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # oem field works
+    provision_data = {
+        "alloem_url": "http://example.com/image.img.xz",
+        "robot_tasks": ["task"],
+        "oem": "dell",
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+
+
+def test_add_job_zapper_kvm_generic_provision_data(mongo_app):
+    """Test that a job with zapper_kvm_generic provision_data works."""
+    # Invalid URL fails
+    provision_data = {
+        "url": "invalid",
+        "robot_tasks": ["task"],
+        "live_image": False,
+        "wait_until_ssh": False,
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Valid provision_data works
+    provision_data = {
+        "url": "http://example.com/image.img.xz",
+        "robot_tasks": ["task"],
+        "live_image": False,
+        "wait_until_ssh": False,
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+
+
 def test_add_job_good(mongo_app):
     """Test that adding a new job works"""
     job_data = {"job_queue": "test", "tags": ["foo", "bar"]}

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -20,6 +20,7 @@ Unit tests for Testflinger v1 API
 import json
 import os
 from datetime import datetime
+from http import HTTPStatus
 from io import BytesIO
 
 from testflinger.api import v1
@@ -111,6 +112,50 @@ def test_add_job_valid_reserve_data(mongo_app):
     app, _ = mongo_app
     output = app.post("/v1/job", json=job_data)
     assert 200 == output.status_code
+
+
+def test_add_job_invalid_provision_data(mongo_app):
+    """Test that a job with an invalid provision_data field fails"""
+    # Invalid URL fails
+    reserve_data = {"url": "invalid_url"}
+    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Invalid email fails
+    reserve_data = {"ubuntu_sso_email": "invalid_email"}
+    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Invalid attachments fails
+    reserve_data = {"attachments": [{"invalid": "filename"}]}
+    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+
+
+def test_add_job_valid_provision_data(mongo_app):
+    """Test that a job with a valid provision_data field works"""
+    # Valid URL succeeds
+    reserve_data = {"url": "http://example.com/image.img.xz"}
+    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Valid email succeeds
+    reserve_data = {"ubuntu_sso_email": "noreply@ubuntu.com"}
+    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+    # Valid attachments succeeds
+    reserve_data = {"attachments": [{"agent": "filename"}]}
+    job_data = {"job_queue": "test", "reserve_data": reserve_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
 
 
 def test_add_job_good(mongo_app):

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -833,6 +833,18 @@ wheels = [
 ]
 
 [[package]]
+name = "marshmallow-oneofschema"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/75/8dd134f08375845910d134e50246fdfcab3f1d84ab3284bd09bb15f69be9/marshmallow_oneofschema-3.1.1.tar.gz", hash = "sha256:68b4a57d0281a04ac25d4eb7a4c5865a57090a0a8fd30fd6362c8e833ac6a6d9", size = 8684 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/81/3ef15337c19d3e3432945aad738081a5f54c16885277c7dff300b5f85b24/marshmallow_oneofschema-3.1.1-py3-none-any.whl", hash = "sha256:ff4cb2a488785ee8edd521a765682c2c80c78b9dc48894124531bdfa1ec9303b", size = 5726 },
+]
+
+[[package]]
 name = "mccabe"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1375,6 +1387,7 @@ dependencies = [
     { name = "flask-pymongo" },
     { name = "gevent" },
     { name = "gunicorn" },
+    { name = "marshmallow-oneofschema" },
     { name = "prometheus-client" },
     { name = "prometheus-flask-exporter" },
     { name = "pyjwt" },
@@ -1410,6 +1423,7 @@ requires-dist = [
     { name = "flask-pymongo", specifier = ">=3.0.0" },
     { name = "gevent", specifier = ">=24.2.1" },
     { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "marshmallow-oneofschema", specifier = ">=3.1.1" },
     { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "prometheus-flask-exporter", specifier = ">=0.23.1" },
     { name = "pyjwt", specifier = ">=2.8.0" },


### PR DESCRIPTION
## Description

- Add `marshmallow-oneofschema` dependency
- Define the `provision_data` section of the job schema as a nested schema
- Define separate schemas for the supported device connectors

## Resolved issues

- Resolves [CERTTF-546](https://warthogs.atlassian.net/browse/CERTTF-546)

## Documentation

## Web service API changes

## Tests

Added unit tests


[CERTTF-546]: https://warthogs.atlassian.net/browse/CERTTF-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ