### PR TITLE
Allow trailing slash in Testflinger routes

### DIFF
--- a/server/src/application.py
+++ b/server/src/application.py
@@ -41,6 +41,10 @@ except ImportError:
 def create_flask_app(config=None):
     """Create the flask app"""
     tf_app = APIFlask(__name__)
+
+    # Globally disable strict slashes
+    tf_app.url_map.strict_slashes = False
+
     if config:
         tf_app.config.from_object(config)
     tf_log = create_logger(tf_app)


### PR DESCRIPTION
## Description
Allow trailing slash globally in application routes eg.
https://testflinger.canonical.com/queues/
https://testflinger.canonical.com/jobs/

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Github:
#89 
#340 

Jira:
https://warthogs.atlassian.net/browse/CERTTF-488
https://warthogs.atlassian.net/browse/CERTTF-390

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
This has been tested locally in a dev environment. 

**Before disabling strict slashes**
![Screenshot from 2025-04-15 10-24-48](https://github.com/user-attachments/assets/c783ab74-0f71-4b49-8732-62738c29be14)

Adding trailing slash leads to 404:
![Screenshot from 2025-04-15 10-24-26](https://github.com/user-attachments/assets/ca904f51-055b-45eb-b4e3-558bd1256a56)

**After disabling strict slashes globally**
![Screenshot from 2025-04-15 10-27-41](https://github.com/user-attachments/assets/924f2cd6-966f-4bb7-b27a-0523edfe67b0)

Route is now accessible with a trailing slash
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
