### PR TITLE
Add health check to pebble configuration

### DIFF
--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -41,6 +41,7 @@ class TestflingerCharm(ops.CharmBase):
         """Initialize the charm"""
         super().__init__(*args)
         self.pebble_service_name = "testflinger"
+        self.pebble_check_name = "v1_up"
         self.container = self.unit.get_container("testflinger")
         self._stored.set_default(
             reldata={},
@@ -177,6 +178,17 @@ class TestflingerCharm(ops.CharmBase):
         pebble_layer = {
             "summary": "Testflinger server",
             "description": "pebble config layer for Testflinger server",
+            "checks": {
+                self.pebble_check_name: {
+                    "override": "replace",
+                    "period": "10s",
+                    "timeout": "3s",
+                    "threshold": 5,
+                    "http": {
+                        "url": "0.0.0.0:5000/v1/",
+                    },
+                }
+            },
             "services": {
                 self.pebble_service_name: {
                     "override": "replace",
@@ -184,6 +196,9 @@ class TestflingerCharm(ops.CharmBase):
                     "command": command,
                     "startup": "enabled",
                     "environment": self.app_environment,
+                    "on-check-failure": {
+                        self.pebble_check_name: "restart",
+                    },
                 }
             },
         }

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -173,6 +173,10 @@ class TestflingerCharm(ops.CharmBase):
                 "--bind",
                 "0.0.0.0:5000",
                 "testflinger:app",
+                "--access-logfile",
+                "-",
+                "--error-logfile",
+                "-",
             ]
         )
         pebble_layer = {
@@ -185,7 +189,7 @@ class TestflingerCharm(ops.CharmBase):
                     "timeout": "3s",
                     "threshold": 5,
                     "http": {
-                        "url": "0.0.0.0:5000/v1/",
+                        "url": "http://0.0.0.0:5000/v1/",
                     },
                 }
             },


### PR DESCRIPTION
## Description
There has been some intermittent issues where one of the deployed server units becomes unresponsive but does not crash. This causes `juju status` to report that the unit is healthy, and requests sent to that unit end up timing out. Pebble has the ability to add [health checks](https://documentation.ubuntu.com/pebble/how-to/run-services-reliably/) to running services that can periodically check whether the service is responsive. This PR adds a health check that pings localhost:5000/v1/ every 10 seconds, timing out after 3 seconds. If this ping fails more than 5 times, the pebble service will automatically restart.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Deployed these changes on staging. `/charm/bin/pebble checks` shows the `v1_up` check.
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
