### PR TITLE
Fix: add retries when trying to copy the agent SSH key

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/tests/test_devices.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/tests/test_devices.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2025 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for DefaultDevice base device connector."""
+
+import subprocess
+import unittest
+from unittest.mock import Mock, call, patch
+
+from testflinger_device_connectors.devices import DefaultDevice
+
+
+class DefaultDeviceTests(unittest.TestCase):
+    """Unit tests for DefaultDevice class."""
+
+    @patch("subprocess.check_call")
+    def test_copy_ssh_id(self, mock_check):
+        """
+        Test whether the function copies the agent's SSH key
+        to the DUT.
+        """
+
+        connector = DefaultDevice()
+        connector.copy_ssh_key(
+            "192.168.1.2",
+            "username",
+            "password",
+        )
+
+        cmd = (
+            "sshpass -p password ssh-copy-id -f"
+            + " -o StrictHostKeyChecking=no"
+            + " -o UserKnownHostsFile=/dev/null username@192.168.1.2"
+        )
+        mock_check.assert_called_once_with(cmd.split(), timeout=30)
+
+    @patch("subprocess.check_call")
+    def test_copy_ssh_id_with_key(self, mock_check):
+        """
+        Test whether the function copies the provided key
+        to the DUT.
+        """
+
+        connector = DefaultDevice()
+        connector.copy_ssh_key(
+            "192.168.1.2",
+            "username",
+            key="key.pub",
+        )
+
+        cmd = (
+            "ssh-copy-id -f"
+            + " -i key.pub"
+            + " -o StrictHostKeyChecking=no"
+            + " -o UserKnownHostsFile=/dev/null username@192.168.1.2"
+        )
+        mock_check.assert_called_once_with(cmd.split(), timeout=30)
+
+    @patch("time.sleep", Mock())
+    @patch("subprocess.check_call")
+    def test_copy_ssh_id_raises(self, mock_check):
+        """
+        Test whether the function raises a RuntimeError
+        exception after 3 failed attempts.
+        """
+
+        connector = DefaultDevice()
+        connector = DefaultDevice()
+
+        mock_check.side_effect = subprocess.CalledProcessError(1, "")
+
+        with self.assertRaises(RuntimeError):
+            connector.copy_ssh_key(
+                "192.168.1.2",
+                "username",
+                "password",
+            )
+
+        cmd = (
+            "sshpass -p password ssh-copy-id -f"
+            + " -o StrictHostKeyChecking=no"
+            + " -o UserKnownHostsFile=/dev/null username@192.168.1.2"
+        )
+        expected = call(cmd.split(), timeout=30)
+        mock_check.assert_has_calls(10 * [expected])

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -23,8 +23,6 @@ validating the configuration and preparing the API arguments.
 
 import json
 import logging
-import subprocess
-import time
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Tuple
 
@@ -122,31 +120,16 @@ class ZapperConnector(ABC, DefaultDevice):
             test_username = "ubuntu"
             test_password = "ubuntu"
 
-        cmd = [
-            "sshpass",
-            "-p",
-            test_password,
-            "ssh-copy-id",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            f"{test_username}@{self.config['device_ip']}",
-        ]
-
-        for _ in range(3):
-            try:
-                subprocess.check_call(cmd, timeout=60)
-                break
-            except (
-                subprocess.CalledProcessError,
-                subprocess.TimeoutExpired,
-            ):
-                time.sleep(30)
-        else:
+        try:
+            self.copy_ssh_key(
+                self.config["device_ip"],
+                test_username,
+                test_password,
+            )
+        except RuntimeError as e:
             raise ProvisioningError(
                 "Cannot copy the agent's SSH key to the DUT",
-            )
+            ) from e
 
     @abstractmethod
     def _post_run_actions(self, args):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -13,9 +13,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for Zapper base device connector."""
 
-
+import subprocess
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, call, patch
+
+from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.zapper import (
     ZapperConnector,
     logger,
@@ -55,3 +57,56 @@ class ZapperConnectorTests(unittest.TestCase):
             logger=logger,
             **kwargs,
         )
+
+    @patch("subprocess.check_call")
+    def test_copy_ssh_id(self, mock_check):
+        """
+        Test whether the function copies the agent's SSH key
+        to the DUT.
+        """
+
+        connector = MockConnector()
+        connector.config = {"device_ip": "192.168.1.2"}
+        connector.job_data = {
+            "test_data": {
+                "test_username": "username",
+                "test_password": "password",
+            },
+        }
+        connector._copy_ssh_id()
+
+        cmd = (
+            "sshpass -p password ssh-copy-id"
+            + " -o StrictHostKeyChecking=no"
+            + " -o UserKnownHostsFile=/dev/null username@192.168.1.2"
+        )
+        mock_check.assert_called_once_with(cmd.split(), timeout=60)
+
+    @patch("time.sleep", Mock())
+    @patch("subprocess.check_call")
+    def test_copy_ssh_id_raises(self, mock_check):
+        """
+        Test whether the function raises a ProvisioningError
+        exception after 3 failed attempts.
+        """
+
+        connector = MockConnector()
+        connector.config = {"device_ip": "192.168.1.2"}
+        connector.job_data = {
+            "test_data": {
+                "test_username": "username",
+                "test_password": "password",
+            },
+        }
+        mock_check.side_effect = subprocess.CalledProcessError(1, "")
+
+        with self.assertRaises(ProvisioningError):
+            connector._copy_ssh_id()
+
+        cmd = (
+            "sshpass -p password ssh-copy-id"
+            + " -o StrictHostKeyChecking=no"
+            + " -o UserKnownHostsFile=/dev/null username@192.168.1.2"
+        )
+        expected = call(cmd.split(), timeout=60)
+        mock_check.assert_has_calls(3 * [expected])


### PR DESCRIPTION
## Description

This action might fail from time to time, especially with low-spec devices which might still be adjusting at this point. Adding retries to be a bit more robust.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

None

## Tests

Added!
