### PR TITLE
fix(agent): Fix agent host charm

### DIFF
--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [ main ]
     paths:
+      - common/**  # testflinger-agent depends on testflinger-common
       - agent/**
       - .github/workflows/agent-tox.yml
   pull_request:
     branches: [ main ]
     paths:
+      - common/**  # testflinger-agent depends on testflinger-common
       - agent/**
       - .github/workflows/agent-tox.yml
 

--- a/agent/charms/testflinger-agent-host-charm/src/testflinger_source.py
+++ b/agent/charms/testflinger-agent-host-charm/src/testflinger_source.py
@@ -3,10 +3,10 @@
 
 import os
 import shutil
-from git import Repo
-from common import run_with_logged_errors
-from defaults import DEFAULT_TESTFLINGER_REPO, DEFAULT_BRANCH, VIRTUAL_ENV_PATH
 
+from common import run_with_logged_errors
+from defaults import DEFAULT_BRANCH, DEFAULT_TESTFLINGER_REPO, VIRTUAL_ENV_PATH
+from git import Repo
 
 # Only keep these directories from the repo in the sparse checkout
 CHECKOUT_DIRS = ("agent", "common", "device-connectors")
@@ -32,12 +32,9 @@ def clone_repo(
     )
 
     # do a sparse checkout of only the parts of the repo we need
-    repo.git.checkout(
-        f"origin/{branch}",
-        "--",
-        *CHECKOUT_DIRS,
-    )
-    for dir in (
+    repo.git.checkout(f"origin/{branch}", "--", *CHECKOUT_DIRS)
+    for directory in (
+        "common",
         "agent",
         "device-connectors",
     ):
@@ -46,7 +43,7 @@ def clone_repo(
                 f"{VIRTUAL_ENV_PATH}/bin/pip3",
                 "install",
                 "-I",
-                f"{local_path}/{dir}",
+                f"{local_path}/{directory}",
             ]
         )
 
@@ -56,21 +53,9 @@ def create_virtualenv():
     if os.path.exists(VIRTUAL_ENV_PATH):
         return
 
-    run_with_logged_errors(
-        [
-            "python3",
-            "-m",
-            "virtualenv",
-            VIRTUAL_ENV_PATH,
-        ]
-    )
+    run_with_logged_errors(["python3", "-m", "virtualenv", VIRTUAL_ENV_PATH])
 
     # Update pip in the virtualenv so that poetry works in focal
     run_with_logged_errors(
-        [
-            f"{VIRTUAL_ENV_PATH}/bin/pip3",
-            "install",
-            "-U",
-            "pip",
-        ]
+        [f"{VIRTUAL_ENV_PATH}/bin/pip3", "install", "-U", "pip"]
     )

--- a/agent/charms/testflinger-agent-host-charm/src/testflinger_source.py
+++ b/agent/charms/testflinger-agent-host-charm/src/testflinger_source.py
@@ -42,7 +42,7 @@ def clone_repo(
             [
                 f"{VIRTUAL_ENV_PATH}/bin/pip3",
                 "install",
-                "-I",
+                "--force-reinstall",
                 f"{local_path}/{directory}",
             ]
         )

--- a/agent/charms/testflinger-agent-host-charm/src/testflinger_source.py
+++ b/agent/charms/testflinger-agent-host-charm/src/testflinger_source.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Canonical
 # See LICENSE file for licensing details.
 
+import logging
 import os
 import shutil
 
@@ -10,6 +11,8 @@ from git import Repo
 
 # Only keep these directories from the repo in the sparse checkout
 CHECKOUT_DIRS = ("agent", "common", "device-connectors")
+
+logger = logging.getLogger(__name__)
 
 
 def clone_repo(
@@ -23,6 +26,7 @@ def clone_repo(
     shutil.rmtree(local_path, ignore_errors=True)
 
     # Clone the repo
+    logger.debug("Cloning Testflinger repository: %s", testflinger_repo)
     repo = Repo.clone_from(
         url=testflinger_repo,
         branch=branch,
@@ -33,16 +37,13 @@ def clone_repo(
 
     # do a sparse checkout of only the parts of the repo we need
     repo.git.checkout(f"origin/{branch}", "--", *CHECKOUT_DIRS)
-    for directory in (
-        "common",
-        "agent",
-        "device-connectors",
-    ):
+    for directory in ("common", "agent", "device-connectors"):
+        logger.debug("Installing Python package: %s", directory)
         run_with_logged_errors(
             [
                 f"{VIRTUAL_ENV_PATH}/bin/pip3",
                 "install",
-                "--force-reinstall",
+                "-U",
                 f"{local_path}/{directory}",
             ]
         )
@@ -53,9 +54,11 @@ def create_virtualenv():
     if os.path.exists(VIRTUAL_ENV_PATH):
         return
 
+    logger.debug("Creating virtualenv: %s", VIRTUAL_ENV_PATH)
     run_with_logged_errors(["python3", "-m", "virtualenv", VIRTUAL_ENV_PATH])
 
     # Update pip in the virtualenv so that poetry works in focal
+    logger.debug("Upgrading pip in virtualenv")
     run_with_logged_errors(
         [f"{VIRTUAL_ENV_PATH}/bin/pip3", "install", "-U", "pip"]
     )

--- a/agent/charms/testflinger-agent-host-charm/templates/testflinger-agent.supervisord.conf.j2
+++ b/agent/charms/testflinger-agent-host-charm/templates/testflinger-agent.supervisord.conf.j2
@@ -1,4 +1,5 @@
 [program:{{ agent_name }}]
+startsecs=0
 redirect_stderr=true
 environment=USER="ubuntu",HOME="/home/ubuntu",PYTHONIOENCODING=utf-8
 user=ubuntu

--- a/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import pytest
 from pytest_operator.plugin import OpsTest
 
@@ -124,8 +125,8 @@ async def test_supervisord_num_agents_running(ops_test: OpsTest):
 
     unit_name = f"{APP_NAME}/0"
     command = ["exec", "--unit", unit_name, "--", "supervisorctl", "status"]
-    returncode, stdout, _ = await ops_test.juju(*command)
-    assert returncode == 0
+    returncode, stdout, stderr = await ops_test.juju(*command)
+    assert returncode == 0, stderr or stdout
     running_agents = [
         line for line in stdout.splitlines() if "RUNNING" in line
     ]

--- a/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from defaults import DEFAULT_TESTFLINGER_PATH, VIRTUAL_ENV_PATH
+from defaults import LOCAL_TESTFLINGER_PATH, VIRTUAL_ENV_PATH
 from pytest_operator.plugin import OpsTest
 
 # Root of the charm we need to build is two dirs up
@@ -50,15 +50,13 @@ async def test_action_update_testflinger(ops_test: OpsTest):
         "freeze",
     ]
     returncode, stdout, stderr = await ops_test.juju(*command)
-    assert returncode == 0, stderr or stdout
+    assert returncode == 0, f"{stderr}\n{stdout}"
     for package, path in (
         ("testflinger-common", "common"),
         ("testflinger-agent", "agent"),
         ("testflinger-device-connectors", "device-connectors"),
     ):
-        assert (
-            f"{package} @ file://{DEFAULT_TESTFLINGER_PATH}/{path}" in stdout
-        )
+        assert f"{package} @ file://{LOCAL_TESTFLINGER_PATH}/{path}" in stdout
 
 
 async def test_action_update_testflinger_with_branch(ops_test: OpsTest):
@@ -148,7 +146,7 @@ async def test_supervisord_num_agents_running(ops_test: OpsTest):
     unit_name = f"{APP_NAME}/0"
     command = ["exec", "--unit", unit_name, "--", "supervisorctl", "status"]
     returncode, stdout, stderr = await ops_test.juju(*command)
-    assert returncode == 0, stderr or stdout
+    assert returncode == 0, f"{stderr}\n{stdout}"
     running_agents = [
         line for line in stdout.splitlines() if "RUNNING" in line
     ]
@@ -170,7 +168,7 @@ async def test_supervisord_num_agents_running(ops_test: OpsTest):
     unit_name = f"{APP_NAME}/0"
     command = ["exec", "--unit", unit_name, "--", "supervisorctl", "status"]
     returncode, stdout, stderr = await ops_test.juju(*command)
-    assert returncode == 0, stderr or stdout
+    assert returncode == 0, f"{stderr}\n{stdout}"
     running_agents = [
         line for line in stdout.splitlines() if "RUNNING" in line
     ]

--- a/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
@@ -51,18 +51,14 @@ async def test_action_update_testflinger(ops_test: OpsTest):
     ]
     returncode, stdout, stderr = await ops_test.juju(*command)
     assert returncode == 0, stderr or stdout
-    assert (
-        f"testflinger-common @ file://{DEFAULT_TESTFLINGER_PATH}/common"
-        in stdout
-    )
-    assert (
-        f"testflinger-agent @ file://{DEFAULT_TESTFLINGER_PATH}/agent"
-        in stdout
-    )
-    assert (
-        f"testflinger-device-connectors @ file://{DEFAULT_TESTFLINGER_PATH}/device-connectors"
-        in stdout
-    )
+    for package, path in (
+        ("testflinger-common", "common"),
+        ("testflinger-agent", "agent"),
+        ("testflinger-device-connectors", "device-connectors"),
+    ):
+        assert (
+            f"{package} @ file://{DEFAULT_TESTFLINGER_PATH}/{path}" in stdout
+        )
 
 
 async def test_action_update_testflinger_with_branch(ops_test: OpsTest):

--- a/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/integration/test_charm_integration.py
@@ -113,6 +113,7 @@ async def test_supervisord_files_written(ops_test: OpsTest):
     # check that agent001.conf was written in /etc/supervisor/conf.d/
     expected_contents = (
         "[program:agent001]\n"
+        "startsecs=0\n"
         "redirect_stderr=true\n"
         'environment=USER="ubuntu",HOME="/home/ubuntu",'
         "PYTHONIOENCODING=utf-8\n"

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_source.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_source.py
@@ -28,8 +28,8 @@ def test_clone_repo(mock_run_with_logged_errors, mock_clone_from):
         [
             f"{VIRTUAL_ENV_PATH}/bin/pip3",
             "install",
-            "--force-reinstall",
-            "/srv/testflinger/device-connectors",
+            "-U",
+            f"{LOCAL_TESTFLINGER_PATH}/device-connectors",
         ]
     )
 
@@ -39,18 +39,8 @@ def test_create_virtualenv(mock_run_with_logged_errors):
     """Test the create_virtualenv method"""
     testflinger_source.create_virtualenv()
     mock_run_with_logged_errors.assert_any_call(
-        [
-            "python3",
-            "-m",
-            "virtualenv",
-            VIRTUAL_ENV_PATH,
-        ]
+        ["python3", "-m", "virtualenv", VIRTUAL_ENV_PATH]
     )
     mock_run_with_logged_errors.assert_any_call(
-        [
-            f"{VIRTUAL_ENV_PATH}/bin/pip3",
-            "install",
-            "-U",
-            "pip",
-        ]
+        [f"{VIRTUAL_ENV_PATH}/bin/pip3", "install", "-U", "pip"]
     )

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_source.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_source.py
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 from unittest.mock import patch
+
 import testflinger_source
 from defaults import (
-    DEFAULT_TESTFLINGER_REPO,
     DEFAULT_BRANCH,
+    DEFAULT_TESTFLINGER_REPO,
     LOCAL_TESTFLINGER_PATH,
     VIRTUAL_ENV_PATH,
 )
@@ -27,7 +28,7 @@ def test_clone_repo(mock_run_with_logged_errors, mock_clone_from):
         [
             f"{VIRTUAL_ENV_PATH}/bin/pip3",
             "install",
-            "-I",
+            "--force-reinstall",
             "/srv/testflinger/device-connectors",
         ]
     )


### PR DESCRIPTION
## Description

We are seeing some errors with the agent host charm integration tests. These are due to the venv not finding a suitable installation of `testflinger-common`.

This PR updates the charm to install `testflinger-common` before installing the agent or device connectors packages.

Additionally, the `pip` call has been edited from using `pip install -I` to `pip install -U` so that only necessary upgrades are performed (the Testflinger packages are still reinstalled, but the dependencies are only upgraded if needed).

Adds `startsecs=0` to supervisor configuration files. See https://stackoverflow.com/questions/40909842/supervisor-fatal-exited-too-quickly-process-log-may-have-details

Thank you @rene-oromtz for helping to track, test, and debug this issue

## Resolved issues

See: https://github.com/canonical/testflinger/actions/runs/14604890358/job/40974459185

## Documentation

## Web service API changes

## Tests

Existing integration tests should pass