### PR TITLE
fix(ci): Fix charm-update-libs.yml

### DIFF
--- a/.github/workflows/charm-update-libs.yml
+++ b/.github/workflows/charm-update-libs.yml
@@ -8,14 +8,17 @@ on:
 jobs:
   update-lib:
     strategy:
-      # Can't parallelize because the action uses the same branch for all charms
-      max-parallel: 1
       matrix:
-        path: [server/charm, agent/charms/testflinger-agent-host-charm]
+        include:
+          - charm-path: server/charm
+            git-branch: chore/auto-libs-server
+          - charm-path: agent/charms/testflinger-agent-host-charm
+            git-branch: chore/auto-libs-agent
     name: Check libraries
     uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v1
     secrets: inherit
     with:
-      charm-path: ${{ matrix.path }}
+      charm-path: ${{ matrix.charm-path }}
+      git-branch: ${{ matrix.git-branch }}
       commit-username: Canonical-Certification-Bot
       commit-email: solutions-qa@lists.canonical.com


### PR DESCRIPTION
## Description

- The workflow right now overrides the same branch, we need a different branch per charm
- Depends on https://github.com/canonical/observability/pull/291

## Resolved issues

- Resolves [CERTTF-596](https://warthogs.atlassian.net/browse/CERTTF-596)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-596]: https://warthogs.atlassian.net/browse/CERTTF-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ