### PR TITLE
chore: Fix test warnings

### DIFF
--- a/cli/testflinger_cli/tests/test_cli.py
+++ b/cli/testflinger_cli/tests/test_cli.py
@@ -326,7 +326,7 @@ def test_submit_with_attachments(tmp_path):
         with tarfile.open("attachments.tar.gz") as attachments:
             filenames = attachments.getnames()
             assert len(filenames) == 1
-            attachments.extract(filenames[0])
+            attachments.extract(filenames[0], filter="data")
         with open(filenames[0], "r", encoding="utf-8") as attachment:
             assert json.load(attachment) == job_data
 

--- a/server/src/api/schemas.py
+++ b/server/src/api/schemas.py
@@ -136,14 +136,19 @@ class JobId(Schema):
 class JobSearchRequest(Schema):
     """Job search request schema"""
 
-    tags = fields.List(fields.String, description="List of tags to search for")
+    tags = fields.List(
+        fields.String,
+        metadata={"description": "List of tags to search for"},
+    )
     match = fields.String(
-        description="Match mode - 'all' or 'any' (default 'any')",
         validate=OneOf(["any", "all"]),
+        metadata={
+            "description": "Match mode - 'all' or 'any' (default 'any')"
+        },
     )
     state = fields.List(
         fields.String(validate=OneOf(ValidJobStates)),
-        description="List of job states to include",
+        metadata={"description": "List of job states to include"},
     )
 
 

--- a/server/src/api/v1.py
+++ b/server/src/api/v1.py
@@ -17,26 +17,24 @@
 Testflinger v1 API
 """
 
+import importlib.metadata
 import os
 import uuid
-from datetime import datetime, timezone, timedelta
-import pkg_resources
+from datetime import datetime, timedelta, timezone
+
+import bcrypt
+import jwt
+import requests
 from apiflask import APIBlueprint, abort
 from flask import jsonify, request, send_file
 from prometheus_client import Counter
-
-from werkzeug.exceptions import BadRequest
-
-import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-
-import jwt
-import bcrypt
+from werkzeug.exceptions import BadRequest
 
 from src import database
-from . import schemas
 
+from . import schemas
 
 jobs_metric = Counter(
     "jobs", "Number of jobs", ["queue"], namespace="testflinger"
@@ -61,8 +59,8 @@ def home():
 def get_version():
     """Return the Testflinger version"""
     try:
-        version = pkg_resources.get_distribution("testflinger").version
-    except pkg_resources.DistributionNotFound:
+        version = importlib.metadata.version("testflinger")
+    except importlib.metadata.PackageNotFoundError:
         version = "devel"
     return f"Testflinger Server v{version}"
 
@@ -494,7 +492,7 @@ def output_post(job_id):
     if not check_valid_uuid(job_id):
         abort(400, message="Invalid job_id specified")
     data = request.get_data().decode("utf-8")
-    timestamp = datetime.utcnow()
+    timestamp = datetime.now(timezone.utc)
     database.mongo.db.output.update_one(
         {"job_id": job_id},
         {"$set": {"updated_at": timestamp}, "$push": {"output": data}},
@@ -535,7 +533,7 @@ def serial_output_post(job_id):
     if not check_valid_uuid(job_id):
         abort(400, message="Invalid job_id specified")
     data = request.get_data().decode("utf-8")
-    timestamp = datetime.utcnow()
+    timestamp = datetime.now(timezone.utc)
     database.mongo.db.serial_output.update_one(
         {"job_id": job_id},
         {"$set": {"updated_at": timestamp}, "$push": {"serial_output": data}},
@@ -664,7 +662,7 @@ def agents_post(agent_name, json_data):
     """
 
     json_data["name"] = agent_name
-    json_data["updated_at"] = datetime.utcnow()
+    json_data["updated_at"] = datetime.now(timezone.utc)
     # extract log from data so we can push it instead of setting it
     log = json_data.pop("log", [])
 
@@ -848,7 +846,7 @@ def generate_token(allowed_resources, secret_key):
     See retrieve_token for more information on the contents of
     the token payload
     """
-    expiration_time = datetime.utcnow() + timedelta(seconds=30)
+    expiration_time = datetime.now(timezone.utc) + timedelta(seconds=30)
     token_payload = {
         "exp": expiration_time,
         "iat": datetime.now(timezone.utc),  # Issued at time

--- a/server/tests/test_v1_authorization.py
+++ b/server/tests/test_v1_authorization.py
@@ -18,9 +18,9 @@ Unit tests for Testflinger v1 API relating to job priority and
 restricted queues
 """
 
-from datetime import datetime, timedelta
-import os
 import base64
+import os
+from datetime import datetime, timedelta, timezone
 
 import jwt
 
@@ -144,8 +144,8 @@ def test_priority_expired_token(mongo_app_with_permissions):
     app, _, _, _, _ = mongo_app_with_permissions
     secret_key = os.environ.get("JWT_SIGNING_KEY")
     expired_token_payload = {
-        "exp": datetime.utcnow() - timedelta(seconds=2),
-        "iat": datetime.utcnow() - timedelta(seconds=4),
+        "exp": datetime.now(timezone.utc) - timedelta(seconds=2),
+        "iat": datetime.now(timezone.utc) - timedelta(seconds=4),
         "sub": "access_token",
         "permissions": {
             "max_priority": {},


### PR DESCRIPTION
## Description

- Fixes `datetime.utcnow` calls
- Fixes deprecation warning with `pkg_resources` --> `importlib.metadata`
- Fixes warning with `tarfile.extract`
- Fixes warnings in marshmallow schema definitions using kwargs to define metadata

## Resolved issues

Resolves #542

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
