### PR TITLE
Local deployment agent host

### DIFF
--- a/agent/terraform/.gitignore
+++ b/agent/terraform/.gitignore
@@ -1,3 +1,5 @@
+.terraform.lock.hcl
+
 .terraform/*
 
 *.tfstate

--- a/agent/terraform/README.md
+++ b/agent/terraform/README.md
@@ -60,6 +60,12 @@ multipass exec testflinger-agents-juju -- juju models
 
 Now that everything has been set up, you can initialize the project's terraform.
 
+Change your directory on your host machine to the terraform directory:
+
+```shell
+cd /path/to/testflinger/agent/terraform
+```
+
 In the terraform directory on your host machine, run:
 
 ```shell

--- a/agent/terraform/README.md
+++ b/agent/terraform/README.md
@@ -11,9 +11,9 @@ these can be placed in a `terraform.tfvars` file:
 juju_model = "testflinger-agents"
 agent_host_name = "agent-host"
 
-config_repo = "https://..."
+config_repo = "https://github.com/canonical/testflinger.git"
 config_branch = "main"
-config_dir = "lab/agent-host"
+config_dir = "agent/charms/testflinger-agent-host-charm/tests/integration/data/test01"
 
 ssh_public_key <<-EOT
 (sensitive value)

--- a/agent/terraform/README.md
+++ b/agent/terraform/README.md
@@ -1,79 +1,113 @@
-# Deploying with Terraform + Juju
+# Juju deployment
 
-This Terraform module can be used for deploying the Testflinger agent
-host on a physical or virtual machine model using Juju.
+Local Juju and charm deployment via [Terraform].
 
-## Deploying an Environment
+## Set up variables
 
-This terraform module assume that the Juju model you want to deploy
-to has already been created.
+The agent host charm requires a few variables. When deploying via Terraform,
+these can be placed in a `terraform.tfvars` file:
 
-1. First, create the model
+```tf
+juju_model = "testflinger-agents"
+agent_host_name = "agent-host"
 
-    ```
-    $ juju add-model agent-host-1
-    ```
+config_repo = "https://..."
+config_branch = "main"
+config_dir = "lab/agent-host"
 
-2. Create ssh keys to use on the agent host
+ssh_public_key <<-EOT
+(sensitive value)
+EOT
 
-    ```
-    $ ssh-keygen -t rsa -f mykey
-    ```
+ssh_private_key <<-EOT
+(sensitive value)
+EOT
+```
 
-3. Create a git repo with the Testflinger configs
+> [!TIP]
+> To generate the SSH key, use (for example): `ssh-keygen -t rsa -f id_rsa`.
 
-    If you have more than one agent host to deploy, create a separate directory
-    for each of them in this repo. Then create a separate directory for each
-    agent in the agent host directory where they reside. For example:
+> [!NOTE]
+> The agent host expects to pull configurations from a git repository. Make sure that the your URL includes any tokens needed to access the repository (e.g., FPAT).
 
-    ```
-    /agent-host-1
-    -/agent-101
-      -testflinger-agent.yaml
-      -default.conf
-    -/agent-102
-      -testflinger-agent.yaml
-      -default.conf
-    /agent-host-2
-    ...
-    ```
+## Set up a Juju environment
 
-4. Create a main.tf which specifies the required parameters for this module
+It is recommended to install the pre-requisites on a VM rather than your host
+machine. To do so, first install [Multipass]:
 
-    ```
-    terraform {
-      required_providers {
-        juju = {
-          version = "~> 0.13.0"
-          source  = "juju/juju"
-        }
-      }
-    }
+```shell
+sudo snap install multipass
+```
 
-    provider "juju" {}
+Then launch a new VM instance (this may take a while):
 
-    module "lab1" {
-      source = "/path/to/this/module"
-      agent_host_name = "agent-host-1"
-      juju_model = "agent-host-1"
-      config_repo = "https://github.com/path_to/config_repo.git"
-      config_branch = "main"
-      config_dir = "agent-host-1"
-      ssh_public_key = filebase64("mykey.pub")
-      ssh_private_key = filebase64("mykey")
-    }
-    ```
+```shell
+multipass launch noble --disk 50G --memory 4G --cpus 2 --name testflinger-agents-juju --mount /path/to/testflinger:/home/ubuntu/testflinger --cloud-init /path/to/testflinger/agent/terraform/cloud-init.yaml --timeout 1200
+```
 
-    There are additional parameters you can adjust here if you want:
-     - **agent_host_cores**: (default: 4) Number of cpu cores to use for the agent host
-     - **agent_host_mem**: (default: "32768M") Amount of RAM to use for the agent host. This needs to be specified as a string with "M" at the end.
-     - **agent_host_storage: (default: 1048576M) Storage size for the agent host. This needs to be specified as a string with "M" at the end.
-     - **override_constraints**: By default, the constraints passed to Juju will use the previous parameters to build something in this format: `arch=amd64 cores=${var.agent_host_cores} mem=${var.agent_host_mem} root-disk=${var.agent_host_storage} root-disk-source=remote virt-type=virtual-machine`. If you need to override this entire line to send it something completely different, use this and the previous `agent_host_*` parameters will be ignored.
+Feel free to increase the storage, memory, CPU, or VM name.
 
+> [!NOTE]
+> The initialization may time out. That's fine as long as the setup actually completed. You can tell that the setup completed by checking if the Juju models were created.
 
-5. Initialize terraform and apply
-    ```
-    $ terraform init
-    $ terraform apply
-    ```
+Check that the models were created:
 
+```shell
+multipass exec testflinger-agents-juju -- juju models
+```
+
+## Initialize project's terraform
+
+Now that everything has been set up, you can initialize the project's terraform.
+
+In the terraform directory on your host machine, run:
+
+```shell
+multipass exec testflinger-agents-juju -- terraform init
+```
+
+## Deploy everything
+
+In the terraform directory on your host machine, run:
+
+```shell
+multipass exec testflinger-agents-juju -- terraform apply -auto-approve
+```
+
+Then wait for the deployment to settle and all the statuses to become active.
+You can watch the statuses via:
+
+```shell
+multipass exec testflinger-agents-juju -- juju status --storage --relations --watch 5s
+```
+
+## Teardown
+
+To take everything down, you can start with terraform:
+
+```shell
+multipass exec testflinger-agents-juju -- terraform destroy -auto-approve
+```
+
+The above step can take a while and may even get stuck with some applications
+in error state. You can watch it through:
+
+```bash
+multipass exec testflinger-agents-juju -- juju status --storage --relations --watch 5s
+```
+
+Once everything is down and the juju model has been deleted you can stop the
+multipass VM:
+
+```bash
+multipass stop testflinger-agents-juju
+```
+
+Optionally, delete the VM:
+
+```bash
+multipass delete --purge testflinger-agents-juju
+```
+
+[Terraform]: https://developer.hashicorp.com/terraform
+[Multipass]: https://canonical.com/multipass

--- a/agent/terraform/cloud-init.yaml
+++ b/agent/terraform/cloud-init.yaml
@@ -1,0 +1,14 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+package_reboot_if_required: true
+snap:
+  commands:
+    - snap install lxd --channel=6/stable
+    - snap install juju --channel=3.6/stable
+    - snap install --classic charmcraft --channel=3.x/stable
+    - snap install --classic terraform
+runcmd:
+  - lxd init --auto
+  - sudo -i -u ubuntu snap run juju bootstrap localhost localhost-controller
+  - sudo -i -u ubuntu snap run juju add-model testflinger-agents localhost

--- a/agent/terraform/locals.tf
+++ b/agent/terraform/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  agent_host_constraints = try(var.override_constraints, "arch=amd64 cores=${var.agent_host_cores} mem=${var.agent_host_mem} root-disk=${var.agent_host_storage} root-disk-source=remote virt-type=virtual-machine")
+  agent_host_constraints = coalesce(var.override_constraints, "arch=amd64 cores=${var.agent_host_cores} mem=${var.agent_host_mem} root-disk=${var.agent_host_storage} root-disk-source=remote virt-type=virtual-machine")
 }


### PR DESCRIPTION
## Description

- Adds `cloud-init.yaml` and updates instructions to deploy locally the agent host charm with Terraform.

## Resolved issues

- Resolves [CERTTF-515](https://warthogs.atlassian.net/browse/CERTTF-515)

## Documentation

- Updated `README.md`

## Web service API changes

## Tests

Tested deployment locally. The charm is able to deploy, but the charm itself still expects the configuration to be in a git repository, which complicates local testing (but may be out of scope for this ticket).

[CERTTF-515]: https://warthogs.atlassian.net/browse/CERTTF-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ