### PR TITLE
device-connectors: add TZ to reservation timestamps

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -318,9 +318,9 @@ class DefaultDevice:
                     serial_host, serial_port
                 )
             )
-        now = datetime.utcnow().isoformat()
+        now = datetime.now().astimezone().isoformat()
         expire_time = (
-            datetime.utcnow() + timedelta(seconds=timeout)
+            datetime.now().astimezone() + timedelta(seconds=timeout)
         ).isoformat()
         print("Current time:           [{}]".format(now))
         print("Reservation expires at: [{}]".format(expire_time))


### PR DESCRIPTION
Hello maintainers,

This is my first ever PR to the project. Your feedback is much appreciated.

## Description

The output will change from this one,

```
*** TESTFLINGER SYSTEM RESERVED ***
You can now connect to ubuntu@10.241.4.42
Current time:           [2025-04-04T13:31:35.874299]
Reservation expires at: [2025-04-04T16:31:35.874324]
Reservation will automatically timeout in 10800 seconds
```

To this one,
```
*** TESTFLINGER SYSTEM RESERVED ***
You can now connect to ubuntu@10.241.4.42
Current time:           [2025-04-04T13:31:35.874299+02:00]
Reservation expires at: [2025-04-04T16:31:35.874324+02:00]
Reservation will automatically timeout in 10800 seconds
```
## Resolved issues

Fixes: #545