### PR TITLE
update: reset the efi before releasing the machine

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -66,6 +66,8 @@ class Maas2:
         logger.critical("MAAS: {}".format(message))
 
     def recover(self):
+        if self.config.get("reset_efi"):
+            self.reset_efi()
         self._logger_info("Releasing node {}".format(self.agent_name))
         self.node_release()
         self._logger_info(


### PR DESCRIPTION
## Description

For most machines in TEL using MAAS provisioning, the boot order is modified during the oem-image installation process.
Previously `reset_efi` was executed at the beginning of provisioning, However, since the machine is now released after the test run, there is no opportunity to reset the boot order at the start.
Therefore, I propose this change.

## Resolved issues

The boot order of the machine can't be reset. 

