### PR TITLE
Create new logging handlers in agent

### DIFF
--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -12,6 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from dataclasses import asdict, dataclass
 import json
 import logging
 import os
@@ -32,8 +33,8 @@ from testflinger_agent.errors import TFServerError
 
 logger = logging.getLogger(__name__)
 
-
-class LogEndpointInput(TypedDict):
+@dataclass(frozen=True)
+class LogEndpointInput:
     """Schema for Testflinger Log endpoints."""
 
     fragment_number: int
@@ -279,20 +280,22 @@ class TestflingerClient:
     def post_log(
         self,
         job_id: str,
-        log_dict: LogEndpointInput,
+        log_input: LogEndpointInput,
         log_type: LogType,
     ):
         """Post log data to the testflinger server for this job.
 
-        :param log_dict
-            Dict with all of the keys for the log endpoint
-        :param endpoint
-            Testflinger server endpoint to send logs to
+        :param job_id
+            id for the job
+        :param log_input
+            Dataclass with all of the keys for the log endpoint
+        :param log_type
+            Enum of different log types the server accepts
         """
-        endpoint = urljoin(self.server, f"/v1/result/{job_id}/log/{type}")
+        endpoint = urljoin(self.server, f"/v1/result/{job_id}/log/{log_type}")
         try:
             job_request = self.session.post(
-                endpoint, json=log_dict, timeout=60
+                endpoint, json=asdict(log_input), timeout=60
             )
         except requests.exceptions.RequestException as exc:
             logger.error(exc)

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 class LogEndpointInput(TypedDict):
-    """Schema for Testflinger Log endpoints"""
+    """Schema for Testflinger Log endpoints."""
 
     fragment_number: int
     timestamp: str
@@ -278,8 +278,9 @@ class TestflingerClient:
 
     def post_log(
         self,
+        job_id: str,
         log_dict: LogEndpointInput,
-        endpoint: str,
+        log_type: str,
     ):
         """Post log data to the testflinger server for this job.
 
@@ -288,6 +289,7 @@ class TestflingerClient:
         :param endpoint
             Testflinger server endpoint to send logs to
         """
+        endpoint = urljoin(self.server, f"/v1/result/{job_id}/log/{type}")
         try:
             job_request = self.session.post(
                 endpoint, json=log_dict, timeout=60
@@ -296,28 +298,6 @@ class TestflingerClient:
             logger.error(exc)
             return False
         return bool(job_request)
-
-    def post_output(
-        self,
-        job_id: str,
-        log_dict: LogEndpointInput,
-    ):
-        """Post output data to the testflinger server for this job"""
-        output_uri = urljoin(
-            self.server, "/v1/result/{}/log/output".format(job_id)
-        )
-        return self.post_log(log_dict, output_uri)
-
-    def post_serial(
-        self,
-        job_id: str,
-        log_dict: LogEndpointInput,
-    ):
-        """Post output data to the testflinger server for this job"""
-        serial_uri = urljoin(
-            self.server, "/v1/result/{}/log/serial".format(job_id)
-        )
-        return self.post_log(log_dict, serial_uri)
 
     def post_advertised_queues(self):
         """Post the list of advertised queues to testflinger server."""

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -304,7 +304,7 @@ class TestflingerClient:
     ):
         """Post output data to the testflinger server for this job"""
         output_uri = urljoin(
-            self.server, "/v1/result/{}/output".format(job_id)
+            self.server, "/v1/result/{}/log/output".format(job_id)
         )
         return self.post_log(log_dict, output_uri)
 
@@ -315,7 +315,7 @@ class TestflingerClient:
     ):
         """Post output data to the testflinger server for this job"""
         serial_uri = urljoin(
-            self.server, "/v1/result/{}/serial_output".format(job_id)
+            self.server, "/v1/result/{}/log/serial".format(job_id)
         )
         return self.post_log(log_dict, serial_uri)
 

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -27,7 +27,7 @@ from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-
+from testflinger_common.enums import LogType
 from testflinger_agent.errors import TFServerError
 
 logger = logging.getLogger(__name__)
@@ -280,7 +280,7 @@ class TestflingerClient:
         self,
         job_id: str,
         log_dict: LogEndpointInput,
-        log_type: str,
+        log_type: LogType,
     ):
         """Post log data to the testflinger server for this job.
 

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -12,15 +12,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from dataclasses import asdict, dataclass
 import json
 import logging
 import os
 import shutil
 import tempfile
 import time
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, TypedDict
+from typing import Dict, List
 from urllib.parse import urljoin
 
 import requests
@@ -29,6 +29,7 @@ from influxdb.exceptions import InfluxDBClientError
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from testflinger_common.enums import LogType
+
 from testflinger_agent.errors import TFServerError
 
 logger = logging.getLogger(__name__)

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -36,7 +36,6 @@ class FileLogHandler(LogHandler):
 class EndpointLogHandler(LogHandler):
     def __init__(self, client: TestflingerClient, job_id: str, phase: str):
         self.fragment_number = 0
-        self.log_buffer = ""
         self.client = client
         self.phase = phase
         self.job_id = job_id

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -14,6 +14,7 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
+from testflinger_common.enums import LogType
 
 from .client import LogEndpointInput, TestflingerClient
 
@@ -53,7 +54,7 @@ class EndpointLogHandler(LogHandler):
         self.job_id = job_id
 
     @abstractmethod
-    def write_to_endpoint(self, data_dict: LogEndpointInput):
+    def write_to_endpoint(self, data: LogEndpointInput):
         raise NotImplementedError
 
     def __call__(self, data: str):
@@ -73,8 +74,8 @@ class OutputLogHandler(EndpointLogHandler):
     endpoint in Testflinger server.
     """
 
-    def write_to_endpoint(self, data_dict: LogEndpointInput):
-        self.client.post_log(self.job_id, data_dict, "output")
+    def write_to_endpoint(self, data: LogEndpointInput):
+        self.client.post_log(self.job_id, data, LogType.NORMAL_OUTPUT)
 
 
 class SerialLogHandler(EndpointLogHandler):
@@ -83,5 +84,5 @@ class SerialLogHandler(EndpointLogHandler):
     endpoint in Testflinger server.
     """
 
-    def write_to_endpoint(self, data_dict: LogEndpointInput):
-        self.client.post_log(self.job_id, data_dict, "serial")
+    def write_to_endpoint(self, data: LogEndpointInput):
+        self.client.post_log(self.job_id, data, LogType.SERIAL_OUTPUT)

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -14,6 +14,7 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
+
 from testflinger_common.enums import LogType
 
 from .client import LogEndpointInput, TestflingerClient

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -76,7 +76,7 @@ class OutputLogHandler(EndpointLogHandler):
     """
 
     def write_to_endpoint(self, data: LogEndpointInput):
-        self.client.post_log(self.job_id, data, LogType.NORMAL_OUTPUT)
+        self.client.post_log(self.job_id, data, LogType.STANDARD_OUTPUT)
 
 
 class SerialLogHandler(EndpointLogHandler):

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -23,7 +23,7 @@ class LogHandler(ABC):
 
     @abstractmethod
     def __call__(self, data: str):
-        pass
+        raise NotImplementedError
 
 
 class FileLogHandler(LogHandler):
@@ -54,7 +54,7 @@ class EndpointLogHandler(LogHandler):
 
     @abstractmethod
     def write_to_endpoint(self, data_dict: LogEndpointInput):
-        pass
+        raise NotImplementedError
 
     def __call__(self, data: str):
         data_dict: LogEndpointInput = {

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -15,11 +15,11 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 
-from .client import TestflingerClient, LogEndpointInput
+from .client import LogEndpointInput, TestflingerClient
 
 
 class LogHandler(ABC):
-    """Abstract callable class that receives live log updates"""
+    """Abstract callable class that receives live log updates."""
 
     @abstractmethod
     def __call__(self, data: str):
@@ -74,7 +74,7 @@ class OutputLogHandler(EndpointLogHandler):
     """
 
     def write_to_endpoint(self, data_dict: LogEndpointInput):
-        self.client.post_output(self.job_id, data_dict)
+        self.client.post_log(self.job_id, data_dict, "output")
 
 
 class SerialLogHandler(EndpointLogHandler):
@@ -84,4 +84,4 @@ class SerialLogHandler(EndpointLogHandler):
     """
 
     def write_to_endpoint(self, data_dict: LogEndpointInput):
-        self.client.post_serial(self.job_id, data_dict)
+        self.client.post_log(self.job_id, data_dict, "serial")

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -19,12 +19,19 @@ from .client import TestflingerClient, LogEndpointInput
 
 
 class LogHandler(ABC):
+    """Abstract callable class that receives live log updates"""
+
     @abstractmethod
     def __call__(self, data: str):
         pass
 
 
 class FileLogHandler(LogHandler):
+    """
+    Implementation of LogHandler that writes live log updates
+    to a file.
+    """
+
     def __init__(self, filename: str):
         self.log_file = filename
 
@@ -34,6 +41,11 @@ class FileLogHandler(LogHandler):
 
 
 class EndpointLogHandler(LogHandler):
+    """
+    Abstract class that writes live log updates to a generic endpoint
+    in Testflinger server.
+    """
+
     def __init__(self, client: TestflingerClient, job_id: str, phase: str):
         self.fragment_number = 0
         self.client = client
@@ -56,10 +68,20 @@ class EndpointLogHandler(LogHandler):
 
 
 class OutputLogHandler(EndpointLogHandler):
+    """
+    Implementation of EndpointLogHandler that writes logs to the output
+    endpoint in Testflinger server.
+    """
+
     def write_to_endpoint(self, data_dict: LogEndpointInput):
         self.client.post_output(self.job_id, data_dict)
 
 
 class SerialLogHandler(EndpointLogHandler):
+    """
+    Implementation of EndpointLogHandler that writes logs to the serial
+    endpoint in Testflinger server.
+    """
+
     def write_to_endpoint(self, data_dict: LogEndpointInput):
         self.client.post_serial(self.job_id, data_dict)

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -58,13 +58,13 @@ class EndpointLogHandler(LogHandler):
         raise NotImplementedError
 
     def __call__(self, data: str):
-        data_dict: LogEndpointInput = {
-            "fragment_number": self.fragment_number,
-            "timestamp": str(datetime.now(timezone.utc)),
-            "phase": self.phase,
-            "log_data": data,
-        }
-        self.write_to_endpoint(data_dict)
+        log_input = LogEndpointInput(
+            self.fragment_number,
+            datetime.now(timezone.utc).isoformat(),
+            self.phase,
+            data,
+        )
+        self.write_to_endpoint(log_input)
         self.fragment_number += 1
 
 

--- a/agent/src/testflinger_agent/job.py
+++ b/agent/src/testflinger_agent/job.py
@@ -18,8 +18,7 @@ import os
 import time
 
 from testflinger_agent.errors import TFServerError
-
-from .handlers import LiveOutputHandler, LogUpdateHandler
+from .handlers import  FileLogHandler, OutputLogHandler
 from .runner import CommandRunner, RunnerEvents
 from .stop_condition_checkers import (
     GlobalTimeoutChecker,
@@ -83,9 +82,9 @@ class TestflingerJob:
 
         logger.info("Running %s_command: %s", phase, cmd)
         runner = CommandRunner(cwd=rundir, env=self.client.config)
-        output_log_handler = LogUpdateHandler(output_log)
-        live_output_handler = LiveOutputHandler(self.client, self.job_id)
-        runner.register_output_handler(output_log_handler)
+        output_file_handler = FileLogHandler(output_log)
+        live_output_handler = OutputLogHandler(self.client, self.job_id, phase)
+        runner.register_output_handler(output_file_handler)
         runner.register_output_handler(live_output_handler)
 
         # Reserve phase uses a separate timeout handler

--- a/agent/src/testflinger_agent/job.py
+++ b/agent/src/testflinger_agent/job.py
@@ -18,7 +18,8 @@ import os
 import time
 
 from testflinger_agent.errors import TFServerError
-from .handlers import  FileLogHandler, OutputLogHandler
+
+from .handlers import FileLogHandler, OutputLogHandler
 from .runner import CommandRunner, RunnerEvents
 from .stop_condition_checkers import (
     GlobalTimeoutChecker,

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 import requests_mock as rmock
-from testflinger_common.enums import TestEvent, TestPhase
+from testflinger_common.enums import TestEvent, TestPhase, LogType
 
 import testflinger_agent
 from testflinger_agent.agent import TestflingerAgent as _TestflingerAgent
@@ -398,7 +398,7 @@ class TestClient:
             m.get("http://127.0.0.1:8000/v1/result/" + job_id, text="{}")
             m.post("http://127.0.0.1:8000/v1/result/" + job_id, text="{}")
             m.post(
-                "http://127.0.0.1:8000/v1/result/" + job_id + "/log/output",
+                f"http://127.0.0.1:8000/v1/result/{job_id}/log/{LogType.STANDARD_OUTPUT}",
                 text="{}",
             )
             m.post(

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -398,7 +398,7 @@ class TestClient:
             m.get("http://127.0.0.1:8000/v1/result/" + job_id, text="{}")
             m.post("http://127.0.0.1:8000/v1/result/" + job_id, text="{}")
             m.post(
-                "http://127.0.0.1:8000/v1/result/" + job_id + "/output",
+                "http://127.0.0.1:8000/v1/result/" + job_id + "/log/output",
                 text="{}",
             )
             m.post(

--- a/agent/tests/test_handlers.py
+++ b/agent/tests/test_handlers.py
@@ -62,7 +62,7 @@ class TestHandler:
         job_id = str(uuid.uuid1())
         phase = "phase1"
         output_log_handler = OutputLogHandler(client, job_id, phase)
-        output_url = f"http://127.0.0.1:8000/v1/result/{job_id}/output"
+        output_url = f"http://127.0.0.1:8000/v1/result/{job_id}/log/output"
         requests_mock.post(output_url, status_code=200)
         output_log_handler("output0")
         output_log_handler("output1")
@@ -82,7 +82,7 @@ class TestHandler:
         job_id = str(uuid.uuid1())
         phase = "phase1"
         serial_log_handler = SerialLogHandler(client, job_id, phase)
-        serial_url = f"http://127.0.0.1:8000/v1/result/{job_id}/serial_output"
+        serial_url = f"http://127.0.0.1:8000/v1/result/{job_id}/log/serial"
         requests_mock.post(serial_url, status_code=200)
         serial_log_handler("output0")
         serial_log_handler("output1")

--- a/agent/tests/test_handlers.py
+++ b/agent/tests/test_handlers.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2025 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import shutil
+import tempfile
+import os
+import uuid
+import requests_mock as rmock
+import pytest
+
+import testflinger_agent
+from testflinger_agent.client import TestflingerClient as _TestflingerClient
+from testflinger_agent.handlers import (
+    FileLogHandler,
+    OutputLogHandler,
+    SerialLogHandler,
+)
+
+from testflinger_agent.schema import validate
+
+
+class TestHandler:
+    @pytest.fixture
+    def tmpdir(self):
+        tmpdir = tempfile.mkdtemp()
+        yield tmpdir
+        shutil.rmtree(tmpdir)
+
+    @pytest.fixture
+    def client(self, tmpdir, requests_mock):
+        self.config = validate(
+            {
+                "agent_id": "test01",
+                "polling_interval": 2,
+                "server_address": "127.0.0.1:8000",
+                "job_queues": ["test"],
+                "execution_basedir": tmpdir,
+                "logging_basedir": tmpdir,
+                "results_basedir": os.path.join(tmpdir, "results"),
+            }
+        )
+        testflinger_agent.configure_logging(self.config)
+        requests_mock.get(rmock.ANY)
+        requests_mock.post(rmock.ANY)
+        yield _TestflingerClient(self.config)
+
+    def test_file_log_handler(self, tmpdir):
+        filename = os.path.join(tmpdir, "output.log")
+        file_log_handler = FileLogHandler(filename)
+        file_log_handler("output1")
+        with open(filename, "r") as log:
+            assert log.read() == "output1"
+        file_log_handler("output2")
+        with open(filename, "r") as log:
+            assert log.read() == "output1output2"
+
+    def test_output_log_handler(self, client, requests_mock):
+        job_id = str(uuid.uuid1())
+        phase = "phase1"
+        output_log_handler = OutputLogHandler(client, job_id, phase)
+        output_url = f"http://127.0.0.1:8000/v1/result/{job_id}/output"
+        requests_mock.post(output_url, status_code=200)
+        output_log_handler("output0")
+        output_log_handler("output1")
+        requests = list(
+            filter(
+                lambda req: req.url == output_url,
+                requests_mock.request_history,
+            )
+        )
+        assert len(requests) == 2
+        for i in range(2):
+            assert requests[i].json()["fragment_number"] == i
+            assert requests[i].json()["phase"] == "phase1"
+            assert requests[i].json()["log_data"] == f"output{i}"
+
+    def test_serial_log_handler(self, client, requests_mock):
+        job_id = str(uuid.uuid1())
+        phase = "phase1"
+        serial_log_handler = SerialLogHandler(client, job_id, phase)
+        serial_url = f"http://127.0.0.1:8000/v1/result/{job_id}/serial_output"
+        requests_mock.post(serial_url, status_code=200)
+        serial_log_handler("output0")
+        serial_log_handler("output1")
+        requests = list(
+            filter(
+                lambda req: req.url == serial_url,
+                requests_mock.request_history,
+            )
+        )
+        assert len(requests) == 2
+        for i in range(2):
+            assert requests[i].json()["fragment_number"] == i
+            assert requests[i].json()["phase"] == "phase1"
+            assert requests[i].json()["log_data"] == f"output{i}"

--- a/agent/tests/test_handlers.py
+++ b/agent/tests/test_handlers.py
@@ -13,7 +13,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 import shutil
-import tempfile
 import os
 import uuid
 import requests_mock as rmock
@@ -32,22 +31,16 @@ from testflinger_agent.schema import validate
 
 class TestHandler:
     @pytest.fixture
-    def tmpdir(self):
-        tmpdir = tempfile.mkdtemp()
-        yield tmpdir
-        shutil.rmtree(tmpdir)
-
-    @pytest.fixture
-    def client(self, tmpdir, requests_mock):
+    def client(self, tmp_path, requests_mock):
         self.config = validate(
             {
                 "agent_id": "test01",
                 "polling_interval": 2,
                 "server_address": "127.0.0.1:8000",
                 "job_queues": ["test"],
-                "execution_basedir": tmpdir,
-                "logging_basedir": tmpdir,
-                "results_basedir": os.path.join(tmpdir, "results"),
+                "execution_basedir": str(tmp_path),
+                "logging_basedir": str(tmp_path),
+                "results_basedir": str(tmp_path / "results"),
             }
         )
         testflinger_agent.configure_logging(self.config)
@@ -55,8 +48,8 @@ class TestHandler:
         requests_mock.post(rmock.ANY)
         yield _TestflingerClient(self.config)
 
-    def test_file_log_handler(self, tmpdir):
-        filename = os.path.join(tmpdir, "output.log")
+    def test_file_log_handler(self, tmp_path):
+        filename = tmp_path / "output.log"
         file_log_handler = FileLogHandler(filename)
         file_log_handler("output1")
         with open(filename, "r") as log:

--- a/agent/tests/test_handlers.py
+++ b/agent/tests/test_handlers.py
@@ -12,11 +12,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-import shutil
-import os
 import uuid
-import requests_mock as rmock
+
 import pytest
+import requests_mock as rmock
 
 import testflinger_agent
 from testflinger_agent.client import TestflingerClient as _TestflingerClient
@@ -25,7 +24,6 @@ from testflinger_agent.handlers import (
     OutputLogHandler,
     SerialLogHandler,
 )
-
 from testflinger_agent.schema import validate
 
 

--- a/agent/tests/test_job.py
+++ b/agent/tests/test_job.py
@@ -16,6 +16,7 @@ from testflinger_agent.job import (
 from testflinger_agent.job import (
     read_truncated,
 )
+from testflinger_agent.handlers import FileLogHandler
 from testflinger_agent.runner import CommandRunner
 from testflinger_agent.schema import validate
 from testflinger_agent.stop_condition_checkers import (
@@ -76,7 +77,7 @@ class TestJob:
         timeout_str = "ERROR: Global timeout reached! (1s)"
         logfile = tmp_path / "testlog"
         runner = CommandRunner(tmp_path, env={})
-        log_handler = LogUpdateHandler(logfile)
+        log_handler = FileLogHandler(logfile)
         runner.register_output_handler(log_handler)
         global_timeout_checker = GlobalTimeoutChecker(1)
         runner.register_stop_condition_checker(global_timeout_checker)
@@ -101,7 +102,7 @@ class TestJob:
         timeout_str = "ERROR: Output timeout reached! (1s)"
         logfile = tmp_path / "testlog"
         runner = CommandRunner(tmp_path, env={})
-        log_handler = LogUpdateHandler(logfile)
+        log_handler = FileLogHandler(logfile)
         runner.register_output_handler(log_handler)
         output_timeout_checker = OutputTimeoutChecker(1)
         runner.register_stop_condition_checker(output_timeout_checker)

--- a/agent/tests/test_job.py
+++ b/agent/tests/test_job.py
@@ -9,14 +9,13 @@ from testflinger_common.enums import TestEvent
 
 import testflinger_agent
 from testflinger_agent.client import TestflingerClient as _TestflingerClient
-from testflinger_agent.handlers import LogUpdateHandler
+from testflinger_agent.handlers import FileLogHandler
 from testflinger_agent.job import (
     TestflingerJob as _TestflingerJob,
 )
 from testflinger_agent.job import (
     read_truncated,
 )
-from testflinger_agent.handlers import FileLogHandler
 from testflinger_agent.runner import CommandRunner
 from testflinger_agent.schema import validate
 from testflinger_agent.stop_condition_checkers import (

--- a/common/src/testflinger_common/enums.py
+++ b/common/src/testflinger_common/enums.py
@@ -77,3 +77,13 @@ class TestEvent(StrEnum):
     NORMAL_EXIT = "normal_exit"
     JOB_START = "job_start"
     JOB_END = "job_end"
+
+class LogType(StrEnum):
+    """
+    Enum of different output types
+    NORMAL_OUTPUT - Agent Standard Output
+    SERIAL_OUTPUT - Agent Serial Log Output.
+    """
+
+    NORMAL_OUTPUT = "output"
+    SERIAL_OUTPUT = "serial"

--- a/common/src/testflinger_common/enums.py
+++ b/common/src/testflinger_common/enums.py
@@ -85,5 +85,5 @@ class LogType(StrEnum):
     SERIAL_OUTPUT - Agent Serial Log Output.
     """
 
-    NORMAL_OUTPUT = "output"
+    STANDARD_OUTPUT = "output"
     SERIAL_OUTPUT = "serial"


### PR DESCRIPTION
## Description
This PR renames existing logging handlers, creates new ones, and adds some extra functionality to them. 

- All logging handlers follow the new abstract interface, `LogHandler`.
- The existing `LogUpdateHandler` has been renamed to `FileLogHandler` and inherits from `LogHandler`
- A new abstract class, `EndpointLogHandler` supports writing logs to an endpoint in Testflinger Server by fragment
- `OutputLogHandler` and `SerialLogHandler` support writing to the output and serial_output endpoints in Testflinger server respectively and inherit from `EndpointLogHandler`
- `TestflingerClient` has been modified to support posting to the output and serial_output endpoints with the correct fragment schema defined in a TypedDict `LogEndpointInput`
- `repost_job` function was removed from `TestflingerClient` due to it being unused

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves https://warthogs.atlassian.net/browse/CERTTF-570
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Tested in new test file `test_handlers.py`
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
