### PR TITLE
feat(devices): Update testflinger-devices to use Ruff

### DIFF
--- a/device-connectors/README.md
+++ b/device-connectors/README.md
@@ -2,6 +2,7 @@
 
 [![Documentation status][rtd-badge]][rtd-latest]
 [![uv status][uv-badge]][uv-site]
+[![Ruff status][ruff-badge]][ruff-site]
 
 **Testflinger Device Connectors** provides a unified way for provisioning,
 maintaining, and running tests on devices with different provision types.
@@ -95,3 +96,5 @@ Testflinger Device Connectors is released under the [GPL-3.0 license](COPYING).
 [job-schema]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema.html
 [test-phases]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/test-phases.html
 [github]: https://github.com/canonical/testflinger
+[ruff-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+[ruff-site]: https://github.com/astral-sh/ruff

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -25,7 +25,6 @@ testflinger-device-connector = "testflinger_device_connectors.cmd:main"
 dev = [
     "black>=24.8.0",
     "flake8>=5.0.4",
-    "pylint>=3.2.7",
     "pytest>=8.3.5",
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.14.0",
@@ -40,35 +39,35 @@ line-length = 79
 
 [tool.ruff.lint]
 select = [
-    "A", # flake8-builtins
-    "B", # flake8-bugbear
-    "C4", # comprenhension
-    "D", # docstrings
+    "A",   # flake8-builtins
+    "B",   # flake8-bugbear
+    "C4",  # comprenhension
+    "D",   # docstrings
     "DTZ", # flake8-datetimez 
-    "E", # pycodestyle errors
-    "F", # pyflakes
-    "G", # flake8-logging-format
-    "I", # isort
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "G",   # flake8-logging-format
+    "I",   # isort
     "LOG", # flake8-logging
-    "N", # naming
+    "N",   # naming
     "PLE", # pylint errors
     "PLW0", # pyling warnings
-    #"S", # flake8-bandit 
-    "W", # pycodestyle warnings
+    #"S",  # flake8-bandit 
+    "W",   # pycodestyle warnings
 ]
 ignore = [
-    "B009", # flake8-bugbear; get attr with constant
-    "B904", # flake8-bugbear: raise without from inside except
-    "D100", # docstring: Missing docstring in public module
-    "D101", # docstring: Missing docstring in public class
-    "D102", # docstring: Missing docstring in public method
-    "D103", # docstring: Missing docstring in public function
-    "D104", # docstring: Missing docstring in public package
-    "D107", # docstring: Missing docstring in __init__
-    "D205", # docstring: 1 black line required between summary line and description
-    "G001", # flake8-logging-format: logging string format
-    "G003", # flake8-logging-format: logging string concat
-    "G004", # flake8-logging-format: loggin f-string
+    "B009",    # flake8-bugbear; get attr with constant
+    "B904",    # flake8-bugbear: raise without from inside except
+    "D100",    # docstring: Missing docstring in public module
+    "D101",    # docstring: Missing docstring in public class
+    "D102",    # docstring: Missing docstring in public method
+    "D103",    # docstring: Missing docstring in public function
+    "D104",    # docstring: Missing docstring in public package
+    "D107",    # docstring: Missing docstring in __init__
+    "D205",    # docstring: 1 black line required between summary line and description
+    "G001",    # flake8-logging-format: logging string format
+    "G003",    # flake8-logging-format: logging string concat
+    "G004",    # flake8-logging-format: loggin f-string
     "PLW0603", # pylint warnings: global statement
 ]
 
@@ -76,3 +75,6 @@ ignore = [
 ignore-names = [
     "SerialLogger" # Function needs to follow snake_case, excluded to prevail style
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -40,23 +40,25 @@ line-length = 79
 
 [tool.ruff.lint]
 select = [
-    #"A", # flake8-builtins
-    #"B", # flake8-bugbear
+    "A", # flake8-builtins
+    "B", # flake8-bugbear
     "C4", # comprenhension
     "D", # docstrings
     "DTZ", # flake8-datetimez 
     "E", # pycodestyle errors
     "F", # pyflakes
-    #"G", # flake8-logging-format
+    "G", # flake8-logging-format
     "I", # isort
-    #"LOG", # flake8-logging
+    "LOG", # flake8-logging
     "N", # naming
-    #"PLE", # pylint errors
-    #"PLW0", # pyling warnings
+    "PLE", # pylint errors
+    "PLW0", # pyling warnings
     #"S", # flake8-bandit 
     "W", # pycodestyle warnings
 ]
 ignore = [
+    "B009", # flake8-bugbear; get attr with constant
+    "B904", # flake8-bugbear: raise without from inside except
     "D100", # docstring: Missing docstring in public module
     "D101", # docstring: Missing docstring in public class
     "D102", # docstring: Missing docstring in public method
@@ -64,6 +66,10 @@ ignore = [
     "D104", # docstring: Missing docstring in public package
     "D107", # docstring: Missing docstring in __init__
     "D205", # docstring: 1 black line required between summary line and description
+    "G001", # flake8-logging-format: logging string format
+    "G003", # flake8-logging-format: logging string concat
+    "G004", # flake8-logging-format: loggin f-string
+    "PLW0603", # pylint warnings: global statement
 ]
 
 [tool.ruff.lint.pep8-naming]

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -61,9 +61,6 @@ ignore = [
     "D104",    # docstring: Missing docstring in public package
     "D107",    # docstring: Missing docstring in __init__
     "D205",    # docstring: 1 black line required between summary line and description
-    "G001",    # flake8-logging-format: logging string format
-    "G003",    # flake8-logging-format: logging string concat
-    "G004",    # flake8-logging-format: loggin f-string
 ]
 
 [tool.ruff.lint.pep8-naming]

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -49,7 +49,7 @@ select = [
     "LOG", # flake8-logging
     "N",   # naming
     "PLE", # pylint errors
-    "PLW0", # pyling warnings
+    "PLW", # pyling warnings
     #"S",  # flake8-bandit 
     "W",   # pycodestyle warnings
 ]

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -63,24 +63,7 @@ ignore = [
     "D103", # docstring: Missing docstring in public function
     "D104", # docstring: Missing docstring in public package
     "D107", # docstring: Missing docstring in __init__
-    "D200", # docstring: One-line docstring should fit on one line with quotes
-    "D202", # docstring: No black lines allowed after function docstring
-    "D203", # docstring: 1 black line required before class docstring
-    "D204", # docstring: 1 black line required after class docstring
     "D205", # docstring: 1 black line required between summary line and description
-    "D212", # docstring: Multi-line docstring summary should start at the first line
-    "D213", # docstring: Multi-line docstring summary should start at the second line
-    "D215", # docstring: Section underline is over-indented
-    "D400", # docstring: First line should end with a period
-    "D401", # docstring: First line should be in imperative mood; try rephrasing
-    "D403", # docstring: First word of the first line should be properly capitalized
-    "D404", # docstring: First word of the docstring should not be 'This'
-    "D406", # docstring: Section name should end with a newline
-    "D407", # docstring: Missing dashed underline after section
-    "D408", # docstring: Section underline should be in the line following the section's name
-    "D409", # docstring: Section underline should match the lenght of its name
-    "D413", # docstring: Missing blank line after last section. 
-    "D415", # docstring: First line should end with a period, question mark, or exclamation point
 ]
 
 [tool.ruff.lint.pep8-naming]

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -23,8 +23,6 @@ testflinger-device-connector = "testflinger_device_connectors.cmd:main"
 
 [dependency-groups]
 dev = [
-    "black>=24.8.0",
-    "flake8>=5.0.4",
     "pytest>=8.3.5",
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.14.0",

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -54,8 +54,6 @@ select = [
     "W",   # pycodestyle warnings
 ]
 ignore = [
-    "B009",    # flake8-bugbear; get attr with constant
-    "B904",    # flake8-bugbear: raise without from inside except
     "D100",    # docstring: Missing docstring in public module
     "D101",    # docstring: Missing docstring in public class
     "D102",    # docstring: Missing docstring in public method
@@ -66,7 +64,6 @@ ignore = [
     "G001",    # flake8-logging-format: logging string format
     "G003",    # flake8-logging-format: logging string concat
     "G004",    # flake8-logging-format: loggin f-string
-    "PLW0603", # pylint warnings: global statement
 ]
 
 [tool.ruff.lint.pep8-naming]

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -76,6 +76,9 @@ ignore-names = [
 "src/testflinger_device_connectors/devices/*/tests/*" = [
   "S101", # use of assert
 ]
+"tests/*" = [
+  "S101", # use of assert
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -29,10 +29,61 @@ dev = [
     "pytest>=8.3.5",
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.14.0",
+    "ruff>=0.11.7",
 ]
 
 [tool.setuptools.package-data]
 testflinger_device_connectors = ["data/**"]
 
-[tool.black]
+[tool.ruff]
 line-length = 79
+
+[tool.ruff.lint]
+select = [
+    #"A", # flake8-builtins
+    #"B", # flake8-bugbear
+    "C4", # comprenhension
+    "D", # docstrings
+    "DTZ", # flake8-datetimez 
+    "E", # pycodestyle errors
+    "F", # pyflakes
+    #"G", # flake8-logging-format
+    "I", # isort
+    #"LOG", # flake8-logging
+    "N", # naming
+    #"PLE", # pylint errors
+    #"PLW0", # pyling warnings
+    #"S", # flake8-bandit 
+    "W", # pycodestyle warnings
+]
+ignore = [
+    "D100", # docstring: Missing docstring in public module
+    "D101", # docstring: Missing docstring in public class
+    "D102", # docstring: Missing docstring in public method
+    "D103", # docstring: Missing docstring in public function
+    "D104", # docstring: Missing docstring in public package
+    "D107", # docstring: Missing docstring in __init__
+    "D200", # docstring: One-line docstring should fit on one line with quotes
+    "D202", # docstring: No black lines allowed after function docstring
+    "D203", # docstring: 1 black line required before class docstring
+    "D204", # docstring: 1 black line required after class docstring
+    "D205", # docstring: 1 black line required between summary line and description
+    "D212", # docstring: Multi-line docstring summary should start at the first line
+    "D213", # docstring: Multi-line docstring summary should start at the second line
+    "D215", # docstring: Section underline is over-indented
+    "D400", # docstring: First line should end with a period
+    "D401", # docstring: First line should be in imperative mood; try rephrasing
+    "D403", # docstring: First word of the first line should be properly capitalized
+    "D404", # docstring: First word of the docstring should not be 'This'
+    "D406", # docstring: Section name should end with a newline
+    "D407", # docstring: Missing dashed underline after section
+    "D408", # docstring: Section underline should be in the line following the section's name
+    "D409", # docstring: Section underline should match the lenght of its name
+    "D413", # docstring: Missing blank line after last section. 
+    "D415", # docstring: First line should end with a period, question mark, or exclamation point
+]
+
+[tool.ruff.lint.pep8-naming]
+ignore-names = [
+    "SerialLogger" # Function needs to follow snake_case, excluded to prevail style
+]

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -50,7 +50,7 @@ select = [
     "N",   # naming
     "PLE", # pylint errors
     "PLW", # pyling warnings
-    #"S",  # flake8-bandit 
+    "S",   # flake8-bandit 
     "W",   # pycodestyle warnings
 ]
 ignore = [
@@ -61,11 +61,20 @@ ignore = [
     "D104",    # docstring: Missing docstring in public package
     "D107",    # docstring: Missing docstring in __init__
     "D205",    # docstring: 1 black line required between summary line and description
+    "S105",    # flake8-bandit: Hardcoded password string
+    "S310",    # flake8-bandit: Audit url open for permitted schemes
+    "S602",    # flake8-bandit: Subprocess with shell equals True
+    "S603",    # flake8-bandit: Subprocess without shell equals True
 ]
 
 [tool.ruff.lint.pep8-naming]
 ignore-names = [
     "SerialLogger" # Function needs to follow snake_case, excluded to prevail style
+]
+
+[tool.ruff.lint.per-file-ignores]
+"src/testflinger_device_connectors/devices/*/tests/*" = [
+  "S101", # use of assert
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/device-connectors/src/testflinger_device_connectors/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/__init__.py
@@ -181,7 +181,7 @@ def serve_file(queue, filename):
         The file to transmit
     """
     server = socket.socket()
-    server.bind(("0.0.0.0", 0))
+    server.bind(("0.0.0.0", 0))  # noqa: S104
     port = server.getsockname()[1]
     queue.put(port)
     server.listen(1)
@@ -445,7 +445,7 @@ def _run_test_cmds_str(cmds, config=None, env=None):
         cmds = _process_cmds_template_vars(cmds, config)
     with open("tf_cmd_script", mode="w", encoding="utf-8") as tf_cmd_script:
         tf_cmd_script.write(cmds)
-    os.chmod("tf_cmd_script", 0o775)
+    os.chmod("tf_cmd_script", 0o775)  # noqa: S103
     result = runcmd("./tf_cmd_script", env)
     if result:
         logger.warning("Tests failed, rc=%d", result)

--- a/device-connectors/src/testflinger_device_connectors/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/__init__.py
@@ -362,27 +362,29 @@ def _process_cmds_template_vars(cmds, config=None):
             tokens = []
             for literal, field_name, spec, conv in self.parse(format_string):
                 # replace double braces if parse removed them
-                literal = literal.replace("{", "{{").replace("}", "}}")
+                format_literal = literal.replace("{", "{{").replace("}", "}}")
                 # if the field is {}, just add escaped empty braces
                 if field_name == "":
-                    tokens.extend([literal, "{{}}"])
+                    tokens.extend([format_literal, "{{}}"])
                     continue
                 # if field name was None, we just add the literal token
                 if field_name is None:
-                    tokens.extend([literal])
+                    tokens.extend([format_literal])
                     continue
                 # if conf and spec are not defined, set to ''
-                conv = "!" + conv if conv else ""
-                spec = ":" + spec if spec else ""
+                conv = "!" + conv if conv else ""  # noqa: PLW2901
+                spec = ":" + spec if spec else ""  # noqa: PLW2901
                 # only consider field before index
                 field = field_name.split("[")[0].split(".")[0]
                 # If this field is one we've defined, fill template value
                 if field in kwargs:
-                    tokens.extend([literal, "{", field_name, conv, spec, "}"])
+                    tokens.extend(
+                        [format_literal, "{", field_name, conv, spec, "}"]
+                    )
                 else:
                     # If not, the use escaped braces to pass it through
                     tokens.extend(
-                        [literal, "{{", field_name, conv, spec, "}}"]
+                        [format_literal, "{{", field_name, conv, spec, "}}"]
                     )
             format_string = "".join(tokens)
             return string.Formatter.vformat(self, format_string, args, kwargs)
@@ -412,7 +414,7 @@ def _run_test_cmds_list(cmds, config=None, env=None):
         # Settings from the device yaml configfile like device_ip can be
         # formatted in test commands like "foo {device_ip}"
         if "{{" in cmd:
-            cmd = _process_cmds_template_vars(cmd, config)
+            cmd = _process_cmds_template_vars(cmd, config)  # noqa: PLW2901
 
         logger.info("Running: %s", cmd)
         result = runcmd(cmd, env)

--- a/device-connectors/src/testflinger_device_connectors/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/__init__.py
@@ -99,7 +99,7 @@ def delayretry(func, args, max_retries=3, delay=0):
     for retry_count in range(max_retries):
         try:
             ret = func(*args)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             time.sleep(delay)
             if retry_count == max_retries - 1:
                 raise

--- a/device-connectors/src/testflinger_device_connectors/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/__init__.py
@@ -252,7 +252,7 @@ def compress_file(filename):
 
 
 def configure_logging(config):
-    """Setups logging."""
+    """Set up logging."""
 
     class AgentFormatter(logging.Formatter):
         """Add agent_name to log records."""
@@ -321,7 +321,8 @@ def runcmd(cmd, env=None, timeout=None):
 
 
 def run_test_cmds(cmds, config=None, env=None):
-    """Run the test commands provided
+    """Run the test commands provided.
+
     This is just a frontend to determine the type of cmds we
     were passed and do the right thing with it.
 

--- a/device-connectors/src/testflinger_device_connectors/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/__init__.py
@@ -11,7 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""General functions used by device connectors"""
+"""General functions used by device connectors."""
 
 import bz2
 import gzip
@@ -33,12 +33,11 @@ logger = logging.getLogger(__name__)
 
 
 class CmdTimeoutError(Exception):
-    """Exception for timeout running running commands"""
+    """Exception for timeout running running commands."""
 
 
 def get_test_opportunity(job_data="testflinger.json"):
-    """
-    Read the json test opportunity data from testflinger.json.
+    """Read the json test opportunity data from testflinger.json.
 
     :param job_data:
         Filename and path of the json data if not the default
@@ -51,7 +50,7 @@ def get_test_opportunity(job_data="testflinger.json"):
 
 
 def filetype(filename):
-    """Attempt to determine the compression type of a specified file"""
+    """Attempt to determine the compression type of a specified file."""
     magic_headers = {
         b"\x1f\x8b\x08": "gz",
         b"\x42\x5a\x68": "bz2",
@@ -69,8 +68,7 @@ def filetype(filename):
 
 
 def download(url, filename=None):
-    """
-    Download the at the specified URL
+    """Download the at the specified URL.
 
     :param url:
         URL of the file to download
@@ -87,8 +85,7 @@ def download(url, filename=None):
 
 
 def delayretry(func, args, max_retries=3, delay=0):
-    """
-    Retry the called function with a delay inserted between attempts
+    """Retry the called function with a delay inserted between attempts.
 
     :param func:
         Function to retry
@@ -111,9 +108,8 @@ def delayretry(func, args, max_retries=3, delay=0):
 
 
 def get_test_username(job_data="testflinger.json", default="ubuntu"):
-    """
-    If the test_data specifies a default username, use it. Otherwise
-    allow the provisioning method pick a default, or use ubuntu as a safe bet
+    """If the test_data specifies a default username, use it. Otherwise
+    allow the provisioning method pick a default, or use ubuntu as a safe bet.
 
     :return username:
         Returns the test image username
@@ -127,9 +123,8 @@ def get_test_username(job_data="testflinger.json", default="ubuntu"):
 
 
 def get_test_password(job_data="testflinger.json", default="ubuntu"):
-    """
-    If the test_data specifies a default password, use it. Otherwise
-    allow the provisioning method pick a default, or use ubuntu as a safe bet
+    """If the test_data specifies a default password, use it. Otherwise
+    allow the provisioning method pick a default, or use ubuntu as a safe bet.
 
     :return password:
         Returns the test image password
@@ -143,8 +138,7 @@ def get_test_password(job_data="testflinger.json", default="ubuntu"):
 
 
 def get_image(job_data="testflinger.json"):
-    """
-    Read the json data for a test opportunity from SPI and retrieve or
+    """Read the json data for a test opportunity from SPI and retrieve or
     create the requested image.
 
     :return compressed_filename:
@@ -166,8 +160,7 @@ def get_image(job_data="testflinger.json"):
 
 
 def get_local_ip_addr():
-    """
-    Return our default IP address for another system to connect to
+    """Return our default IP address for another system to connect to.
 
     :return ipaddr:
         Returns the ip address of this system
@@ -180,8 +173,7 @@ def get_local_ip_addr():
 
 
 def serve_file(queue, filename):
-    """
-    Wait for a connection, then send the specified file one time
+    """Wait for a connection, then send the specified file one time.
 
     :param queue:
         multiprocessing queue used to send the port number back
@@ -205,8 +197,7 @@ def serve_file(queue, filename):
 
 
 def compress_file(filename):
-    """
-    Gzip the specified file, return the filename of the compressed image
+    """Gzip the specified file, return the filename of the compressed image.
 
     :param filename:
         The file to compress
@@ -261,10 +252,10 @@ def compress_file(filename):
 
 
 def configure_logging(config):
-    """Setup logging"""
+    """Setups logging."""
 
     class AgentFormatter(logging.Formatter):
-        """Add agent_name to log records"""
+        """Add agent_name to log records."""
 
         def __init__(self, fmt, agent_name):
             super().__init__(fmt)
@@ -289,8 +280,7 @@ def configure_logging(config):
 
 
 def runcmd(cmd, env=None, timeout=None):
-    """
-    Run a command and stream the output to stdout
+    """Run a command and stream the output to stdout.
 
     :param cmd:
         Command to run
@@ -301,7 +291,6 @@ def runcmd(cmd, env=None, timeout=None):
     :return returncode:
         Return value from running the command
     """
-
     # Sanitize the environment, eliminate null values or Popen may choke
     if not env:
         env = {}
@@ -332,10 +321,9 @@ def runcmd(cmd, env=None, timeout=None):
 
 
 def run_test_cmds(cmds, config=None, env=None):
-    """
-    Run the test commands provided
+    """Run the test commands provided
     This is just a frontend to determine the type of cmds we
-    were passed and do the right thing with it
+    were passed and do the right thing with it.
 
     :param cmds:
         Commands to run as a string or list of strings
@@ -344,7 +332,6 @@ def run_test_cmds(cmds, config=None, env=None):
     :param env:
         Environment to pass when running the commands
     """
-
     if not env:
         env = os.environ.copy()
     config_env = config.get("env", {})
@@ -358,8 +345,7 @@ def run_test_cmds(cmds, config=None, env=None):
 
 
 def _process_cmds_template_vars(cmds, config=None):
-    """
-    Fill in templated values for test command string. Ignore any values
+    """Fill in templated values for test command string. Ignore any values
     in braces for which we don't have a config item.
 
     :param cmds:
@@ -367,11 +353,10 @@ def _process_cmds_template_vars(cmds, config=None):
     :param config:
         Config data for the device which can be used for filling templates
     """
-
     logger.warning("DEPRECATED - Detected use of double-braces in test_cmds")
 
     class IgnoreUnknownFormatter(string.Formatter):
-        """Try to allow both double and single curly braces"""
+        """Try to allow both double and single curly braces."""
 
         def vformat(self, format_string, args, kwargs):
             tokens = []
@@ -410,8 +395,7 @@ def _process_cmds_template_vars(cmds, config=None):
 
 
 def _run_test_cmds_list(cmds, config=None, env=None):
-    """
-    Run the test commands provided
+    """Run the test commands provided.
 
     :param cmds:
         Commands to run as a list of strings
@@ -422,7 +406,6 @@ def _run_test_cmds_list(cmds, config=None, env=None):
     :return returncode:
         Return 0 if everything succeeded, or exit code from failed command
     """
-
     if not env:
         env = {}
     for cmd in cmds:
@@ -439,8 +422,7 @@ def _run_test_cmds_list(cmds, config=None, env=None):
 
 
 def _run_test_cmds_str(cmds, config=None, env=None):
-    """
-    Run the test commands provided
+    """Run the test commands provided.
 
     :param cmds:
         Commands to run as a string
@@ -451,7 +433,6 @@ def _run_test_cmds_str(cmds, config=None, env=None):
     :return returncode:
         Return the value of the return code from the script
     """
-
     if not env:
         env = {}
     # If cmds doesn't specify an interpreter, pick a safe default

--- a/device-connectors/src/testflinger_device_connectors/cmd.py
+++ b/device-connectors/src/testflinger_device_connectors/cmd.py
@@ -18,11 +18,12 @@ Main testflinger-device-connectors command module
 
 
 import argparse
+import json
 import logging
-import yaml
 import sys
 from typing import Callable
-import json
+
+import yaml
 
 from testflinger_device_connectors import configure_logging
 from testflinger_device_connectors.devices import (

--- a/device-connectors/src/testflinger_device_connectors/cmd.py
+++ b/device-connectors/src/testflinger_device_connectors/cmd.py
@@ -12,9 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
-Main testflinger-device-connectors command module
-"""
+"""Main testflinger-device-connectors command module."""
 
 
 import argparse
@@ -46,7 +44,7 @@ STAGES = (
 
 
 def get_args(argv=None):
-    """main command function for testflinger-device-connectors"""
+    """Command function for testflinger-device-connectors."""
     parser = argparse.ArgumentParser()
 
     # First add a subcommand for each supported device type
@@ -75,7 +73,9 @@ def get_args(argv=None):
 
 
 def add_exception_logging_to_file(func: Callable, stage: str):
-    """Decorator function to add logging of exceptions to a json file"""
+    """Add logging of exceptions to a json file,
+    used as a decorator function.
+    """
 
     def _wrapper(*args, **kwargs):
         try:
@@ -105,9 +105,7 @@ def add_exception_logging_to_file(func: Callable, stage: str):
 
 
 def main():
-    """
-    Dynamically load the selected module and call the selected method
-    """
+    """Dynamically load the selected module and call the selected method."""
     args = get_args()
     with open(args.config) as configfile:
         config = yaml.safe_load(configfile)

--- a/device-connectors/src/testflinger_device_connectors/cmd.py
+++ b/device-connectors/src/testflinger_device_connectors/cmd.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Main testflinger-device-connectors command module."""
 
-
 import argparse
 import json
 import logging

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -172,7 +172,7 @@ class DefaultDevice:
                     if not update_succeeded:
                         exitcode = 1
             except Exception as err:
-                logger.error("Firmware Update failed: ", str(err))
+                logger.error("Firmware Update failed: %s", str(err))
                 exitcode = 1
             finally:
                 logger.info("END firmware_update")
@@ -257,7 +257,7 @@ class DefaultDevice:
             ]
         )
 
-        for retry in range(10):
+        for _retry in range(10):
             # Retry ssh key copy just in case it's rebooting
             try:
                 subprocess.check_call(cmd, timeout=30)

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -295,7 +295,7 @@ class DefaultDevice:
             except FileNotFoundError:
                 pass
             cmd = ["ssh-import-id", "-o", "key.pub", key]
-            proc = subprocess.run(cmd)
+            proc = subprocess.run(cmd, check=False)
             if proc.returncode != 0:
                 logger.error("Unable to import ssh key from: %s", key)
                 continue

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -101,9 +101,12 @@ class RealSerialLogger:
                 try:
                     self._log_serial()
                 except Exception:
-                    pass
+                    logger.error("Error connecting to serial logging server")
+
                 # Keep trying if we can't connect, but sleep between attempts
-                logger.error("Error connecting to serial logging server")
+                logger.info(
+                    "Sleeping for 30 seconds before reattemting to reconnect"
+                )
                 time.sleep(30)
 
         self.proc = multiprocessing.Process(target=reconnector, daemon=True)

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -64,16 +64,14 @@ class RecoveryError(Exception):
 
 
 def SerialLogger(host=None, port=None, filename=None):
-    """
-    Factory to generate real or fake SerialLogger object based on params
-    """
+    """Generate real or fake SerialLogger object based on params."""
     if host and port and filename:
         return RealSerialLogger(host, port, filename)
     return StubSerialLogger(host, port, filename)
 
 
 class StubSerialLogger:
-    """Fake SerialLogger when we don't have Serial Logger data defined"""
+    """Fake SerialLogger when we don't have Serial Logger data defined."""
 
     def __init__(self, host, port, filename):
         pass
@@ -86,19 +84,19 @@ class StubSerialLogger:
 
 
 class RealSerialLogger:
-    """Real SerialLogger for when we have a serial logging service"""
+    """Real SerialLogger for when we have a serial logging service."""
 
     def __init__(self, host, port, filename):
-        """Set up a subprocess to connect to an ip and collect serial logs"""
+        """Set up a subprocess to connect to an ip and collect serial logs."""
         self.host = host
         self.port = int(port)
         self.filename = filename
 
     def start(self):
-        """Start the serial logger connection"""
+        """Start the serial logger connection."""
 
         def reconnector():
-            """Reconnect when needed"""
+            """Reconnect when needed."""
             while True:
                 try:
                     self._log_serial()
@@ -112,7 +110,7 @@ class RealSerialLogger:
         self.proc.start()
 
     def _log_serial(self):
-        """Log data to the serial data to the output file"""
+        """Log data to the serial data to the output file."""
         with open(self.filename, "ab+") as f:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.connect((self.host, self.port))
@@ -132,13 +130,13 @@ class RealSerialLogger:
                             return
 
     def stop(self):
-        """Stop the serial logger"""
+        """Stop the serial logger."""
         self.proc.terminate()
 
 
 class DefaultDevice:
     def firmware_update(self, args):
-        """Default method for processing firmware update commands"""
+        """Process firmware update commands (default method)."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
         logger.info("BEGIN firmware_update")
@@ -183,7 +181,7 @@ class DefaultDevice:
         return exitcode
 
     def runtest(self, args):
-        """Default method for processing test commands"""
+        """Process test commands (default method)."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
         logger.info("BEGIN testrun")
@@ -215,7 +213,7 @@ class DefaultDevice:
         return exitcode
 
     def allocate(self, args):
-        """Default method for allocating devices for multi-agent jobs"""
+        """Allocate devices for multi-agent jobs (default method)."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
         device_ip = config["device_ip"]
@@ -231,8 +229,7 @@ class DefaultDevice:
         password: Optional[str] = None,
         key: Optional[str] = None,
     ):
-        """
-        If provided, copy the SSH `key` to the DUT,
+        """If provided, copy the SSH `key` to the DUT,
         otherwise copy the agent's using password authentication.
 
         :raises RuntimeError in case it can't copy the SSH keys
@@ -278,7 +275,7 @@ class DefaultDevice:
             raise RuntimeError
 
     def reserve(self, args):
-        """Default method for reserving systems"""
+        """Reserve systems (default method)."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
         logger.info("BEGIN reservation")
@@ -337,13 +334,13 @@ class DefaultDevice:
         time.sleep(int(timeout))
 
     def cleanup(self, _):
-        """Default method for cleaning up devices"""
+        """Clean up devices (default method)."""
         pass
 
 
 def get_device_stage_func(device: str, stage: str) -> Callable:
-    """
-    Load the selected device connector and return the selected stage method
+    """Load the selected device connector and
+    return the selected stage method.
     """
     module = import_module(f".{device}", package=__package__)
     device_class = getattr(module, "DeviceConnector")

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -155,7 +155,7 @@ class DefaultDevice:
         if version not in supported_version:
             logger.info(
                 "Fail to provide version in firmware_update_data. "
-                + "Current supported version: latest",
+                "Current supported version: latest",
             )
             exitcode = 1
         else:

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -104,9 +104,6 @@ class RealSerialLogger:
                     logger.error("Error connecting to serial logging server")
 
                 # Keep trying if we can't connect, but sleep between attempts
-                logger.info(
-                    "Sleeping for 30 seconds before reattemting to reconnect"
-                )
                 time.sleep(30)
 
         self.proc = multiprocessing.Process(target=reconnector, daemon=True)

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -343,7 +343,7 @@ def get_device_stage_func(device: str, stage: str) -> Callable:
     return the selected stage method.
     """
     module = import_module(f".{device}", package=__package__)
-    device_class = getattr(module, "DeviceConnector")
+    device_class = module.DeviceConnector
     device_instance = device_class()
     stage_method = getattr(device_instance, stage)
     return stage_method

--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/__init__.py
@@ -31,7 +31,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
         device = CM3(args.config, args.job_data)

--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
@@ -147,13 +147,12 @@ class CM3:
         ]
         for dev in dev_list:
             # FIXME: Specify exception instead of `Exception`
-            with contextlib.suppress(Exception):
-                with self.remote_mount(dev):
-                    dirs = self._run_control("ls /mnt")
-                    for path, img_type in self.IMAGE_PATH_IDS.items():
-                        if path in dirs.decode().split():
-                            return img_type, dev
-                continue
+            with contextlib.suppress(Exception), self.remote_mount(dev):
+                dirs = self._run_control("ls /mnt")
+                for path, img_type in self.IMAGE_PATH_IDS.items():
+                    if path in dirs.decode().split():
+                        return img_type, dev
+
         # We have no idea what kind of image this is
         return "unknown", dev
 

--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
@@ -115,7 +115,7 @@ class CM3:
             return
         agent_name = self.config.get("agent_name")
         logger.error(
-            "Device %s unreachable after provisioning, deployment " "failed!",
+            "Device %s unreachable after provisioning, deployment failed!",
             agent_name,
         )
         raise ProvisioningError("Provisioning failed!")

--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
@@ -89,8 +89,9 @@ class CM3:
             self._run_control("test -f /dev/sda")
             # paranoid, but be really certain we're not running locally
             self._run_control("sudo rm -f /dev/sda")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Exception found while removing /dev/sda: %s", e)
+
         self._run_control("sudo pi3gpio set high 16")
         time.sleep(5)
         self.hardreset()
@@ -151,8 +152,13 @@ class CM3:
                     for path, img_type in self.IMAGE_PATH_IDS.items():
                         if path in dirs.decode().split():
                             return img_type, dev
-            except Exception:
+            except Exception as e:
                 # If unmountable or any other error, go on to the next one
+                logger.warning(
+                    "Error %s found while processing device: %s.",
+                    e,
+                    dev,
+                )
                 continue
         # We have no idea what kind of image this is
         return "unknown", dev
@@ -185,8 +191,10 @@ class CM3:
                     cmd, stderr=subprocess.STDOUT, timeout=60
                 )
                 return True
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(
+                    "Exception %s encountered while running: %s", e, cmd
+                )
         # If we get here, then we didn't boot in time
         raise ProvisioningError("Failed to boot test image!")
 

--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
@@ -72,18 +72,18 @@ class CM3:
                 ssh_cmd, stderr=subprocess.STDOUT, timeout=timeout
             )
         except subprocess.CalledProcessError as e:
-            raise ProvisioningError(e.output)
+            raise ProvisioningError(e.output) from e
         return output
 
     def provision(self):
         try:
             url = self.job_data["provision_data"]["url"]
-        except KeyError:
+        except KeyError as err:
             raise ProvisioningError(
                 'You must specify a "url" value in '
                 'the "provision_data" section of '
                 "your job_data"
-            )
+            ) from err
         # Remove /dev/sda if somehow it's a normal file
         try:
             self._run_control("test -f /dev/sda")
@@ -251,8 +251,8 @@ class CM3:
                         )
                     )
                     self._run_control(rm_cmd)
-        except Exception:
-            raise ProvisioningError("Error creating user files")
+        except Exception as e:
+            raise ProvisioningError("Error creating user files") from e
 
     def hardreset(self):
         """Reboot the device.
@@ -268,5 +268,5 @@ class CM3:
             logger.info("Running %s", cmd)
             try:
                 subprocess.check_call(cmd.split(), timeout=120)
-            except Exception:
-                raise RecoveryError("timeout reaching control host!")
+            except Exception as e:
+                raise RecoveryError("timeout reaching control host!") from e

--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/cm3.py
@@ -47,8 +47,7 @@ class CM3:
             self.job_data = json.load(j)
 
     def _run_control(self, cmd, timeout=60):
-        """
-        Run a command on the control host over ssh
+        """Run a command on the control host over ssh.
 
         :param cmd:
             Command to run
@@ -132,8 +131,7 @@ class CM3:
             self._run_control("sudo umount {}".format(mount_point))
 
     def get_image_type(self):
-        """
-        Figure out which kind of image is on the configured block device
+        """Figure out which kind of image is on the configured block device.
 
         :returns:
             tuple of image type and device as strings
@@ -193,7 +191,7 @@ class CM3:
         raise ProvisioningError("Failed to boot test image!")
 
     def create_user(self, image_type):
-        """Create user account for default ubuntu user"""
+        """Create user account for default ubuntu user."""
         metadata = "instance_id: cloud-image"
         userdata = (
             "#cloud-config\n"
@@ -257,8 +255,7 @@ class CM3:
             raise ProvisioningError("Error creating user files")
 
     def hardreset(self):
-        """
-        Reboot the device.
+        """Reboot the device.
 
         :raises RecoveryError:
             If the command times out or anything else fails.

--- a/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
@@ -24,6 +24,7 @@ import logging
 from testflinger_device_connectors.devices import (
     DefaultDevice,
 )
+
 from .dell_oemscript import DellOemScript
 
 logger = logging.getLogger(__name__)

--- a/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
@@ -12,8 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Ubuntu OEM Recovery provisioning for Dell OEM devices
+"""Ubuntu OEM Recovery provisioning for Dell OEM devices
 Use this for systems that can use the oem recovery-from-iso.sh script
 for provisioning, but require the --ubr flag in order to use the
 "ubuntu recovery" method.
@@ -34,7 +33,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning Dell OEM devices with an oem image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         device = DellOemScript(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/dell_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/dell_oemscript.py
@@ -19,6 +19,7 @@ for provisioning, but require the --ubr flag in order to use the
 """
 
 import logging
+
 from testflinger_device_connectors.devices.oemscript.oemscript import OemScript
 
 logger = logging.getLogger(__name__)

--- a/device-connectors/src/testflinger_device_connectors/devices/dragonboard/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dragonboard/__init__.py
@@ -33,7 +33,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
         device = Dragonboard(args.config, args.job_data)

--- a/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
@@ -48,8 +48,7 @@ class Dragonboard:
         )
 
     def _run_control(self, cmd, timeout=60):
-        """
-        Run a command on the control host over ssh
+        """Run a command on the control host over ssh.
 
         :param cmd:
             Command to run
@@ -73,8 +72,7 @@ class Dragonboard:
         return output
 
     def setboot(self, mode):
-        """
-        Set the boot mode of the device.
+        """Set the boot mode of the device.
 
         :param mode:
             One of 'master' or 'test'
@@ -99,8 +97,7 @@ class Dragonboard:
                 raise ProvisioningError("timeout reaching control host!")
 
     def hardreset(self):
-        """
-        Reboot the device.
+        """Reboot the device.
 
         :raises RecoveryError:
             If the command times out or anything else fails.
@@ -117,9 +114,7 @@ class Dragonboard:
                 raise RecoveryError("timeout reaching control host!")
 
     def copy_ssh_id(self):
-        """
-        Copy the ssh key to the device.
-        """
+        """Copy the ssh key to the device."""
         cmd = [
             "sshpass",
             "-p",
@@ -137,8 +132,7 @@ class Dragonboard:
             pass
 
     def ensure_test_image(self):
-        """
-        Actively switch the device to boot the test image.
+        """Actively switch the device to boot the test image.
 
         :raises ProvisioningError:
             If the command times out or anything else fails.
@@ -165,8 +159,7 @@ class Dragonboard:
             raise ProvisioningError("Failed to boot test image!")
 
     def is_test_image_booted(self):
-        """
-        Check if the master image is booted.
+        """Check if the master image is booted.
 
         :returns:
             True if the test image is currently booted, False otherwise.
@@ -189,8 +182,7 @@ class Dragonboard:
         return True
 
     def is_master_image_booted(self):
-        """
-        Check if the master image is booted.
+        """Check if the master image is booted.
 
         :returns:
             True if the master image is currently booted, False otherwise.
@@ -210,8 +202,7 @@ class Dragonboard:
         return False
 
     def ensure_master_image(self):
-        """
-        Actively switch the device to boot the test image.
+        """Actively switch the device to boot the test image.
 
         :raises RecoveryError:
             If the command times out or anything else fails.
@@ -258,8 +249,7 @@ class Dragonboard:
         # If we get here, the master image was already booted, so just return
 
     def flash_test_image(self, server_ip, server_port):
-        """
-        Flash the image at :image_url to the sd card.
+        """Flash the image at :image_url to the sd card.
 
         :param server_ip:
             IP address of the image server. The image will be downloaded and
@@ -323,7 +313,7 @@ class Dragonboard:
             raise ProvisioningError(err)
 
     def create_user(self):
-        """Create user account for default ubuntu user"""
+        """Create user account for default ubuntu user."""
         self.mount_writable_partition()
         metadata = "instance_id: cloud-image"
         userdata = (
@@ -370,7 +360,7 @@ class Dragonboard:
         )
 
     def wipe_test_device(self):
-        """Safety check - wipe the test drive if things go wrong
+        """Safety check - wipe the test drive if things go wrong.
 
         This way if we reboot the sytem after a failed provision, it goes
         back to the control boot image which we could use to provision
@@ -386,7 +376,7 @@ class Dragonboard:
             pass
 
     def provision(self):
-        """Provision the device"""
+        """Provision the device."""
         url = self.job_data["provision_data"].get("url")
         self.copy_ssh_id()
         self.ensure_master_image()

--- a/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
@@ -229,7 +229,7 @@ class Dragonboard:
 
         master_booted = self.is_master_image_booted()
         if not master_booted:
-            logging.warn(
+            logger.warning(
                 "Device is in an unknown state, attempting to recover"
             )
             self.hardreset()
@@ -281,7 +281,7 @@ class Dragonboard:
             self._run_control("sync")
         except subprocess.SubprocessError:
             # Nothing should go wrong here, but let's sleep if it does
-            logger.warn("Something went wrong with the sync, sleeping...")
+            logger.warning("Something went wrong with the sync, sleeping...")
             time.sleep(30)
         try:
             self._run_control(
@@ -290,8 +290,9 @@ class Dragonboard:
             )
         except subprocess.CalledProcessError as exc:
             raise ProvisioningError(
-                "Unable to run hdparm to rescan"
-                "partitions: {}".format(exc.output)
+                "Unable to run hdparm to rescan partitions: {}".format(
+                    exc.output
+                )
             )
 
     def mount_writable_partition(self):

--- a/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dragonboard/dragonboard.py
@@ -93,8 +93,10 @@ class Dragonboard:
             logger.info("Running %s", cmd)
             try:
                 subprocess.check_call(cmd.split(), timeout=60)
-            except subprocess.TimeoutExpired:
-                raise ProvisioningError("timeout reaching control host!")
+            except subprocess.TimeoutExpired as exc:
+                raise ProvisioningError(
+                    "timeout reaching control host!"
+                ) from exc
 
     def hardreset(self):
         """Reboot the device.
@@ -110,8 +112,8 @@ class Dragonboard:
             logger.info("Running %s", cmd)
             try:
                 subprocess.check_call(cmd.split(), timeout=120)
-            except subprocess.TimeoutExpired:
-                raise RecoveryError("timeout reaching control host!")
+            except subprocess.TimeoutExpired as exc:
+                raise RecoveryError("timeout reaching control host!") from exc
 
     def copy_ssh_id(self):
         """Copy the ssh key to the device."""
@@ -275,8 +277,10 @@ class Dragonboard:
         try:
             # XXX: I hope 30 min is enough? but maybe not!
             self._run_control(cmd, timeout=1800)
-        except subprocess.TimeoutExpired:
-            raise ProvisioningError("timeout reached while flashing image!")
+        except subprocess.TimeoutExpired as exc:
+            raise ProvisioningError(
+                "timeout reached while flashing image!"
+            ) from exc
         try:
             self._run_control("sync")
         except subprocess.SubprocessError:
@@ -293,7 +297,7 @@ class Dragonboard:
                 "Unable to run hdparm to rescan partitions: {}".format(
                     exc.output
                 )
-            )
+            ) from exc
 
     def mount_writable_partition(self):
         # Mount the writable partition
@@ -311,7 +315,7 @@ class Dragonboard:
                     self.config["snappy_writable_partition"], exc.output
                 )
             )
-            raise ProvisioningError(err)
+            raise ProvisioningError(err) from exc
 
     def create_user(self):
         """Create user account for default ubuntu user."""
@@ -348,7 +352,7 @@ class Dragonboard:
         except subprocess.CalledProcessError as exc:
             raise ProvisioningError(
                 "Error creating user files: {}".format(exc.output)
-            )
+            ) from exc
 
     def setup_sudo(self):
         sudo_data = "ubuntu ALL=(ALL) NOPASSWD:ALL"

--- a/device-connectors/src/testflinger_device_connectors/devices/fake_connector/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/fake_connector/__init__.py
@@ -25,7 +25,6 @@ from testflinger_device_connectors.devices import (
     DefaultDevice,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/device-connectors/src/testflinger_device_connectors/devices/fake_connector/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/fake_connector/__init__.py
@@ -11,8 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
-This is a fake device connector that can be used for testing
+"""Fake device connector that can be used for testing.
 
 It will not actually provision anything, but it will otherwise act like a
 normal device connector for the other phases, such as running the test_cmds
@@ -32,7 +31,7 @@ class DeviceConnector(DefaultDevice):
     """Fake device connector."""
 
     def provision(self, args):
-        """dummy provision"""
+        """Begin dummy provision."""
         with open(args.job_data) as json_file:
             job_data = json.load(json_file)
         provision_data = job_data.get("provision_data", {})

--- a/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
@@ -24,6 +24,7 @@ import logging
 from testflinger_device_connectors.devices import (
     DefaultDevice,
 )
+
 from .hp_oemscript import HPOemScript
 
 logger = logging.getLogger(__name__)

--- a/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
@@ -12,8 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Ubuntu OEM Recovery Provisioning for HP OEM devices
+"""Ubuntu OEM Recovery Provisioning for HP OEM devices
 Use this for systems that can use the oem recovery-from-iso.sh script
 for provisioning, but require the --ubr flag in order to use the
 "ubuntu recovery" method.
@@ -34,7 +33,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning HP OEM devices with an oem image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         device = HPOemScript(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/hp_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/hp_oemscript.py
@@ -19,6 +19,7 @@ for provisioning, but require the --ubr flag in order to use the
 """
 
 import logging
+
 from testflinger_device_connectors.devices.oemscript.oemscript import OemScript
 
 logger = logging.getLogger(__name__)

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
@@ -12,8 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Ubuntu OEM Recovery Provisioning for Lenovo OEM devices
+"""Ubuntu OEM Recovery Provisioning for Lenovo OEM devices
 Use this for systems that can use the oem recovery-from-iso.sh script
 for provisioning, but require the --ubr flag in order to use the
 "ubuntu recovery" method.
@@ -34,7 +33,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning Lenovo OEM devices with an oem image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         device = LenovoOemScript(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
@@ -12,7 +12,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Ubuntu OEM Recovery Provisioning for Lenovo OEM devices
+"""Ubuntu OEM Recovery Provisioning for Lenovo OEM devices.
+
 Use this for systems that can use the oem recovery-from-iso.sh script
 for provisioning, but require the --ubr flag in order to use the
 "ubuntu recovery" method.

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
@@ -24,6 +24,7 @@ import logging
 from testflinger_device_connectors.devices import (
     DefaultDevice,
 )
+
 from .lenovo_oemscript import LenovoOemScript
 
 logger = logging.getLogger(__name__)

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/lenovo_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/lenovo_oemscript.py
@@ -12,8 +12,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Ubuntu OEM Script provisioning for Lenovo OEM devices
-this for systems that can use the oem recovery-from-iso.sh script
+"""Ubuntu OEM Script provisioning for Lenovo OEM devices.
+
+Use this for systems that can use the oem recovery-from-iso.sh script
 for provisioning, but require the --ubr flag in order to use the
 "ubuntu recovery" method.
 """

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/lenovo_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/lenovo_oemscript.py
@@ -19,6 +19,7 @@ for provisioning, but require the --ubr flag in order to use the
 """
 
 import logging
+
 from testflinger_device_connectors.devices.oemscript.oemscript import OemScript
 
 logger = logging.getLogger(__name__)

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
@@ -32,7 +32,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
         device = Maas2(args.config, args.job_data)

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -241,8 +241,7 @@ class Maas2:
         return False
 
     def run_maas_cmd_with_retry(self, cmd, max_retries=5, backoff_start=60):
-        """
-        Run maas command with retries on failure
+        """Run maas command with retries on failure.
 
         :param cmd:
             MAAS command to be run
@@ -407,7 +406,7 @@ class Maas2:
         return True
 
     def node_status(self):
-        """Return status of the node according to maas:
+        """Return status of the node according to maas.
 
         Ready: Node is unused
         Allocated: Node is allocated
@@ -421,7 +420,7 @@ class Maas2:
         return data.get("status_name")
 
     def node_release(self):
-        """Release the node to make it available again"""
+        """Release the node to make it available again."""
         cmd = ["maas", self.maas_user, "machine", "release", self.node_id]
         subprocess.run(cmd, check=False)
         # Make sure the device is available before returning
@@ -437,7 +436,7 @@ class Maas2:
         raise RecoveryError("Device recovery failed!")
 
     def set_flat_storage_layout(self):
-        """Reset to default flat storage layout"""
+        """Reset to default flat storage layout."""
         cmd = [
             "maas",
             self.maas_user,

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -50,19 +50,19 @@ class Maas2:
         self.maas_storage = MaasStorage(self.maas_user, self.node_id)
 
     def _logger_debug(self, message):
-        logger.debug("MAAS: {}".format(message))
+        logger.debug("MAAS: %s", message)
 
     def _logger_info(self, message):
-        logger.info("MAAS: {}".format(message))
+        logger.info("MAAS: %s", message)
 
     def _logger_warning(self, message):
-        logger.warning("MAAS: {}".format(message))
+        logger.warning("MAAS: %s", message)
 
     def _logger_error(self, message):
-        logger.error("MAAS: {}".format(message))
+        logger.error("MAAS: %s", message)
 
     def _logger_critical(self, message):
-        logger.critical("MAAS: {}".format(message))
+        logger.critical("MAAS: %s", message)
 
     def recover(self):
         if self.config.get("reset_efi"):

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -32,7 +32,6 @@ from testflinger_device_connectors.devices.maas2.maas_storage import (
     MaasStorageError,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -175,8 +175,9 @@ class Maas2:
         )
         if p.returncode:
             self._logger_error(
-                'Failed to set efi boot order to "{}":\n'
-                "{}".format(boot_order, p.stdout.decode())
+                'Failed to set efi boot order to "{}":\n{}'.format(
+                    boot_order, p.stdout.decode()
+                )
             )
 
     def reset_efi(self):
@@ -328,8 +329,7 @@ class Maas2:
         # Do not use runcmd for this - we need the output, not the end user
         proc = self.run_maas_cmd_with_retry(cmd)
         self._logger_info(
-            "Starting node {} "
-            "with distro {}".format(self.agent_name, distro)
+            "Starting node {} with distro {}".format(self.agent_name, distro)
         )
         cmd = [
             "maas",
@@ -355,7 +355,7 @@ class Maas2:
             time.sleep(60)
             minutes_spent += 1
             self._logger_info(
-                "{} minutes passed " "since deployment.".format(minutes_spent)
+                "{} minutes passed since deployment.".format(minutes_spent)
             )
             status = self.node_status()
 
@@ -374,8 +374,9 @@ class Maas2:
                     return
 
         self._logger_error(
-            'Device {} still in "{}" state, deployment '
-            "failed!".format(self.agent_name, status)
+            'Device {} still in "{}" state, deployment failed!'.format(
+                self.agent_name, status
+            )
         )
         self._logger_error(proc.stdout.decode())
         exception_msg = (
@@ -430,8 +431,9 @@ class Maas2:
             if status == "Ready":
                 return
         self._logger_error(
-            'Device {} still in "{}" state, could not '
-            "recover!".format(self.agent_name, status)
+            'Device {} still in "{}" state, could not recover!'.format(
+                self.agent_name, status
+            )
         )
         raise RecoveryError("Device recovery failed!")
 

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
@@ -14,13 +14,13 @@
 
 """Ubuntu MAAS 2.x storage provisioning code."""
 
-import logging
-import subprocess
 import collections
 import json
+import logging
 import math
-from testflinger_device_connectors.devices import ProvisioningError
+import subprocess
 
+from testflinger_device_connectors.devices import ProvisioningError
 
 logger = logging.getLogger(__name__)
 
@@ -204,7 +204,8 @@ class MaasStorage:
 
     def assign_parent_disk(self):
         """Transverse device hierarchy to determine each device's parent
-        disk."""
+        disk.
+        """
         dev_dict = {dev["id"]: dev for dev in self.device_list}
         for dev in self.device_list:
             parent_id = dev.get("device") or dev.get("volume")

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
@@ -129,11 +129,11 @@ class MaasStorage:
             try:
                 # attempt to convert the size string to an integer
                 return int(size_str)
-            except ValueError:
+            except ValueError as err:
                 raise MaasStorageError(
                     "Sizes must end in T, G, M, K, B, or be an integer "
                     "when no unit is provided."
-                )
+                ) from err
 
     def configure_node_storage(self, storage_data, reset=False):
         """Configure the node's storage layout, from provisioning data."""

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas_storage.py
@@ -46,13 +46,13 @@ class MaasStorage:
             self.node_info = node_info
 
     def _logger_debug(self, message):
-        logger.debug("MAAS: {}".format(message))
+        logger.debug("MAAS: %s", message)
 
     def _logger_info(self, message):
-        logger.info("MAAS: {}".format(message))
+        logger.info("MAAS: %s", message)
 
     def _logger_error(self, message):
-        logger.error("MAAS: {}".format(message))
+        logger.error("MAAS: %s", message)
 
     def _node_read(self):
         """Read node block-devices.

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
@@ -14,7 +14,6 @@
 
 """Maas2 agent module unit tests."""
 
-
 import json
 from collections import namedtuple
 from unittest.mock import patch

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
@@ -30,7 +30,7 @@ from testflinger_device_connectors.devices.maas2.maas_storage import (
 
 
 def test_maas2_agent_invalid_storage(tmp_path):
-    """Test that the maas2 agent raises an exception when storage init fails"""
+    """Test maas2 agent raises an exception when storage init fails."""
     config_yaml = tmp_path / "config.yaml"
     config = {"maas_user": "user", "node_id": "abc", "agent_name": "agent001"}
     config_yaml.write_text(yaml.safe_dump(config))
@@ -47,9 +47,8 @@ def test_maas2_agent_invalid_storage(tmp_path):
 
 
 def test_maas_cmd_retry(tmp_path):
-    """
-    Test that maas commands get retried when the command returns an
-    exit code
+    """Test that maas commands get retried when the command returns an
+    exit code.
     """
     Process = namedtuple("Process", ["returncode", "stdout"])
     with patch(

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
@@ -16,12 +16,14 @@
 
 
 import json
+from collections import namedtuple
+from unittest.mock import patch
+
 import pytest
 import yaml
-from unittest.mock import patch
-from collections import namedtuple
-from testflinger_device_connectors.devices.maas2 import Maas2
+
 from testflinger_device_connectors.devices import ProvisioningError
+from testflinger_device_connectors.devices.maas2 import Maas2
 from testflinger_device_connectors.devices.maas2.maas_storage import (
     MaasStorageError,
 )

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas_storage.py
@@ -15,10 +15,12 @@
 """Maas2 agent storage module unit tests."""
 
 
-import pytest
 import json
 import subprocess
-from unittest.mock import Mock, MagicMock, call
+from unittest.mock import MagicMock, Mock, call
+
+import pytest
+
 from testflinger_device_connectors.devices.maas2.maas_storage import (
     MaasStorage,
     MaasStorageError,

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas_storage.py
@@ -38,7 +38,6 @@ class MockMaasStorage(MaasStorage):
         """Mock method to simulate the call_cmd method in the
         parent MaasStorage class.
         """
-
         if output_json:
             return json.loads(TestMaasStorage.node_info)
         else:
@@ -110,7 +109,7 @@ class TestMaasStorage:
 
     @pytest.fixture
     def maas_storage(self):
-        """Provides a MockMaasStorage instance for testing."""
+        """Provide a MockMaasStorage instance for testing."""
         maas_user = "maas_user"
         node_id = "node_id"
         yield MockMaasStorage(maas_user, node_id)
@@ -609,7 +608,7 @@ class TestMaasStorageCallCmd:
 
     @pytest.fixture
     def maas_storage(self):
-        """Provides a MockMaasStorage instance for testing."""
+        """Provide a MockMaasStorage instance for testing."""
         maas_user = "maas_user"
         node_id = "node_id"
         yield MockMaasStorageWithCallCmd(maas_user, node_id, self.node_info)

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas_storage.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas_storage.py
@@ -14,7 +14,6 @@
 
 """Maas2 agent storage module unit tests."""
 
-
 import json
 import subprocess
 from unittest.mock import MagicMock, Mock, call
@@ -392,7 +391,7 @@ class TestMaasStorage:
         }
 
         for dev_type, devices in devs_by_type.items():
-            for device in devices:
+            for _device in devices:
                 setattr(maas_storage, mock_methods[dev_type], MagicMock())
 
             setattr(

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class DeviceConnector(DefaultDevice):
-    """Device Connector for provisioning multiple devices at the same time"""
+    """Device Connector for provisioning multiple devices at the same time."""
 
     def init_device(self, args):
         """Read config data and initialize the device object."""
@@ -46,7 +46,7 @@ class DeviceConnector(DefaultDevice):
         self.device = Multi(self.config, self.job_data, tfclient)
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked.."""
         self.init_device(args)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")
@@ -54,8 +54,7 @@ class DeviceConnector(DefaultDevice):
         logger.info("END provision")
 
     def runtest(self, args):
-        """
-        The runtest method for multi-device connectors
+        """Runtest method for multi-device connectors.
 
         This is slightly different from the generic one because we also need
         to import the job_list.json data and inject the device_ip for each
@@ -89,7 +88,7 @@ class DeviceConnector(DefaultDevice):
         return exitcode
 
     def get_job_list_data(self, job_list_file: str = "job_list.json") -> list:
-        """Read job_list.json and return the list data"""
+        """Read job_list.json and return the list data."""
         if not os.path.exists(job_list_file):
             logger.error(
                 "Unable to find multi-job data file, job_list.json not found",
@@ -100,13 +99,12 @@ class DeviceConnector(DefaultDevice):
         return job_list_data
 
     def get_device_ip_dict(self):
-        """
-        Read job_list.json and return a dict of device IPs like this that
+        """Read job_list.json and return a dict of device IPs like this that
         can be used in the environment for the test commands:
         {
             "DEVICE_IP_1": "10.1.1.1",
             "DEVICE_IP_2": "10.1.1.2"
-        }
+        }.
         """
         job_list_data = self.get_job_list_data()
         device_ip_dict = {}
@@ -117,7 +115,7 @@ class DeviceConnector(DefaultDevice):
         return device_ip_dict
 
     def cleanup(self, args):
-        """Cancel all subordinates jobs before finishing the multi-agent job"""
+        """Cancel all subordinates jobs before finishing a multi-agent job."""
         self.init_device(args)
         job_list_data = self.get_job_list_data()
         job_id_list = [job.get("job_id") for job in job_list_data]

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
@@ -17,6 +17,7 @@
 import json
 import logging
 import os
+
 import yaml
 
 import testflinger_device_connectors

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import time
+
 import requests
 
 from testflinger_device_connectors.devices import ProvisioningError

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
@@ -138,11 +138,11 @@ class Multi:
             if not isinstance(job, dict):
                 logger.error("Job is not a dict: %s", job)
                 continue
-            job = self.inject_allocate_data(job)
-            job = self.inject_parent_jobid(job)
+            job_allocate_data = self.inject_allocate_data(job)
+            job_parent_jobid = self.inject_parent_jobid(job_allocate_data)
 
             try:
-                job_id = self.client.submit_job(job)
+                job_id = self.client.submit_job(job_parent_jobid)
             except requests.exceptions.HTTPError as exc:
                 logger.error("Unable to create job: %s", exc.response.text)
                 self.cancel_jobs(self.jobs)

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
@@ -138,11 +138,11 @@ class Multi:
             if not isinstance(job, dict):
                 logger.error("Job is not a dict: %s", job)
                 continue
-            job_allocate_data = self.inject_allocate_data(job)
-            job_parent_jobid = self.inject_parent_jobid(job_allocate_data)
+            updated_job = self.inject_allocate_data(job)
+            updated_job = self.inject_parent_jobid(updated_job)
 
             try:
-                job_id = self.client.submit_job(job_parent_jobid)
+                job_id = self.client.submit_job(updated_job)
             except requests.exceptions.HTTPError as exc:
                 logger.error("Unable to create job: %s", exc.response.text)
                 self.cancel_jobs(self.jobs)

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/multi.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class Multi:
-    """Device Connector for multi-device"""
+    """Device Connector for multi-device."""
 
     def __init__(self, config, job_data, client):
         """Initialize the multi-device connector.
@@ -44,7 +44,7 @@ class Multi:
         self.jobs = []
 
     def provision(self):
-        """Provision multi-device connector by creating the specified jobs"""
+        """Provision multi-device connector by creating the specified jobs."""
         self.create_jobs()
 
         # Wait for all jobs to reach the "allocated" state
@@ -81,17 +81,15 @@ class Multi:
         self.save_job_list_file()
 
     def terminate_if_parent_completed(self):
-        """If parent job is completed or cancelled, cancel sub jobs"""
+        """If parent job is completed or cancelled, cancel sub jobs."""
         if self.this_job_completed():
             self.cancel_jobs(self.jobs)
             raise ProvisioningError("Job cancelled or completed")
 
     def this_job_completed(self):
+        """If the job is completed, or cancelled, then we need to exit the
+        provision phase, and cleanup the subordinate jobs.
         """
-        If the job is completed, or cancelled, then we need to exit the
-        provision phase, and cleanup the subordinate jobs
-        """
-
         job_id = self.job_data.get("job_id")
         status = self.client.get_status(job_id)
         if status in ("cancelled", "completed"):
@@ -99,8 +97,7 @@ class Multi:
         return False
 
     def save_job_list_file(self):
-        """
-        Retrieve results for each job from the server, and look at the
+        """Retrieve results for each job from the server, and look at the
         "device_info" in each one to get the IP of the device, then
         create a job_list.json file with a list of jobs that looks like:
         [
@@ -112,7 +109,7 @@ class Multi:
             },
             ...
         ]
-        This file gets used by other steps that also need this information
+        This file gets used by other steps that also need this information.
         """
         job_list = []
         for job in self.jobs:
@@ -127,7 +124,7 @@ class Multi:
             json.dump(job_list, json_file)
 
     def create_jobs(self):
-        """Create the jobs for the multi-device connector"""
+        """Create the jobs for the multi-device connector."""
         jobs_list = self.job_data.get("provision_data", {}).get("jobs")
         if not jobs_list:
             raise ProvisioningError(
@@ -165,7 +162,7 @@ class Multi:
             self.jobs.append(job_id)
 
     def inject_allocate_data(self, job):
-        """Inject the allocate_data section into the job
+        """Inject the allocate_data section into the job.
 
         :param job: the job to inject the allocate data into
         :returns: the job with the allocate_data injected
@@ -175,7 +172,7 @@ class Multi:
         return job
 
     def inject_parent_jobid(self, job):
-        """Inject the parent job_id into the job
+        """Inject the parent job_id into the job.
 
         :param job: the job to inject the parent job_id into
         :returns: the job with parent_job_id added to it
@@ -185,7 +182,7 @@ class Multi:
         return job
 
     def cancel_jobs(self, jobs):
-        """Cancel all jobs in the specified list of job_ids"""
+        """Cancel all jobs in the specified list of job_ids."""
         for job in jobs:
             try:
                 self.client.cancel_job(job)

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/tests/test_multi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/tests/test_multi.py
@@ -23,15 +23,15 @@ from testflinger_device_connectors.devices.multi.tfclient import TFClient
 
 
 class MockTFClient(TFClient):
-    """Mock TFClient object"""
+    """Mock TFClient object."""
 
     def submit_job(self, job_data):
-        """Return a fake job id"""
+        """Return a fake job id."""
         return str(uuid4())
 
 
 def test_bad_tfclient_url():
-    """Test that Multi raises an exception when TFClient URL is bad"""
+    """Test that Multi raises an exception when TFClient URL is bad."""
     with pytest.raises(ValueError):
         TFClient(None)
     with pytest.raises(ValueError):
@@ -39,7 +39,7 @@ def test_bad_tfclient_url():
 
 
 def test_inject_allocate_data():
-    """Test that allocate_data section is injected into job"""
+    """Test that allocate_data section is injected into job."""
     test_config = {"agent_name": "test_agent"}
     job_data = {
         "provision_data": {
@@ -56,7 +56,7 @@ def test_inject_allocate_data():
 
 
 def test_inject_parent_jobid():
-    """Test that parent_jobid is injected into job"""
+    """Test that parent_jobid is injected into job."""
     test_config = {"agent_name": "test_agent"}
     parent_job_id = "11111111-1111-1111-1111-111111111111"
     job_data = {
@@ -75,7 +75,7 @@ def test_inject_parent_jobid():
 
 
 def test_this_job_completed():
-    """Test this_job_completed() returns True only when the job is completed"""
+    """Test this_job_completed returns True only when the job is completed."""
     test_config = {"agent_name": "test_agent"}
     job_data = {
         "job_id": "11111111-1111-1111-1111-111111111111",

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/tests/test_multi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/tests/test_multi.py
@@ -17,6 +17,7 @@
 from uuid import uuid4
 
 import pytest
+
 from testflinger_device_connectors.devices.multi.multi import Multi
 from testflinger_device_connectors.devices.multi.tfclient import TFClient
 

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/tfclient.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/tfclient.py
@@ -17,6 +17,7 @@
 import json
 import logging
 import urllib.parse
+
 import requests
 
 logger = logging.getLogger(__name__)

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/tfclient.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/tfclient.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Client for talking to Testflinger Server"""
+"""Client for talking to Testflinger Server."""
 
 import json
 import logging
@@ -24,10 +24,10 @@ logger = logging.getLogger(__name__)
 
 
 class TFClient:
-    """Testflinger connection class"""
+    """Testflinger connection class."""
 
     def __init__(self, url):
-        """Initialize the client with the url of the server
+        """Initialize the client with the url of the server.
 
         :param url: URL of the Testflinger server
         """
@@ -44,7 +44,7 @@ class TFClient:
         :param uri_frag:
             endpoint for the GET request
         :return:
-            String containing the response from the server
+            String containing the response from the server.
         """
         uri = urllib.parse.urljoin(self.server, uri_frag)
         try:
@@ -74,7 +74,7 @@ class TFClient:
         :param uri_frag:
             endpoint for the POST request
         :return:
-            String containing the response from the server
+            String containing the response from the server.
         """
         uri = urllib.parse.urljoin(self.server, uri_frag)
         try:
@@ -99,7 +99,7 @@ class TFClient:
         return req.text
 
     def get_status(self, job_id):
-        """Get the status of a test job
+        """Get the status of a test job.
 
         :param job_id:
             ID for the test job
@@ -118,7 +118,7 @@ class TFClient:
         return state
 
     def get_results(self, job_id):
-        """Get the results of a test job
+        """Get the results of a test job.
 
         :param job_id:
             ID for the test job
@@ -134,7 +134,7 @@ class TFClient:
         return data
 
     def submit_job(self, job_data):
-        """Submit a test job to the testflinger server
+        """Submit a test job to the testflinger server.
 
         :param job_data:
             dict of data for the job to submit
@@ -146,7 +146,7 @@ class TFClient:
         return json.loads(response).get("job_id")
 
     def cancel_job(self, job_id):
-        """Tell the server to cancel a specified job_id"""
+        """Tell the server to cancel a specified job_id."""
         try:
             self.post(f"/v1/job/{job_id}/action", {"action": "cancel"})
         except requests.exceptions.HTTPError as exc:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
@@ -31,7 +31,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
         device = MuxPi(args.config, args.job_data)

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -328,7 +328,7 @@ class MuxPi:
             self._run_control("sync")
         except Exception:
             # Nothing should go wrong here, but let's sleep if it does
-            logger.warn("Something went wrong with the sync, sleeping...")
+            logger.warning("Something went wrong with the sync, sleeping...")
             time.sleep(30)
         try:
             self._run_control(
@@ -337,7 +337,7 @@ class MuxPi:
             )
         except Exception as error:
             raise ProvisioningError(
-                "Unable to run hdparm to rescan " "partitions"
+                "Unable to run hdparm to rescan partitions"
             ) from error
 
     def _get_part_labels(self):
@@ -406,8 +406,8 @@ class MuxPi:
             image type as a string
         """
 
-        def check_path(dir):
-            self._run_control("test -e {}".format(dir))
+        def check_path(dir_path):
+            self._run_control("test -e {}".format(dir_path))
 
         # First check if this is a ce-oem-iot image and type
         res = self.check_ce_oem_iot_image()
@@ -637,7 +637,6 @@ class MuxPi:
             time.sleep(10)
 
             if boot_check_url is not None:
-
                 logger.info(
                     "Checking %s to confirm boot success ...", boot_check_url
                 )
@@ -654,7 +653,6 @@ class MuxPi:
                     logger.info("Boot check failed with %s", e)
 
             else:
-
                 device_ip = self.config["device_ip"]
                 cmd = [
                     "sshpass",
@@ -683,4 +681,4 @@ class MuxPi:
             try:
                 self._run_control(cmd)
             except Exception:
-                logger.warn("Error running %s", cmd)
+                logger.warning("Error running %s", cmd)

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -186,13 +186,17 @@ class MuxPi:
             try:
                 cmd = "zapper sdwire plug_to_self"
                 sd_node = self._run_control(cmd)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(
+                    "Exception %s encountered while running: %s", e, cmd
+                )
             try:
                 cmd = "zapper typecmux plug_to_self"
                 usb_node = self._run_control(cmd)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(
+                    "Exception %s encountered while running: %s", e, cmd
+                )
 
             if media == "sd":
                 try:
@@ -430,7 +434,9 @@ class MuxPi:
                 check_path(full_path)
                 return img_type
             except Exception:
-                # Path was not found, continue trying others
+                logger.warning(
+                    "Path %s was not found, continue trying others", full_path
+                )
                 continue
         # We have no idea what kind of image this is
         return "unknown"
@@ -475,12 +481,12 @@ class MuxPi:
             raise RecoveryError("Device config missing test_device") from err
         except Exception:
             # We might not be mounted, so expect this to fail sometimes
-            pass
+            logger.warning("Device %s might not be mounted", self.test_device)
 
     def create_user(self, image_type):
         """Create user account for default ubuntu user."""
         base = self.mount_point
-        remote_tmp = Path("/tmp") / self.agent_name
+        remote_tmp = Path("/tmp") / self.agent_name  # noqa: S108
         try:
             data_path = Path(__file__).parent / "../../data/muxpi"
             if image_type == "ce-oem-iot-before-24":

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -14,18 +14,18 @@
 
 """Ubuntu Raspberry PI muxpi support code."""
 
-from contextlib import contextmanager
 import json
 import logging
-from pathlib import Path
-import requests
 import shlex
 import subprocess
 import tempfile
 import time
-from typing import Optional, Union
 import urllib
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional, Union
 
+import requests
 import yaml
 
 from testflinger_device_connectors.devices import (

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -14,6 +14,7 @@
 
 """Ubuntu Raspberry PI muxpi support code."""
 
+import contextlib
 import json
 import logging
 import shlex
@@ -183,20 +184,14 @@ class MuxPi:
             # If media option is provided, then DUT is probably capable of
             # booting from different media, we should switch both of them
             # to TS side regardless of which one was previously used
-            try:
+            # FIXME: Specify exception instead of `Exception`
+            with contextlib.suppress(Exception):
                 cmd = "zapper sdwire plug_to_self"
                 sd_node = self._run_control(cmd)
-            except Exception as e:
-                logger.warning(
-                    "Exception %s encountered while running: %s", e, cmd
-                )
-            try:
+            # FIXME: Specify exception instead of `Exception`
+            with contextlib.suppress(Exception):
                 cmd = "zapper typecmux plug_to_self"
                 usb_node = self._run_control(cmd)
-            except Exception as e:
-                logger.warning(
-                    "Exception %s encountered while running: %s", e, cmd
-                )
 
             if media == "sd":
                 try:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -244,7 +244,7 @@ class MuxPi:
             if self.job_data["provision_data"].get("create_user", True):
                 with self.remote_mount():
                     image_type = self.get_image_type()
-                    logger.info("Image type detected: {}".format(image_type))
+                    logger.info("Image type detected: %s", image_type)
                     logger.info("Creating Test User")
                     self.create_user(image_type)
             else:
@@ -310,17 +310,17 @@ class MuxPi:
         if isinstance(source, Path):
             # the source is an existing attachment
             logger.info(
-                f"Flashing Test image {source.name} on {self.test_device}"
+                "Flashing Test image %s on %s", source, self.test_device
             )
             self.transfer_test_image(local=source, timeout=1200)
         else:
             # the source is a URL
             with tempfile.NamedTemporaryFile(delete=True) as source_file:
-                logger.info(f"Downloading test image from {source}")
+                logger.info("Downloading test image from %s", source)
                 self.download(source, local=source_file.name, timeout=1200)
                 url_name = Path(urllib.parse.urlparse(source).path).name
                 logger.info(
-                    f"Flashing Test image {url_name} on {self.test_device}"
+                    "Flashing Test image %s on %s", url_name, self.test_device
                 )
                 self.transfer_test_image(local=source_file.name, timeout=1800)
 

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -426,8 +426,8 @@ class MuxPi:
 
         for path, img_type in self.IMAGE_PATH_IDS.items():
             try:
-                path = self.mount_point / path
-                check_path(path)
+                full_path = self.mount_point / path
+                check_path(full_path)
                 return img_type
             except Exception:
                 # Path was not found, continue trying others

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -80,8 +80,7 @@ class MuxPi:
         )
 
     def _run_control(self, cmd, timeout=60):
-        """
-        Run a command on the control host over ssh
+        """Run a command on the control host over ssh.
 
         :param cmd:
             Command to run
@@ -106,8 +105,7 @@ class MuxPi:
         return output
 
     def _copy_to_control(self, local_file, remote_file):
-        """
-        Copy a file to the control host over ssh
+        """Copy a file to the control host over ssh.
 
         :param local_file:
             Local filename
@@ -128,8 +126,7 @@ class MuxPi:
         return output
 
     def reboot_sdwire(self):
-        """
-        Reboot both control host and DUT to ensure SDwire be in a good state
+        """Reboot both control host and DUT to ensure SDwire be in a good state
         before provisioning.
         """
         if not self.config.get("control_host_reboot_script"):
@@ -300,8 +297,7 @@ class MuxPi:
             ) from error
 
     def flash_test_image(self, source: Union[str, Path]):
-        """
-        Flash the image at :source to the sd card.
+        """Flash the image at :source to the sd card.
 
         :param source:
             URL or Path to retrieve the image from
@@ -387,8 +383,7 @@ class MuxPi:
                 )
 
     def hardreset(self):
-        """
-        Reboot the device.
+        """Reboot the device.
 
         :raises RecoveryError:
             If the command times out or anything else fails.
@@ -405,8 +400,7 @@ class MuxPi:
                 raise RecoveryError("timeout reaching control host!")
 
     def get_image_type(self):
-        """
-        Figure out which kind of image is on the configured block device
+        """Figure out which kind of image is on the configured block device.
 
         :returns:
             image type as a string
@@ -442,8 +436,7 @@ class MuxPi:
         return "unknown"
 
     def check_ce_oem_iot_image(self) -> bool:
-        """
-        Determine if this is a ce-oem-iot image
+        """Determine if this is a ce-oem-iot image.
 
         These images will have a .disk/info file with a buildstamp in it
         that looks like:
@@ -485,7 +478,7 @@ class MuxPi:
             pass
 
     def create_user(self, image_type):
-        """Create user account for default ubuntu user"""
+        """Create user account for default ubuntu user."""
         base = self.mount_point
         remote_tmp = Path("/tmp") / self.agent_name
         try:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -101,7 +101,7 @@ class MuxPi:
                 ssh_cmd, stderr=subprocess.STDOUT, timeout=timeout
             )
         except subprocess.SubprocessError as e:
-            raise ProvisioningError(e.output)
+            raise ProvisioningError(e.output) from e
         return output
 
     def _copy_to_control(self, local_file, remote_file):
@@ -122,7 +122,7 @@ class MuxPi:
         try:
             output = subprocess.check_output(ssh_cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            raise ProvisioningError(e.output)
+            raise ProvisioningError(e.output) from e
         return output
 
     def reboot_sdwire(self):
@@ -140,8 +140,8 @@ class MuxPi:
             logger.info("Running %s", cmd)
             try:
                 subprocess.check_call(cmd.split(), timeout=60)
-            except Exception:
-                raise ProvisioningError("fail to reboot control host")
+            except Exception as e:
+                raise ProvisioningError("fail to reboot control host") from e
 
         logger.info("Rebooting DUT")
         self.hardreset()
@@ -396,8 +396,8 @@ class MuxPi:
             logger.info("Running %s", cmd)
             try:
                 subprocess.check_call(cmd.split(), timeout=120)
-            except Exception:
-                raise RecoveryError("timeout reaching control host!")
+            except Exception as e:
+                raise RecoveryError("timeout reaching control host!") from e
 
     def get_image_type(self):
         """Figure out which kind of image is on the configured block device.
@@ -471,8 +471,8 @@ class MuxPi:
                 "sudo umount {}*".format(self.test_device),
                 timeout=30,
             )
-        except KeyError:
-            raise RecoveryError("Device config missing test_device")
+        except KeyError as err:
+            raise RecoveryError("Device config missing test_device") from err
         except Exception:
             # We might not be mounted, so expect this to fail sometimes
             pass
@@ -601,8 +601,8 @@ class MuxPi:
                         base / "etc/cloud/cloud.cfg.d/99-fake?cloud.cfg"
                     )
                     self._run_control(rm_cmd)
-        except Exception:
-            raise ProvisioningError("Error creating user files")
+        except Exception as e:
+            raise ProvisioningError("Error creating user files") from e
 
     def _configure_sudo(self):
         # Setup sudoers data

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -14,6 +14,7 @@
 """Unit tests for muxpi device connector"""
 
 from subprocess import CalledProcessError
+
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
 
 

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -11,7 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for muxpi device connector"""
+"""Unit tests for muxpi device connector."""
 
 from subprocess import CalledProcessError
 

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
@@ -64,8 +64,10 @@ class DeviceConnector(DefaultDevice):
             try:
                 device.ensure_test_image(test_username, test_password)
                 device.ensure_master_image()
-            except ProvisioningError:
-                raise RecoveryError("Unable to put system in a usable state!")
+            except ProvisioningError as err:
+                raise RecoveryError(
+                    "Unable to put system in a usable state!"
+                ) from err
         q = multiprocessing.Queue()
         file_server = multiprocessing.Process(
             target=testflinger_device_connectors.serve_file,

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
@@ -18,14 +18,14 @@ import logging
 import multiprocessing
 
 import yaml
+
+import testflinger_device_connectors
 from testflinger_device_connectors.devices import (
     DefaultDevice,
     ProvisioningError,
     RecoveryError,
     SerialLogger,
 )
-
-import testflinger_device_connectors
 from testflinger_device_connectors.devices.netboot.netboot import Netboot
 
 logger = logging.getLogger(__name__)

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
@@ -35,7 +35,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
         device = Netboot(args.config)

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
@@ -38,8 +38,7 @@ class Netboot:
             self.config = yaml.safe_load(configfile)
 
     def setboot(self, mode):
-        """
-        Set the boot mode of the device.
+        """Set the boot mode of the device.
 
         :param mode:
             One of 'master' or 'test'
@@ -61,8 +60,7 @@ class Netboot:
         self._run_cmd_list(setboot_script)
 
     def _run_cmd_list(self, cmdlist):
-        """
-        Run a list of commands
+        """Run a list of commands.
 
         :param cmdlist:
             List of commands to run
@@ -81,8 +79,7 @@ class Netboot:
                 )
 
     def hardreset(self):
-        """
-        Reboot the device.
+        """Reboot the device.
 
         :raises RecoveryError:
             If the command times out or anything else fails.
@@ -99,8 +96,7 @@ class Netboot:
                 raise RecoveryError("timeout reaching control host!")
 
     def ensure_test_image(self, test_username, test_password):
-        """
-        Actively switch the device to boot the test image.
+        """Actively switch the device to boot the test image.
 
         :param test_username:
             Username of the default user in the test image
@@ -138,8 +134,7 @@ class Netboot:
         raise ProvisioningError("Failed to boot test image!")
 
     def is_test_image_booted(self, test_username, test_password):
-        """
-        Check if the test image is booted.
+        """Check if the test image is booted.
 
         :returns:
             True if the test image is currently booted, False otherwise.
@@ -170,8 +165,7 @@ class Netboot:
         return True
 
     def is_master_image_booted(self):
-        """
-        Check if the master image is booted.
+        """Check if the master image is booted.
 
         :returns:
             True if the master image is currently booted, False otherwise.
@@ -194,8 +188,7 @@ class Netboot:
             return False
 
     def ensure_master_image(self):
-        """
-        Actively switch the device to boot the test image.
+        """Actively switch the device to boot the test image.
 
         :raises RecoveryError:
             If the command times out or anything else fails.
@@ -218,8 +211,7 @@ class Netboot:
             raise RecoveryError("Could not reboot to master image!")
 
     def flash_test_image(self, server_ip, server_port):
-        """
-        Flash the image at :image_url to the sd card.
+        """Flash the image at :image_url to the sd card.
 
         :param server_ip:
             IP address of the image server. The image will be downloaded and

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
@@ -181,9 +181,9 @@ class Netboot:
             logger.info("Checking if master image booted: %s", check_url)
             with urllib.request.urlopen(check_url) as url:
                 data = url.read()
-        except Exception:
+        except Exception as e:
             # Any connection error will fail through the normal path
-            pass
+            logger.warning("An exception occurred: %s", e)
         if "Snappy Test Device Imager" in str(data):
             return True
         else:
@@ -247,6 +247,6 @@ class Netboot:
         try:
             logger.info("Rebooting target device: %s", url)
             urllib.request.urlopen(url, timeout=10)
-        except Exception:
+        except Exception as e:
             # FIXME: This could fail to return right now due to a bug
-            pass
+            logger.warning("Known bug exception: %s", e)

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
@@ -181,10 +181,11 @@ class Netboot:
 
         # FIXME: Specify exception instead of `Exception`
         # Any connection error will fail through the normal path
-        with contextlib.suppress(Exception):
-            logger.info("Checking if master image booted: %s", check_url)
-            with urllib.request.urlopen(check_url) as url:
-                data = url.read()
+        logger.info("Checking if master image booted: %s", check_url)
+        with contextlib.suppress(Exception), urllib.request.urlopen(
+            check_url
+        ) as url:
+            data = url.read()
         if "Snappy Test Device Imager" in str(data):
             return True
         else:

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
@@ -71,8 +71,10 @@ class Netboot:
             logger.info("Running %s", cmd)
             try:
                 rc = runcmd(cmd, timeout=60)
-            except CmdTimeoutError:
-                raise ProvisioningError("timeout reaching control host!")
+            except CmdTimeoutError as err:
+                raise ProvisioningError(
+                    "timeout reaching control host!"
+                ) from err
             if rc:
                 raise ProvisioningError(
                     "Error running {} (rc={})".format(cmd, rc)
@@ -92,8 +94,8 @@ class Netboot:
             logger.info("Running %s", cmd)
             try:
                 subprocess.check_call(cmd.split(), timeout=120)
-            except Exception:
-                raise RecoveryError("timeout reaching control host!")
+            except Exception as e:
+                raise RecoveryError("timeout reaching control host!") from e
 
     def ensure_test_image(self, test_username, test_password):
         """Actively switch the device to boot the test image.
@@ -233,8 +235,8 @@ class Netboot:
             req = urllib.request.urlopen(url, timeout=1800)
             logger.info("Image write output:")
             logger.info(str(req.read()))
-        except Exception:
-            raise ProvisioningError("Error while flashing image!")
+        except Exception as e:
+            raise ProvisioningError("Error while flashing image!") from e
 
         # Run post-flash hooks
         post_flash_cmds = self.config.get("post_flash_cmds")

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
@@ -182,9 +182,10 @@ class Netboot:
         # FIXME: Specify exception instead of `Exception`
         # Any connection error will fail through the normal path
         logger.info("Checking if master image booted: %s", check_url)
-        with contextlib.suppress(Exception), urllib.request.urlopen(
-            check_url
-        ) as url:
+        with (
+            contextlib.suppress(Exception),
+            urllib.request.urlopen(check_url) as url,
+        ):
             data = url.read()
         if "Snappy Test Device Imager" in str(data):
             return True

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/netboot.py
@@ -14,6 +14,7 @@
 
 """Netboot support code."""
 
+import contextlib
 import logging
 import subprocess
 import time
@@ -177,13 +178,13 @@ class Netboot:
         """
         check_url = "http://{}:8989/check".format(self.config["device_ip"])
         data = ""
-        try:
+
+        # FIXME: Specify exception instead of `Exception`
+        # Any connection error will fail through the normal path
+        with contextlib.suppress(Exception):
             logger.info("Checking if master image booted: %s", check_url)
             with urllib.request.urlopen(check_url) as url:
                 data = url.read()
-        except Exception as e:
-            # Any connection error will fail through the normal path
-            logger.warning("An exception occurred: %s", e)
         if "Snappy Test Device Imager" in str(data):
             return True
         else:
@@ -244,9 +245,9 @@ class Netboot:
 
         # Now reboot the target system
         url = "http://{}:8989/reboot".format(self.config["device_ip"])
-        try:
+
+        # FIXME: Specify exception instead of `Exception`
+        # FIXME: This could fail to return right now due to a bug
+        with contextlib.suppress(Exception):
             logger.info("Rebooting target device: %s", url)
             urllib.request.urlopen(url, timeout=10)
-        except Exception as e:
-            # FIXME: This could fail to return right now due to a bug
-            logger.warning("Known bug exception: %s", e)

--- a/device-connectors/src/testflinger_device_connectors/devices/noprovision/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/noprovision/__init__.py
@@ -16,11 +16,10 @@
 
 import logging
 
+import testflinger_device_connectors
 from testflinger_device_connectors.devices import (
     DefaultDevice,
 )
-
-import testflinger_device_connectors
 from testflinger_device_connectors.devices.noprovision.noprovision import (
     Noprovision,
 )

--- a/device-connectors/src/testflinger_device_connectors/devices/noprovision/noprovision.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/noprovision/noprovision.py
@@ -36,8 +36,7 @@ class Noprovision:
             self.config = yaml.safe_load(configfile)
 
     def hardreset(self):
-        """
-        Reboot the device.
+        """Reboot the device.
 
         :raises RecoveryError:
             If the command times out or anything else fails.
@@ -54,8 +53,7 @@ class Noprovision:
                 raise RecoveryError("timeout reaching control host!")
 
     def ensure_test_image(self, test_username):
-        """
-        Actively switch the device to boot the test image.
+        """Actively switch the device to boot the test image.
 
         :param test_username:
             Username of the default user in the test image

--- a/device-connectors/src/testflinger_device_connectors/devices/noprovision/noprovision.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/noprovision/noprovision.py
@@ -49,8 +49,8 @@ class Noprovision:
             logger.info("Running %s", cmd)
             try:
                 subprocess.check_call(cmd.split(), timeout=120)
-            except subprocess.TimeoutExpired:
-                raise RecoveryError("timeout reaching control host!")
+            except subprocess.TimeoutExpired as e:
+                raise RecoveryError("timeout reaching control host!") from e
 
     def ensure_test_image(self, test_username):
         """Actively switch the device to boot the test image.

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/__init__.py
@@ -13,7 +13,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Device connector to provision Ubuntu OEM on systems
-that support autoinstall and provision-image.sh script
+that support autoinstall and provision-image.sh script.
 """
 
 import logging
@@ -32,7 +32,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         device = OemAutoinstall(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/__init__.py
@@ -13,7 +13,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Device connector to provision Ubuntu OEM on systems
-that support autoinstall and provision-image.sh script"""
+that support autoinstall and provision-image.sh script
+"""
 
 import logging
 

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -12,11 +12,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Starting from Ubuntu 24.04, OEM uses autoinstall to provision
+"""Starting from Ubuntu 24.04, OEM uses autoinstall to provision
 the PC platforms for all vendors.
 Use this device connector for systems that support autoinstall provisioning
-with provision-image.sh script
+with provision-image.sh script.
 """
 
 import json
@@ -50,8 +49,7 @@ class OemAutoinstall:
         self.data_path = Path(__file__).parent / "../../data/oem_autoinstall"
 
     def provision(self):
-        """Provision the device"""
-
+        """Provision the device."""
         # Ensure the device is online and reachable
         try:
             self.copy_ssh_id()
@@ -100,9 +98,8 @@ class OemAutoinstall:
         self.check_device_booted()
 
     def copy_to_deploy_path(self, source_path, dest_path):
-        """
-        Verify if attachment exists, then copy when
-        it's missing in deployment dir
+        """Verify if attachment exists, then copy when
+        it's missing in deployment dir.
         """
         source_path = Path(source_path)
         if source_path.is_absolute():
@@ -123,7 +120,7 @@ class OemAutoinstall:
             shutil.copy(source_path, dest_path)
 
     def run_deploy_script(self, image_url):
-        """Run the script to deploy ISO and config files"""
+        """Run the script to deploy ISO and config files."""
         device_ip = self.config["device_ip"]
         test_username = self.get_test_data_or_default(
             "test_username", "ubuntu"
@@ -155,7 +152,7 @@ class OemAutoinstall:
             raise ProvisioningError("Deploy script failed")
 
     def test_ssh_access(self):
-        """Verify SSH access available to DUT without any prompts"""
+        """Verify SSH access available to DUT without any prompts."""
         try:
             test_username = self.job_data.get("test_data", {}).get(
                 "test_username", "ubuntu"
@@ -182,7 +179,7 @@ class OemAutoinstall:
             raise ProvisioningError("Failed SSH to DUT")
 
     def get_test_data_or_default(self, attribute, default_value):
-        """Helper function to safely get test attributes"""
+        """Retrieve safely test attributes."""
         try:
             return self.job_data.get("test_data", {}).get(
                 attribute, default_value
@@ -191,8 +188,7 @@ class OemAutoinstall:
             return default_value
 
     def copy_ssh_id(self):
-        """Copy the ssh id to the device"""
-
+        """Copy the ssh id to the device."""
         test_username = self.get_test_data_or_default(
             "test_username", "ubuntu"
         )
@@ -214,8 +210,7 @@ class OemAutoinstall:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=60)
 
     def hardreset(self):
-        """
-        Reboot the device.
+        """Reboot the device.
 
         :raises RecoveryError:
             If the command times out or anything else fails.
@@ -232,7 +227,7 @@ class OemAutoinstall:
                 raise RecoveryError("Error running reboot script!") from exc
 
     def check_device_booted(self):
-        """Check to see if the device is booted and reachable with ssh"""
+        """Check to see if the device is booted and reachable with ssh."""
         logger.info("Checking to see if the device is available.")
         started = time.time()
         # Wait for provisioning to complete - can take a very long time

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -109,8 +109,9 @@ class OemAutoinstall:
 
         if not source_path.exists():
             logger.error(
-                f"{source_path} file was not found in attachments. "
-                "Please check the filename."
+                "%s file was not found in attachments. "
+                "Please check the filename.",
+                source_path,
             )
             raise ProvisioningError(
                 f"{source_path} file was not found in attachments"

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -174,7 +174,9 @@ class OemAutoinstall:
             f"{test_username}@{self.config['device_ip']}",
             "true",
         ]
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=False
+        )
         if result.returncode != 0:
             logger.error("SSH connection failed: %s", result.stderr)
             raise ProvisioningError("Failed SSH to DUT")

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -240,7 +240,5 @@ class OemAutoinstall:
                 pass
         # If we get here, then we didn't boot in time
         agent_name = self.config.get("agent_name")
-        logger.error(
-            "Device %s unreachable,  provisioning" "failed!", agent_name
-        )
+        logger.error("Device %s unreachable,  provisioningfailed!", agent_name)
         raise ProvisioningError("Failed to boot test image!")

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -243,5 +243,7 @@ class OemAutoinstall:
                 pass
         # If we get here, then we didn't boot in time
         agent_name = self.config.get("agent_name")
-        logger.error("Device %s unreachable,  provisioningfailed!", agent_name)
+        logger.error(
+            "Device %s unreachable,  provisioning failed!", agent_name
+        )
         raise ProvisioningError("Failed to boot test image!")

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -21,12 +21,13 @@ with provision-image.sh script
 
 import json
 import logging
-from pathlib import Path
-import subprocess
-import yaml
-import shutil
-import time
 import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import yaml
 
 from testflinger_device_connectors.devices import (
     ProvisioningError,

--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/__init__.py
@@ -30,7 +30,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         device = OemRecovery(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
@@ -201,7 +201,7 @@ class OemRecovery:
         # If we get here, then we didn't boot in time
         agent_name = self.config.get("agent_name")
         logger.error(
-            "Device %s unreachable,  provisioning" "failed!", agent_name
+            "Device %s unreachable,  provisioning failed!", agent_name
         )
         raise ProvisioningError("Failed to boot test image!")
 

--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py
@@ -39,8 +39,7 @@ class OemRecovery:
             self.job_data = json.load(job_json)
 
     def run_on_control_host(self, cmd, timeout=60):
-        """
-        Run a command on the control host over ssh
+        """Run a command on the control host over ssh.
 
         :param cmd:
             Command to run
@@ -74,8 +73,7 @@ class OemRecovery:
         return proc.returncode, proc.stdout
 
     def provision(self):
-        """Provision the device"""
-
+        """Provision the device."""
         # First, ensure the device is online and reachable
         try:
             self.copy_ssh_id()
@@ -157,7 +155,7 @@ class OemRecovery:
         return False
 
     def copy_ssh_id(self):
-        """Copy the ssh id to the device"""
+        """Copy the ssh id to the device."""
         try:
             test_username = self.job_data.get("test_data", {}).get(
                 "test_username", "ubuntu"
@@ -182,7 +180,7 @@ class OemRecovery:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=60)
 
     def check_device_booted(self):
-        """Check to see if the device is booted and reachable with ssh"""
+        """Check to see if the device is booted and reachable with ssh."""
         logger.info("Checking to see if the device is available.")
         started = time.time()
         # Wait for provisioning to complete - can take a very long time
@@ -208,8 +206,7 @@ class OemRecovery:
         raise ProvisioningError("Failed to boot test image!")
 
     def _run_cmd_list(self, cmdlist):
-        """
-        Run a list of commands
+        """Run a list of commands.
 
         :param cmdlist:
             List of commands to run
@@ -231,8 +228,7 @@ class OemRecovery:
             logger.info(output)
 
     def hardreset(self):
-        """
-        Reboot the device.
+        """Reboot the device.
 
         :raises RecoveryError:
             If the command times out or anything else fails.

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/__init__.py
@@ -28,7 +28,7 @@ class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         device = OemScript(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
@@ -17,9 +17,10 @@
 import json
 import logging
 import os
-from pathlib import Path
 import subprocess
 import time
+from pathlib import Path
+
 import yaml
 
 from testflinger_device_connectors.devices import (

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
@@ -169,7 +169,7 @@ class OemScript:
         # If we get here, then we didn't boot in time
         agent_name = self.config.get("agent_name")
         logger.error(
-            "Device %s unreachable,  provisioning" "failed!", agent_name
+            "Device %s unreachable,  provisioning failed!", agent_name
         )
         raise ProvisioningError("Failed to boot test image!")
 

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
@@ -44,8 +44,7 @@ class OemScript:
             self.job_data = json.load(job_json)
 
     def run_on_control_host(self, cmd, timeout=60):
-        """
-        Run a command on the control host over ssh
+        """Run a command on the control host over ssh.
 
         :param cmd:
             Command to run
@@ -79,8 +78,7 @@ class OemScript:
         return proc.returncode, proc.stdout
 
     def provision(self):
-        """Provision the device"""
-
+        """Provision the device."""
         # First, ensure the device is online and reachable
         try:
             self.copy_ssh_id()
@@ -102,7 +100,7 @@ class OemScript:
         self.check_device_booted()
 
     def run_recovery_script(self, image_url):
-        """Download and run the OEM recovery script"""
+        """Download and run the OEM recovery script."""
         device_ip = self.config["device_ip"]
 
         data_path = Path(__file__).parent / "../../data/muxpi/oemscript"
@@ -132,7 +130,7 @@ class OemScript:
             raise ProvisioningError("Recovery script failed")
 
     def copy_ssh_id(self):
-        """Copy the ssh id to the device"""
+        """Copy the ssh id to the device."""
         try:
             test_username = self.job_data.get("test_data", {}).get(
                 "test_username", "ubuntu"
@@ -157,7 +155,7 @@ class OemScript:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=60)
 
     def check_device_booted(self):
-        """Check to see if the device is booted and reachable with ssh"""
+        """Check to see if the device is booted and reachable with ssh."""
         logger.info("Checking to see if the device is available.")
         started = time.time()
         # Wait for provisioning to complete - can take a very long time
@@ -176,8 +174,7 @@ class OemScript:
         raise ProvisioningError("Failed to boot test image!")
 
     def _run_cmd_list(self, cmdlist):
-        """
-        Run a list of commands
+        """Run a list of commands.
 
         :param cmdlist:
             List of commands to run
@@ -199,8 +196,7 @@ class OemScript:
             logger.info(output)
 
     def hardreset(self):
-        """
-        Reboot the device.
+        """Reboot the device.
 
         :raises RecoveryError:
             If the command times out or anything else fails.

--- a/device-connectors/src/testflinger_device_connectors/devices/tests/test_devices.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/tests/test_devices.py
@@ -25,11 +25,9 @@ class DefaultDeviceTests(unittest.TestCase):
 
     @patch("subprocess.check_call")
     def test_copy_ssh_id(self, mock_check):
-        """
-        Test whether the function copies the agent's SSH key
+        """Test whether the function copies the agent's SSH key
         to the DUT.
         """
-
         connector = DefaultDevice()
         connector.copy_ssh_key(
             "192.168.1.2",
@@ -46,11 +44,9 @@ class DefaultDeviceTests(unittest.TestCase):
 
     @patch("subprocess.check_call")
     def test_copy_ssh_id_with_key(self, mock_check):
-        """
-        Test whether the function copies the provided key
+        """Test whether the function copies the provided key
         to the DUT.
         """
-
         connector = DefaultDevice()
         connector.copy_ssh_key(
             "192.168.1.2",
@@ -69,11 +65,9 @@ class DefaultDeviceTests(unittest.TestCase):
     @patch("time.sleep", Mock())
     @patch("subprocess.check_call")
     def test_copy_ssh_id_raises(self, mock_check):
-        """
-        Test whether the function raises a RuntimeError
+        """Test whether the function raises a RuntimeError
         exception after 3 failed attempts.
         """
-
         connector = DefaultDevice()
         connector = DefaultDevice()
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -12,8 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Package containing modules for implementing Zapper-driven device connectors.
+"""Package containing modules for implementing Zapper-driven device connectors.
 
 Modules inheriting from the provided abstract class will run Zapper-driven
 provisioning procedures via Zapper API. The provisioning logic is implemented
@@ -38,8 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class ZapperConnector(ABC, DefaultDevice):
-    """
-    Abstract base class defining a common interface for Zapper-driven
+    """Abstract base class defining a common interface for Zapper-driven
     device connectors.
     """
 
@@ -48,7 +46,7 @@ class ZapperConnector(ABC, DefaultDevice):
     ZAPPER_SERVICE_PORT = 60000
 
     def provision(self, args):
-        """Method called when the command is invoked."""
+        """Provision device when the command is invoked."""
         with open(args.config, encoding="utf-8") as configfile:
             self.config = yaml.safe_load(configfile)
         with open(args.job_data, encoding="utf-8") as job_json:
@@ -72,22 +70,19 @@ class ZapperConnector(ABC, DefaultDevice):
     def _validate_configuration(
         self,
     ) -> Tuple[Tuple, Dict[str, Any]]:
-        """
-        Validate the job config and data and prepare the arguments
+        """Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.
         """
         raise NotImplementedError
 
     def _run(self, zapper_ip, *args, **kwargs):
-        """
-        Run the Zapper `provision` API via RPyC. The arguments are
+        """Run the Zapper `provision` API via RPyC. The arguments are
         not stricly defined so that the same API can be used by different
         implementations.
 
         The connector logger is passed as an argument to the Zapper API
         in order to get a real time feedback throughout the whole execution.
         """
-
         connection = rpyc.connect(
             zapper_ip,
             self.ZAPPER_SERVICE_PORT,
@@ -105,8 +100,7 @@ class ZapperConnector(ABC, DefaultDevice):
         )
 
     def _copy_ssh_id(self):
-        """Copy the ssh id to the device"""
-
+        """Copy the ssh id to the device."""
         logger.info("Copying the agent's SSH public key to the DUT.")
 
         try:

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -38,11 +38,9 @@ class ZapperConnectorTests(unittest.TestCase):
 
     @patch("rpyc.connect")
     def test_run(self, mock_connect):
-        """
-        Test the `run` function connects to a Zapper via RPyC
+        """Test the `run` function connects to a Zapper via RPyC
         and runs the `provision` API.
         """
-
         args = (1, 2, 3)
         kwargs = {"key1": 1, "key2": 2}
 
@@ -58,12 +56,10 @@ class ZapperConnectorTests(unittest.TestCase):
         )
 
     def test_copy_ssh_id(self):
-        """
-        Test the function collects the device info from
+        """Test the function collects the device info from
         job and config and attempts to copy the agent SSH
         key to the DUT.
         """
-
         connector = MockConnector()
         connector.job_data = {
             "test_data": {
@@ -81,11 +77,9 @@ class ZapperConnectorTests(unittest.TestCase):
         )
 
     def test_copy_ssh_id_raises(self):
-        """
-        Test the function raises a ProvisioningError exception
+        """Test the function raises a ProvisioningError exception
         in case of failure.
         """
-
         connector = MockConnector()
         connector.job_data = {
             "test_data": {

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -34,11 +34,9 @@ class DeviceConnector(ZapperConnector):
     def _validate_configuration(
         self,
     ) -> Tuple[Tuple, Dict[str, Any]]:
-        """
-        Validate the job config and data and prepare the arguments
+        """Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.
         """
-
         username = self.job_data.get("test_data", {}).get(
             "test_username", "ubuntu"
         )

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -13,6 +13,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Zapper Connector for IOT provisioning."""
+
 import contextlib
 import logging
 from typing import Any, Dict, Tuple
@@ -58,7 +59,6 @@ class DeviceConnector(ZapperConnector):
 
         provision_plan = self.job_data["provision_data"].get("provision_plan")
         if provision_plan:
-
             try:
                 # Ensure the provisioning username matches either the test
                 # username or the Ubuntu SSO email if provided

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -13,11 +13,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Zapper Connector for IOT provisioning."""
-import logging
 import contextlib
+import logging
 from typing import Any, Dict, Tuple
-from testflinger_device_connectors.devices.zapper import ZapperConnector
+
 from testflinger_device_connectors.devices import ProvisioningError
+from testflinger_device_connectors.devices.zapper import ZapperConnector
 from testflinger_device_connectors.devices.zapper_iot.parser import (
     validate_urls,
 )

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
@@ -1,8 +1,9 @@
 """provision yaml verify"""
 
 import logging
-import validators
 from typing import List
+
+import validators
 
 logger = logging.getLogger(__name__)
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/parser.py
@@ -1,4 +1,4 @@
-"""provision yaml verify"""
+"""provision yaml verify."""
 
 import logging
 from typing import List
@@ -9,8 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def validate_urls(urls: List[str]):
-    """
-    Validate whether the provided URL
+    """Validate whether the provided URL
     is valid in terms of format.
 
     We cannot assert for resource availability here,

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -9,11 +9,9 @@ class ZapperIoTTests(unittest.TestCase):
     """Test Cases for the Zapper IoT class."""
 
     def test_validate_configuration(self):
-        """
-        Test the function creates a proper provision_data
+        """Test the function creates a proper provision_data
         dictionary when valid data are provided.
         """
-
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
@@ -41,10 +39,7 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertDictEqual(kwargs, expected)
 
     def test_validate_configuration_ubuntu_sso_email(self):
-        """
-        Test the function username will be ubuntu_sso_email if it is provided.
-        """
-
+        """Test the function username will be ubuntu_sso_email if provided."""
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
@@ -73,11 +68,9 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertDictEqual(kwargs, expected)
 
     def test_validate_configuration_provision_plan(self):
-        """
-        Test the function validates a custom test plan
+        """Test the function validates a custom test plan
         when provided.
         """
-
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
@@ -133,12 +126,10 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertDictEqual(expected, kwargs)
 
     def test_validate_configuration_ubuntu_sso_email_provision_plan(self):
-        """
-        Test the function validates a custom test plan
+        """Test the function validates a custom test plan
         when provided and an ubuntu_sso_email is provided.
         The username should be overridden with the ubuntu_sso_email.
         """
-
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
@@ -195,11 +186,9 @@ class ZapperIoTTests(unittest.TestCase):
     def test_validate_configuration_ubuntu_sso_email_missing_provision_plan(
         self,
     ):
-        """
-        Test the function raises an exception if ubuntu_sso_email is not
+        """Test the function raises an exception if ubuntu_sso_email is not
         provided and the initial login method is console-conf.
         """
-
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
@@ -227,11 +216,9 @@ class ZapperIoTTests(unittest.TestCase):
             device._validate_configuration()
 
     def test_validate_configuration_invalid_url(self):
-        """
-        Test the function raises an exception if one of
+        """Test the function raises an exception if one of
         the url is not valid.
         """
-
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
@@ -247,11 +234,9 @@ class ZapperIoTTests(unittest.TestCase):
             device._validate_configuration()
 
     def test_validate_configuration_invalid_provision_plan_key_error(self):
-        """
-        Test the function raises an exception if the
+        """Test the function raises an exception if the
         provided custom testplan is not valid.
         """
-
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {"provision_plan": {"key1": "value1"}}
@@ -265,11 +250,9 @@ class ZapperIoTTests(unittest.TestCase):
             device._validate_configuration()
 
     def test_validate_configuration_invalid_provision_plan_value_error(self):
-        """
-        Test the function raises an exception if the
+        """Test the function raises an exception if the
         provided custom testplan is not valid.
         """
-
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
@@ -290,11 +273,9 @@ class ZapperIoTTests(unittest.TestCase):
     def test_post_run_actions_copy_ssh_id_no_provision_plan(
         self, mock_copy_ssh_id
     ):
-        """
-        Test the function copy the ssh id if there is no provision plan
+        """Test the function copy the ssh id if there is no provision plan
         and without ubuntu_sso_email.
         """
-
         device = DeviceConnector()
         device.job_data = {"provision_data": {}}
         device._post_run_actions(args=None)
@@ -304,11 +285,9 @@ class ZapperIoTTests(unittest.TestCase):
     def test_post_run_actions_not_copy_ssh_id_ubuntu_sso_email(
         self, mock_copy_ssh_id
     ):
-        """
-        Test the function does not copy the ssh id if there is
+        """Test the function does not copy the ssh id if there is
         buntu_sso_email.
         """
-
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {
@@ -322,11 +301,9 @@ class ZapperIoTTests(unittest.TestCase):
     def test_post_run_actions_copy_ssh_id_provision_plan(
         self, mock_copy_ssh_id
     ):
-        """
-        Test the function copies the ssh id if the
+        """Test the function copies the ssh id if the
         initial login method is Not console-conf.
         """
-
         device = DeviceConnector()
         device.job_data = {
             "provision_data": {

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -67,11 +67,11 @@ class DeviceConnector(ZapperConnector):
             if "autoinstall_" not in key:
                 continue
 
-            key = key.replace("autoinstall_", "")
+            autoinstall_key = key.replace("autoinstall_", "")
             with contextlib.suppress(AttributeError):
-                getattr(self, f"_validate_{key}")(value)
+                getattr(self, f"_validate_{autoinstall_key}")(value)
 
-            autoinstall_conf[key] = value
+            autoinstall_conf[autoinstall_key] = value
 
         if not autoinstall_conf:
             logger.info("Autoinstall-related keys were not provided.")

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -23,14 +23,15 @@ import subprocess
 from typing import Any, Dict, Optional, Tuple
 
 import yaml
+
 from testflinger_device_connectors.devices import ProvisioningError
-from testflinger_device_connectors.devices.zapper import ZapperConnector
-from testflinger_device_connectors.devices.oemscript import OemScript
+from testflinger_device_connectors.devices.dell_oemscript import DellOemScript
+from testflinger_device_connectors.devices.hp_oemscript import HPOemScript
 from testflinger_device_connectors.devices.lenovo_oemscript import (
     LenovoOemScript,
 )
-from testflinger_device_connectors.devices.dell_oemscript import DellOemScript
-from testflinger_device_connectors.devices.hp_oemscript import HPOemScript
+from testflinger_device_connectors.devices.oemscript import OemScript
+from testflinger_device_connectors.devices.zapper import ZapperConnector
 
 logger = logging.getLogger(__name__)
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -42,9 +42,7 @@ class DeviceConnector(ZapperConnector):
     PROVISION_METHOD = "ProvisioningKVM"
 
     def _validate_base_user_data(self, encoded_user_data: str):
-        """
-        Assert `base_user_data` argument is a valid base64 encoded YAML.
-        """
+        """Assert `base_user_data` argument is a valid base64 encoded YAML."""
         try:
             user_data = base64.b64decode(encoded_user_data.encode()).decode()
             yaml.safe_load(user_data)
@@ -58,14 +56,12 @@ class DeviceConnector(ZapperConnector):
             ) from exc
 
     def _get_autoinstall_conf(self) -> Optional[Dict[str, Any]]:
-        """
-        Autoinstall-related keys are pre-fixed with `autoinstall_`.
+        """Autoinstall-related keys are pre-fixed with `autoinstall_`.
 
         If any of those arguments are provided and valid, the function
         returns an autoinstall_conf dictionary, including the agent
         SSH public key.
         """
-
         autoinstall_conf = {}
         for key, value in self.job_data["provision_data"].items():
             if "autoinstall_" not in key:
@@ -89,11 +85,9 @@ class DeviceConnector(ZapperConnector):
     def _validate_configuration(
         self,
     ) -> Tuple[Tuple, Dict[str, Any]]:
-        """
-        Validate the job config and data and prepare the arguments
+        """Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.
         """
-
         if "alloem_url" in self.job_data["provision_data"]:
             url = self.job_data["provision_data"]["alloem_url"]
             username = "ubuntu"
@@ -165,12 +159,10 @@ class DeviceConnector(ZapperConnector):
         self._run_oem_script(args)
 
     def _run_oem_script(self, args):
-        """
-        If "alloem_url" was in scope, the Zapper only restored
+        """If "alloem_url" was in scope, the Zapper only restored
         the OEM reset partition. The usual oemscript will take care
         of the rest.
         """
-
         if not self.job_data["provision_data"].get("url"):
             logger.warning(
                 "Provisioned with base `alloem` image, no test URL specified."
@@ -188,7 +180,6 @@ class DeviceConnector(ZapperConnector):
 
     def _change_password(self, username, orig_password):
         """Change password via SSH to the one specified in the job data."""
-
         password = self.job_data.get("test_data", {}).get(
             "test_password", "ubuntu"
         )

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -16,8 +16,10 @@
 import base64
 import subprocess
 import unittest
+from unittest.mock import Mock, mock_open, patch
+
 import yaml
-from unittest.mock import Mock, patch, mock_open
+
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.zapper_kvm import DeviceConnector
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -28,12 +28,10 @@ class ZapperKVMConnectorTests(unittest.TestCase):
     """Unit tests for ZapperConnector KVM class."""
 
     def test_validate_configuration(self):
-        """
-        Test whether the validate_configuration function returns
+        """Test whether the validate_configuration function returns
         the expected data merging the relevant bits from conf and job
-        data when passing only the required arguments
+        data when passing only the required arguments.
         """
-
         connector = DeviceConnector()
         connector.config = {
             "device_ip": "1.1.1.1",
@@ -68,12 +66,10 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertDictEqual(kwargs, expected)
 
     def test_validate_configuration_w_opt(self):
-        """
-        Test whether the validate_configuration function returns
+        """Test whether the validate_configuration function returns
         the expected data merging the relevant bits from conf and job
         data when passing all the optional arguments.
         """
-
         connector = DeviceConnector()
         connector.config = {
             "device_ip": "1.1.1.1",
@@ -124,14 +120,12 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertDictEqual(kwargs, expected)
 
     def test_validate_configuration_alloem(self):
-        """
-        Test whether the validate_configuration function returns
+        """Test whether the validate_configuration function returns
         the expected data merging the relevant bits from conf and job
         data when `alloem_url` is passed. In that case, username and
         password are hardcoded and the Zapper shall try the procedures
         at least twice because it can fail on purpose.
         """
-
         connector = DeviceConnector()
         connector.config = {
             "device_ip": "1.1.1.1",
@@ -172,12 +166,10 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertDictEqual(kwargs, expected)
 
     def test_get_autoinstall_none(self):
-        """
-        Test whether the get_autoinstall_conf function returns
+        """Test whether the get_autoinstall_conf function returns
         None in case none of the autoinstall-related keys are
         provided.
         """
-
         connector = DeviceConnector()
         connector.job_data = {
             "job_queue": "queue",
@@ -200,12 +192,10 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertIsNone(conf)
 
     def test_get_autoinstall_conf(self):
-        """
-        Test whether the get_autoinstall_conf function returns
+        """Test whether the get_autoinstall_conf function returns
         the expected data merging the relevant bits from conf and job
         data when password and base_user_data are not given.
         """
-
         connector = DeviceConnector()
         connector.job_data = {
             "job_queue": "queue",
@@ -233,12 +223,10 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertDictEqual(conf, expected)
 
     def test_get_autoinstall_conf_full(self):
-        """
-        Test whether the get_autoinstall_conf function returns
+        """Test whether the get_autoinstall_conf function returns
         the expected data merging the relevant bits from conf and job
         data when password and user_data_base are given.
         """
-
         connector = DeviceConnector()
         connector.job_data = {
             "job_queue": "queue",
@@ -272,8 +260,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertDictEqual(conf, expected)
 
     def test_validate_base_user_data(self):
-        """
-        Test whether the function returns without errors in case of a
+        """Test whether the function returns without errors in case of a
         sane base64 encoded YAML.
         """
         connector = DeviceConnector()
@@ -282,8 +269,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         connector._validate_base_user_data(encoded)
 
     def test_validate_base_user_data_raises_decode(self):
-        """
-        Test whether the function raises an exception if the input
+        """Test whether the function raises an exception if the input
         is not correctly encoded.
         """
         connector = DeviceConnector()
@@ -291,8 +277,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             connector._validate_base_user_data("notbase64")
 
     def test_validate_base_user_data_raises_load(self):
-        """
-        Test whether the function raises an exception if the input
+        """Test whether the function raises an exception if the input
         is not a valid YAML.
         """
         connector = DeviceConnector()
@@ -302,11 +287,9 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             connector._validate_base_user_data(encoded)
 
     def test_run_oem_no_url(self):
-        """
-        Test the function returns without further action when URL
+        """Test the function returns without further action when URL
         is not specified.
         """
-
         connector = DeviceConnector()
         connector.job_data = {"provision_data": {}}
 
@@ -319,7 +302,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
     def test_run_oem_default(self):
         """Test the function runs the base OemScript."""
-
         connector = DeviceConnector()
         connector.job_data = {"provision_data": {"url": "file://image.iso"}}
         args = Mock()
@@ -334,7 +316,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
     def test_run_oem_hp(self):
         """Test the function runs the HP OemScript when oem=hp."""
-
         connector = DeviceConnector()
         connector.job_data = {
             "provision_data": {"url": "file://image.iso", "oem": "hp"}
@@ -351,7 +332,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
     def test_run_oem_dell(self):
         """Test the function runs the Dell OemScript when oem=dell."""
-
         connector = DeviceConnector()
         connector.job_data = {
             "provision_data": {"url": "file://image.iso", "oem": "dell"}
@@ -368,7 +348,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
     def test_run_oem_lenovo(self):
         """Test the function runs the Lenovo OemScript when oem=lenovo."""
-
         connector = DeviceConnector()
         connector.job_data = {
             "provision_data": {"url": "file://image.iso", "oem": "lenovo"}
@@ -385,8 +364,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
     @patch("subprocess.check_output")
     def test_change_password(self, mock_check_output):
-        """
-        Test the function runs a command over SSH to change the
+        """Test the function runs a command over SSH to change the
         original password to the one specified in test_data.
         """
         connector = DeviceConnector()
@@ -412,8 +390,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         )
 
     def test_post_run_actions_alloem(self):
-        """
-        Test the function updates the password and run the OEM script
+        """Test the function updates the password and run the OEM script
         when `alloem_url` is in scope.
         """
         connector = DeviceConnector()
@@ -431,8 +408,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         connector._copy_ssh_id.assert_called()
 
     def test_post_run_actions_alloem_error(self):
-        """
-        Test the function raises the ProvisioningError
+        """Test the function raises the ProvisioningError
         exception in case one of the SSH commands fail.
         """
         connector = DeviceConnector()
@@ -461,8 +437,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             connector._post_run_actions("args")
 
     def test_post_run_actions_alloem_timeout(self):
-        """
-        Test the function raises the ProvisioningError
+        """Test the function raises the ProvisioningError
         exception in case one of the SSH commands times out.
         """
         connector = DeviceConnector()

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
@@ -46,6 +46,7 @@ class LVFSDevice(AbstractDevice):
                 shell=True,
                 capture_output=True,
                 timeout=timeout,
+                check=False,
             )
         except subprocess.TimeoutExpired as e:
             if raise_stderr:

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
@@ -1,4 +1,4 @@
-"""Device class for flashing firmware on device supported by LVFS-fwupd"""
+"""Device class for flashing firmware on device supported by LVFS-fwupd."""
 
 import json
 import logging
@@ -16,7 +16,7 @@ SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
 
 class LVFSDevice(AbstractDevice):
-    """Device class for devices supported by LVFS-fwupd"""
+    """Device class for devices supported by LVFS-fwupd."""
 
     fw_update_type = "LVFS"
     vendor = ["HP", "Dell Inc.", "LENOVO"]
@@ -25,8 +25,7 @@ class LVFSDevice(AbstractDevice):
     def run_cmd(
         self, cmd: str, raise_stderr: bool = True, timeout: int = 30
     ) -> Tuple[int, str, str]:
-        """
-        Execute command on the DUT via SSH
+        """Execute command on the DUT via SSH.
 
         :param cmd:          command to run on the DUT
         :param raise_stderr: when set to `True`, raise RuntimeError if return
@@ -64,9 +63,8 @@ class LVFSDevice(AbstractDevice):
         return rc, stdout, stderr
 
     def get_fw_info(self):
-        """
-        Get current firmware version of all updatable devices on DUT, and
-        print out devices with upgradable/downgradable versions
+        """Get current firmware version of all updatable devices on DUT, and
+        print out devices with upgradable/downgradable versions.
         """
         self._install_fwupd()
         logger.info("collect firmware info")
@@ -82,8 +80,7 @@ class LVFSDevice(AbstractDevice):
         logger.info("fwupd version\n%s", stdout)
 
     def _parse_fwupd_raw(self, fwupd_raw: str) -> bool:
-        """
-        Parse the output of ```$ fwupdmgr get-devices```
+        """Parse the output of ```$ fwupdmgr get-devices```.
 
         :param fwupd_raw: output string of ```$ fwupdmgr get-devices```
         """
@@ -127,8 +124,7 @@ class LVFSDevice(AbstractDevice):
                 logger.info(msg)
 
     def upgrade(self) -> bool:
-        """
-        Upgrade all devices firmware to latest version if available on LVFS
+        """Upgrade all devices firmware to latest version if available on LVFS.
 
         :return: `True` if upgrading is done and reboot is required, `False`
                  otherwise
@@ -173,8 +169,8 @@ class LVFSDevice(AbstractDevice):
         return reboot
 
     def downgrade(self) -> bool:
-        """
-        Downgrade all devices firmware to 2nd new version if available on LVFS
+        """Downgrade all devices firmware to 2nd new version
+        if available on LVFS.
 
         :return: `True` if downgrading is done and reboot is required, `False`
                  otherwise
@@ -227,8 +223,7 @@ class LVFSDevice(AbstractDevice):
         return reboot
 
     def check_results(self) -> bool:
-        """
-        Get upgrade/downgrade result and validate if it succeeds
+        """Get upgrade/downgrade result and validate if it succeeds.
 
         :return: `True` if overall upgrade status is success, `False` otherwise
         """
@@ -284,9 +279,8 @@ class LVFSDevice(AbstractDevice):
         return fwupd_result
 
     def check_connectable(self, timeout: int):
-        """
-        After DUT reboot, check if SSH to DUT works within a given timeout
-        period
+        """After DUT reboot, check if SSH to DUT works within a given timeout
+        period.
 
         :param timeout: wait time for regaining DUT access
         """
@@ -318,7 +312,7 @@ class LVFSDevice(AbstractDevice):
         logger.info("%s is SSHable after %ds", self.ipaddr, int(delta))
 
     def reboot(self):
-        """Reboot the DUT from OS"""
+        """Reboot the DUT from OS."""
         logger.info("reboot DUT")
         self.run_cmd("sudo reboot", raise_stderr=False)
         time.sleep(10)

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
@@ -1,12 +1,13 @@
 """Device class for flashing firmware on device supported by LVFS-fwupd"""
 
-import subprocess
 import json
-import time
 import logging
-from typing import Tuple
-from testflinger_device_connectors.fw_devices.base import AbstractDevice
+import subprocess
+import time
 from enum import Enum, auto
+from typing import Tuple
+
+from testflinger_device_connectors.fw_devices.base import AbstractDevice
 
 logger = logging.getLogger()
 

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/fwupd_data.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/fwupd_data.py
@@ -1,4 +1,4 @@
-"""This file provides fwupdmgr outputs for unit tests"""
+"""Provide fwupdmgr outputs for unit tests."""
 
 """normal output of `fwupdmgr get-results <DeviceId> --json`"""
 GET_RESULTS_RESPONSE_DATA = """{

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
@@ -1,4 +1,4 @@
-"""Test LVFSDevice"""
+"""Test LVFSDevice."""
 
 import json
 import unittest
@@ -15,14 +15,13 @@ device_results = json.loads(fwupd_data.GET_RESULTS_RESPONSE_DATA)
 
 class TestLVFSDevice(unittest.TestCase):
     def mock_run_cmd(*args, **kwargs):
-        """Mock run_cmd"""
+        """Mock run_cmd."""
         if "sudo fwupdmgr get-results" in args[1]:
             return 0, json.dumps(device_results), ""
         return 0, "", ""
 
     def test_upgradable(self):
-        """
-        Given fwupd data with only newer System Firmware releases available.
+        """Given fwupd data with only newer System Firmware releases available.
         Test if upgrade function returns True. And test if downgrade function
         returns False.
         """
@@ -36,8 +35,7 @@ class TestLVFSDevice(unittest.TestCase):
             self.assertFalse(device.downgrade())
 
     def test_downgradable(self):
-        """
-        Given fwupd data with only older System Firmware releases available.
+        """Given fwupd data with only older System Firmware releases available.
         Test if upgrade function returns False. And test if downgrade function
         returns True.
         """
@@ -58,7 +56,7 @@ class TestLVFSDevice(unittest.TestCase):
             self.assertTrue(device.downgrade())
 
     def test_check_results_failed_state(self):
-        """Validate UpdateState check in check_results"""
+        """Validate UpdateState check in check_results."""
         global device_results
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
@@ -72,7 +70,7 @@ class TestLVFSDevice(unittest.TestCase):
             self.assertFalse(device.check_results())
 
     def test_check_results_mismatched_version(self):
-        """Validate version check in check_results"""
+        """Validate version check in check_results."""
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
         ) as mock_path:
@@ -83,7 +81,7 @@ class TestLVFSDevice(unittest.TestCase):
             self.assertFalse(device.check_results())
 
     def test_check_results_good(self):
-        """Test if check_results works with a valid case"""
+        """Test if check_results works with a valid case."""
         global device_results
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
@@ -100,9 +98,8 @@ class TestLVFSDevice(unittest.TestCase):
             self.assertTrue(device.check_results())
 
     def test_check_results_error(self):
-        """
-        Test error in check_results with an error return from ```$ fwupdmgr
-        get-results```
+        """Test error in check_results with an error return from ```$ fwupdmgr
+        get-results```.
         """
         global device_results
         with patch(

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
@@ -57,7 +57,7 @@ class TestLVFSDevice(unittest.TestCase):
 
     def test_check_results_failed_state(self):
         """Validate UpdateState check in check_results."""
-        global device_results  # noqa PLW0603
+        global device_results  # noqa: PLW0603
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
         ) as mock_path:
@@ -82,7 +82,7 @@ class TestLVFSDevice(unittest.TestCase):
 
     def test_check_results_good(self):
         """Test if check_results works with a valid case."""
-        global device_results  # noqa PLW0603
+        global device_results  # noqa: PLW0603
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
         ) as mock_path:
@@ -101,7 +101,7 @@ class TestLVFSDevice(unittest.TestCase):
         """Test error in check_results with an error return from ```$ fwupdmgr
         get-results```.
         """
-        global device_results  # noqa PLW0603
+        global device_results  # noqa: PLW0603
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
         ) as mock_path:

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
@@ -57,7 +57,7 @@ class TestLVFSDevice(unittest.TestCase):
 
     def test_check_results_failed_state(self):
         """Validate UpdateState check in check_results."""
-        global device_results
+        global device_results  # noqa PLW0603
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
         ) as mock_path:
@@ -82,7 +82,7 @@ class TestLVFSDevice(unittest.TestCase):
 
     def test_check_results_good(self):
         """Test if check_results works with a valid case."""
-        global device_results
+        global device_results  # noqa PLW0603
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
         ) as mock_path:
@@ -101,7 +101,7 @@ class TestLVFSDevice(unittest.TestCase):
         """Test error in check_results with an error return from ```$ fwupdmgr
         get-results```.
         """
-        global device_results
+        global device_results  # noqa PLW0603
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
         ) as mock_path:

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
@@ -1,11 +1,12 @@
 """Test LVFSDevice"""
 
-import unittest
 import json
+import unittest
 from unittest.mock import patch
+
 from testflinger_device_connectors.fw_devices import (
-    LVFSDevice,
     FwupdUpdateState,
+    LVFSDevice,
 )
 from testflinger_device_connectors.fw_devices.LVFS.tests import fwupd_data
 

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/OEM/OEM.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/OEM/OEM.py
@@ -1,16 +1,16 @@
-"""Device classes for flashing firmware on device with OEM-specific methods"""
+"""Device classes for flashing firmware on device with OEM-specific methods."""
 
 from testflinger_device_connectors.fw_devices.base import AbstractDevice
 
 
 class OEMDevice(AbstractDevice):
-    """Device class for devices that are not supported by LVFS-fwupd"""
+    """Device class for devices that are not supported by LVFS-fwupd."""
 
     fw_update_type = "OEM-defined"
 
 
 class HPEDevice(OEMDevice):
-    """Place-holder for device class for HPE server"""
+    """Place-holder for device class for HPE server."""
 
     fw_update_type = "OEM-defined"
     vendor = "HPE"

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/__init__.py
@@ -1,11 +1,11 @@
 from testflinger_device_connectors.fw_devices.base import AbstractDevice
 from testflinger_device_connectors.fw_devices.LVFS.LVFS import (
-    LVFSDevice,
     FwupdUpdateState,
+    LVFSDevice,
 )
 from testflinger_device_connectors.fw_devices.OEM.OEM import (
-    OEMDevice,
     HPEDevice,
+    OEMDevice,
 )
 
 __all__ = [

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/base.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/base.py
@@ -1,4 +1,4 @@
-"""Base class for flashing firmware on devices"""
+"""Base class for flashing firmware on devices."""
 
 from abc import ABC, abstractmethod
 

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/dmi.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/dmi.py
@@ -1,5 +1,4 @@
-"""This maps DMI chassis type to readable name"""
-
+"""Map DMI chassis type to readable name."""
 
 class Dmi:
     chassis = (

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/dmi.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/dmi.py
@@ -1,5 +1,6 @@
 """Map DMI chassis type to readable name."""
 
+
 class Dmi:
     chassis = (
         ("Undefined", "unknown"),  # 0x00

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/firmware_update.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/firmware_update.py
@@ -48,7 +48,7 @@ def detect_device(
         )
     except subprocess.CalledProcessError as err:
         logger.error(err.output)
-        raise RuntimeError(err.output)
+        raise RuntimeError(err.output) from err
 
     err_msg = ""
     if rc1 != 0:
@@ -79,9 +79,9 @@ def detect_device(
             and any(x == vendor_string for x in dev.vendor)
         ][0]
         logger.info("%s is a %s %s", ip, vendor_string, dev.__name__)
-    except IndexError:
+    except IndexError as err:
         logger.error(err_msg)
-        raise RuntimeError(err_msg)
+        raise RuntimeError(err_msg) from err
 
     if issubclass(dev, LVFSDevice):
         return dev(ip, user, password)

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/firmware_update.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/firmware_update.py
@@ -1,4 +1,4 @@
-"""Detecting device types"""
+"""Detecting device types."""
 
 import logging
 import subprocess
@@ -25,8 +25,7 @@ def all_subclasses(cls):
 def detect_device(
     ip: str, user: str, password: str = "", **options
 ) -> AbstractDevice:
-    """
-    Detect device's firmware upgrade type by checking on DMI data
+    """Detect device's firmware upgrade type by checking on DMI data.
 
     :param ip:        DUT IP
     :param user:      DUT user

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/firmware_update.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/firmware_update.py
@@ -1,13 +1,14 @@
 """Detecting device types"""
 
-import subprocess
 import logging
-from testflinger_device_connectors.fw_devices.dmi import Dmi
+import subprocess
+
 from testflinger_device_connectors.fw_devices import (
     AbstractDevice,
     LVFSDevice,
     OEMDevice,
 )
+from testflinger_device_connectors.fw_devices.dmi import Dmi
 
 logger = logging.getLogger()
 

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
@@ -1,4 +1,4 @@
-"""Test detect_device in firmware_update.py"""
+"""Test detect_device in firmware_update.py."""
 
 import unittest
 from unittest.mock import patch
@@ -16,8 +16,7 @@ type_cmd = "sudo cat /sys/class/dmi/id/chassis_type"
 
 class TestFirmwareUpdate(unittest.TestCase):
     def mock_run_cmd_supported(*args, **kwargs):
-        """
-        Mock run_cmd for a HP All In One device, which has a supported
+        """Mock run_cmd for a HP All In One device, which has a supported
         Device class.
         """
         if args[1] == vendor_cmd:
@@ -26,8 +25,8 @@ class TestFirmwareUpdate(unittest.TestCase):
             return 0, "13", ""
 
     def mock_run_cmd_unsupported(*args, **kwargs):
-        """
-        Mock run_cmd for a device which doesn't have a supported Device class.
+        """Mock run_cmd for a device which doesn't have
+        a supported Device class.
         """
         if args[1] == vendor_cmd:
             return 0, "Default string", ""
@@ -35,9 +34,7 @@ class TestFirmwareUpdate(unittest.TestCase):
             return 0, "3", ""
 
     def mock_run_cmd_fail(*args, **kwargs):
-        """
-        Mock run_cmd for a device which couldn't provide dmi data.
-        """
+        """Mock run_cmd for a device which couldn't provide dmi data."""
         if args[1] == vendor_cmd:
             return (
                 1,
@@ -54,9 +51,7 @@ class TestFirmwareUpdate(unittest.TestCase):
             )
 
     def mock_run_cmd_nossh(*args, **kwargs):
-        """
-        Mock run_cmd to simulate an unreachable device.
-        """
+        """Mock run_cmd to simulate an unreachable device."""
         if args[1] == vendor_cmd:
             return (
                 255,
@@ -73,7 +68,7 @@ class TestFirmwareUpdate(unittest.TestCase):
             )
 
     def test_detect_device_supported(self):
-        """Test if detects_device returns a correct device class"""
+        """Test if detects_device returns a correct device class."""
         with patch(
             "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
         ) as mock_path:
@@ -82,7 +77,7 @@ class TestFirmwareUpdate(unittest.TestCase):
             self.assertTrue(isinstance(device, LVFSDevice))
 
     def test_detect_device_unsupported(self):
-        """Test if detects_device exits while given a unsupported device"""
+        """Test if detects_device exits while given a unsupported device."""
         with pytest.raises(RuntimeError) as pytest_wrapped_e:
             with patch(
                 "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
@@ -96,8 +91,8 @@ class TestFirmwareUpdate(unittest.TestCase):
         )
 
     def test_detect_device_fail(self):
-        """
-        Test if detects_device exits while given a device without dmi data
+        """Test if detects_device exits while given a
+        device without dmi data.
         """
         with pytest.raises(RuntimeError) as pytest_wrapped_e:
             with patch(
@@ -112,9 +107,7 @@ class TestFirmwareUpdate(unittest.TestCase):
         )
 
     def test_detect_device_nossh(self):
-        """
-        Test if detects_device exits while given an unreachable device
-        """
+        """Test if detects_device exits while given an unreachable device."""
         with pytest.raises(RuntimeError) as pytest_wrapped_e:
             with patch(
                 "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
@@ -1,13 +1,14 @@
 """Test detect_device in firmware_update.py"""
 
 import unittest
-import pytest
 from unittest.mock import patch
+
+import pytest
+
 from testflinger_device_connectors.fw_devices import LVFSDevice
 from testflinger_device_connectors.fw_devices.firmware_update import (
     detect_device,
 )
-
 
 vendor_cmd = "sudo cat /sys/class/dmi/id/chassis_vendor"
 type_cmd = "sudo cat /sys/class/dmi/id/chassis_type"

--- a/device-connectors/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
@@ -56,15 +56,13 @@ class TestFirmwareUpdate(unittest.TestCase):
             return (
                 255,
                 "",
-                "ssh: connect to host 10.10.10.10 port 22: "
-                "No route to host",
+                "ssh: connect to host 10.10.10.10 port 22: No route to host",
             )
         elif args[1] == type_cmd:
             return (
                 255,
                 "",
-                "ssh: connect to host 10.10.10.10 port 22: "
-                "No route to host",
+                "ssh: connect to host 10.10.10.10 port 22: No route to host",
             )
 
     def test_detect_device_supported(self):

--- a/device-connectors/tests/test_cmd.py
+++ b/device-connectors/tests/test_cmd.py
@@ -11,20 +11,21 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
-"""Tests for the cmd argument parser"""
+"""Tests for the cmd argument parser."""
 
-import pytest
 import json
 
-from testflinger_device_connectors.devices import RecoveryError
+import pytest
+
 from testflinger_device_connectors.cmd import (
-    get_args,
     add_exception_logging_to_file,
+    get_args,
 )
+from testflinger_device_connectors.devices import RecoveryError
 
 
 def test_good_args():
-    """Test that we can parse good arguments"""
+    """Test that we can parse good arguments."""
     argv = ["noprovision", "reserve", "-c", "config.cfg", "job_data.json"]
 
     args = get_args(argv)
@@ -36,7 +37,7 @@ def test_good_args():
 
 
 def test_invalid_device():
-    """Test that an invalid device raises an exception"""
+    """Test that an invalid device raises an exception."""
     argv = ["INVALID", "provision", "-c", "config.cfg", "job_data.json"]
 
     with pytest.raises(SystemExit) as err:
@@ -45,7 +46,7 @@ def test_invalid_device():
 
 
 def test_invalid_stage():
-    """Test that an invalid stage raises an exception"""
+    """Test that an invalid stage raises an exception."""
     argv = ["INVALID", "provision", "-c", "config.cfg", "job_data.json"]
 
     with pytest.raises(SystemExit) as err:
@@ -54,7 +55,7 @@ def test_invalid_stage():
 
 
 def test_exception_logging(tmp_path):
-    """Tests exception logging decorator that adds file logging"""
+    """Tests exception logging decorator that adds file logging."""
     open("device-connector-error.json", "w").close()
 
     exception_info = {
@@ -76,7 +77,7 @@ def test_exception_logging(tmp_path):
 
 
 def test_exception_logging_no_cause(tmp_path):
-    """Tests exception logging for causeless exceptions"""
+    """Tests exception logging for causeless exceptions."""
     open("device-connector-error.json", "w").close()
 
     exception_info = {
@@ -100,7 +101,7 @@ def test_exception_logging_no_cause(tmp_path):
 def test_recovery_error_return_value():
     """
     Tests that exception logging function return exit code 46
-    on RecoveryError
+    on RecoveryError.
     """
 
     def test_func():

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -11,7 +11,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
-"""Tests for the devices module"""
+"""Tests for the devices module."""
 
 from importlib import import_module
 from itertools import product
@@ -29,7 +29,7 @@ STAGES_CONNECTORS_PRODUCT = tuple(product(STAGES, DEVICE_CONNECTORS))
 
 @pytest.mark.parametrize("stage,device", STAGES_CONNECTORS_PRODUCT)
 def test_get_device_stage_func(stage, device):
-    """Check that we can load all stages from all device connectors"""
+    """Check that we can load all stages from all device connectors."""
     connector_instance = import_module(
         f"testflinger_device_connectors.devices.{device}"
     ).DeviceConnector()

--- a/device-connectors/tests/test_snappy_device_agents.py
+++ b/device-connectors/tests/test_snappy_device_agents.py
@@ -18,10 +18,10 @@ import testflinger_device_connectors
 
 
 class TestCommandsTemplate:
-    """Tests to ensure test_cmds templating works properly"""
+    """Tests to ensure test_cmds templating works properly."""
 
     def test_known_config_items(self):
-        """Known config items should fill in the expected value"""
+        """Known config items should fill in the expected value."""
         cmds = "test {item}"
         config = {"item": "foo"}
         expected = "test foo"
@@ -33,7 +33,7 @@ class TestCommandsTemplate:
         )
 
     def test_unknown_config_items(self):
-        """Unknown config items should not cause an error"""
+        """Unknown config items should not cause an error."""
         cmds = "test  {unknown_item}"
         config = {}
         assert (
@@ -44,7 +44,7 @@ class TestCommandsTemplate:
         )
 
     def test_escaped_braces(self):
-        """Escaped braces should be unescaped, not interpreted"""
+        """Escaped braces should be unescaped, not interpreted."""
         cmds = "test {{item}}"
         config = {"item": "foo"}
         expected = "test {item}"

--- a/device-connectors/tox.ini
+++ b/device-connectors/tox.ini
@@ -21,13 +21,12 @@ commands =
 [testenv:format]
 description = Run formatting tests
 commands =
-    black --check src
+    ruff format --check src
 
 [testenv:lint]
 description = Run linting tests
 commands =
-    flake8 src
-    # pylint src
+    ruff check src
 
 [testenv:unit]
 description = Run unit tests

--- a/device-connectors/tox.ini
+++ b/device-connectors/tox.ini
@@ -21,12 +21,12 @@ commands =
 [testenv:format]
 description = Run formatting tests
 commands =
-    ruff format --check src
+    ruff format --check src tests
 
 [testenv:lint]
 description = Run linting tests
 commands =
-    ruff check src
+    ruff check src tests
 
 [testenv:unit]
 description = Run unit tests

--- a/device-connectors/uv.lock
+++ b/device-connectors/uv.lock
@@ -650,6 +650,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.11.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/89/6f9c9674818ac2e9cc2f2b35b704b7768656e6b7c139064fc7ba8fbc99f1/ruff-0.11.7.tar.gz", hash = "sha256:655089ad3224070736dc32844fde783454f8558e71f501cb207485fe4eee23d4", size = 4054861, upload_time = "2025-04-24T18:49:37.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/ec/21927cb906c5614b786d1621dba405e3d44f6e473872e6df5d1a6bca0455/ruff-0.11.7-py3-none-linux_armv6l.whl", hash = "sha256:d29e909d9a8d02f928d72ab7837b5cbc450a5bdf578ab9ebee3263d0a525091c", size = 10245403, upload_time = "2025-04-24T18:48:40.459Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/af/fec85b6c2c725bcb062a354dd7cbc1eed53c33ff3aa665165871c9c16ddf/ruff-0.11.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dd1fb86b168ae349fb01dd497d83537b2c5541fe0626e70c786427dd8363aaee", size = 11007166, upload_time = "2025-04-24T18:48:44.742Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9a/2d0d260a58e81f388800343a45898fd8df73c608b8261c370058b675319a/ruff-0.11.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d3d7d2e140a6fbbc09033bce65bd7ea29d6a0adeb90b8430262fbacd58c38ada", size = 10378076, upload_time = "2025-04-24T18:48:47.918Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/9b09b45051404d2e7dd6d9dbcbabaa5ab0093f9febcae664876a77b9ad53/ruff-0.11.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4809df77de390a1c2077d9b7945d82f44b95d19ceccf0c287c56e4dc9b91ca64", size = 10557138, upload_time = "2025-04-24T18:48:51.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5e/f62a1b6669870a591ed7db771c332fabb30f83c967f376b05e7c91bccd14/ruff-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f3a0c2e169e6b545f8e2dba185eabbd9db4f08880032e75aa0e285a6d3f48201", size = 10095726, upload_time = "2025-04-24T18:48:54.243Z" },
+    { url = "https://files.pythonhosted.org/packages/45/59/a7aa8e716f4cbe07c3500a391e58c52caf665bb242bf8be42c62adef649c/ruff-0.11.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49b888200a320dd96a68e86736cf531d6afba03e4f6cf098401406a257fcf3d6", size = 11672265, upload_time = "2025-04-24T18:48:57.639Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e3/101a8b707481f37aca5f0fcc3e42932fa38b51add87bfbd8e41ab14adb24/ruff-0.11.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2b19cdb9cf7dae00d5ee2e7c013540cdc3b31c4f281f1dacb5a799d610e90db4", size = 12331418, upload_time = "2025-04-24T18:49:00.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/71/037f76cbe712f5cbc7b852e4916cd3cf32301a30351818d32ab71580d1c0/ruff-0.11.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64e0ee994c9e326b43539d133a36a455dbaab477bc84fe7bfbd528abe2f05c1e", size = 11794506, upload_time = "2025-04-24T18:49:03.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/de/e450b6bab1fc60ef263ef8fcda077fb4977601184877dce1c59109356084/ruff-0.11.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bad82052311479a5865f52c76ecee5d468a58ba44fb23ee15079f17dd4c8fd63", size = 13939084, upload_time = "2025-04-24T18:49:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2c/1e364cc92970075d7d04c69c928430b23e43a433f044474f57e425cbed37/ruff-0.11.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7940665e74e7b65d427b82bffc1e46710ec7f30d58b4b2d5016e3f0321436502", size = 11450441, upload_time = "2025-04-24T18:49:11.41Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7d/1b048eb460517ff9accd78bca0fa6ae61df2b276010538e586f834f5e402/ruff-0.11.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:169027e31c52c0e36c44ae9a9c7db35e505fee0b39f8d9fca7274a6305295a92", size = 10441060, upload_time = "2025-04-24T18:49:14.184Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/57/8dc6ccfd8380e5ca3d13ff7591e8ba46a3b330323515a4996b991b10bd5d/ruff-0.11.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:305b93f9798aee582e91e34437810439acb28b5fc1fee6b8205c78c806845a94", size = 10058689, upload_time = "2025-04-24T18:49:17.559Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bf/20487561ed72654147817885559ba2aa705272d8b5dee7654d3ef2dbf912/ruff-0.11.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a681db041ef55550c371f9cd52a3cf17a0da4c75d6bd691092dfc38170ebc4b6", size = 11073703, upload_time = "2025-04-24T18:49:20.247Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/04f2db95f4ef73dccedd0c21daf9991cc3b7f29901a4362057b132075aa4/ruff-0.11.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:07f1496ad00a4a139f4de220b0c97da6d4c85e0e4aa9b2624167b7d4d44fd6b6", size = 11532822, upload_time = "2025-04-24T18:49:23.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/72/43b123e4db52144c8add336581de52185097545981ff6e9e58a21861c250/ruff-0.11.7-py3-none-win32.whl", hash = "sha256:f25dfb853ad217e6e5f1924ae8a5b3f6709051a13e9dad18690de6c8ff299e26", size = 10362436, upload_time = "2025-04-24T18:49:27.377Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a0/3e58cd76fdee53d5c8ce7a56d84540833f924ccdf2c7d657cb009e604d82/ruff-0.11.7-py3-none-win_amd64.whl", hash = "sha256:0a931d85959ceb77e92aea4bbedfded0a31534ce191252721128f77e5ae1f98a", size = 11566676, upload_time = "2025-04-24T18:49:30.938Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ca/69d7c7752bce162d1516e5592b1cc6b6668e9328c0d270609ddbeeadd7cf/ruff-0.11.7-py3-none-win_arm64.whl", hash = "sha256:778c1e5d6f9e91034142dfd06110534ca13220bfaad5c3735f6cb844654f6177", size = 10677936, upload_time = "2025-04-24T18:49:34.392Z" },
+]
+
+[[package]]
 name = "testflinger-device-connectors"
 version = "0.0.2"
 source = { editable = "." }
@@ -669,6 +694,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -688,6 +714,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "ruff", specifier = ">=0.11.7" },
 ]
 
 [[package]]

--- a/device-connectors/uv.lock
+++ b/device-connectors/uv.lock
@@ -29,40 +29,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449, upload_time = "2025-01-29T04:15:40.373Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/3b/4ba3f93ac8d90410423fdd31d7541ada9bcee1df32fb90d26de41ed40e1d/black-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32", size = 1629419, upload_time = "2025-01-29T05:37:06.642Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/02/0bde0485146a8a5e694daed47561785e8b77a0466ccc1f3e485d5ef2925e/black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da", size = 1461080, upload_time = "2025-01-29T05:37:09.321Z" },
-    { url = "https://files.pythonhosted.org/packages/52/0e/abdf75183c830eaca7589144ff96d49bce73d7ec6ad12ef62185cc0f79a2/black-25.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7", size = 1766886, upload_time = "2025-01-29T04:18:24.432Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/a6/97d8bb65b1d8a41f8a6736222ba0a334db7b7b77b8023ab4568288f23973/black-25.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9", size = 1419404, upload_time = "2025-01-29T04:19:04.296Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/4f/87f596aca05c3ce5b94b8663dbfe242a12843caaa82dd3f85f1ffdc3f177/black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0", size = 1614372, upload_time = "2025-01-29T05:37:11.71Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/d0/2c34c36190b741c59c901e56ab7f6e54dad8df05a6272a9747ecef7c6036/black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299", size = 1442865, upload_time = "2025-01-29T05:37:14.309Z" },
-    { url = "https://files.pythonhosted.org/packages/21/d4/7518c72262468430ead45cf22bd86c883a6448b9eb43672765d69a8f1248/black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096", size = 1749699, upload_time = "2025-01-29T04:18:17.688Z" },
-    { url = "https://files.pythonhosted.org/packages/58/db/4f5beb989b547f79096e035c4981ceb36ac2b552d0ac5f2620e941501c99/black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2", size = 1428028, upload_time = "2025-01-29T04:18:51.711Z" },
-    { url = "https://files.pythonhosted.org/packages/83/71/3fe4741df7adf015ad8dfa082dd36c94ca86bb21f25608eb247b4afb15b2/black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b", size = 1650988, upload_time = "2025-01-29T05:37:16.707Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f3/89aac8a83d73937ccd39bbe8fc6ac8860c11cfa0af5b1c96d081facac844/black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc", size = 1453985, upload_time = "2025-01-29T05:37:18.273Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/22/b99efca33f1f3a1d2552c714b1e1b5ae92efac6c43e790ad539a163d1754/black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f", size = 1783816, upload_time = "2025-01-29T04:18:33.823Z" },
-    { url = "https://files.pythonhosted.org/packages/18/7e/a27c3ad3822b6f2e0e00d63d58ff6299a99a5b3aee69fa77cd4b0076b261/black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba", size = 1440860, upload_time = "2025-01-29T04:19:12.944Z" },
-    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673, upload_time = "2025-01-29T05:37:20.574Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190, upload_time = "2025-01-29T05:37:22.106Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926, upload_time = "2025-01-29T04:18:58.564Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613, upload_time = "2025-01-29T04:19:27.63Z" },
-    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload_time = "2025-01-29T04:15:38.082Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -130,18 +96,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391, upload_time = "2024-12-24T18:11:24.139Z" },
     { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702, upload_time = "2024-12-24T18:11:26.535Z" },
     { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767, upload_time = "2024-12-24T18:12:32.852Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload_time = "2024-12-21T18:38:44.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload_time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
@@ -228,20 +182,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flake8"
-version = "7.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/c4/5842fc9fc94584c455543540af62fd9900faade32511fab650e9891ec225/flake8-7.2.0.tar.gz", hash = "sha256:fa558ae3f6f7dbf2b4f22663e5343b6b6023620461f8d4ff2019ef4b5ee70426", size = 48177, upload_time = "2025-03-29T20:08:39.329Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/5c/0627be4c9976d56b1217cb5187b7504e7fd7d3503f8bfd312a04077bd4f7/flake8-7.2.0-py2.py3-none-any.whl", hash = "sha256:93b92ba5bdb60754a6da14fa3b93a9361fd00a59632ada61fd7b130436c40343", size = 57786, upload_time = "2025-03-29T20:08:37.902Z" },
-]
-
-[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -296,24 +236,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload_time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload_time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433, upload_time = "2023-02-04T12:11:27.157Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695, upload_time = "2023-02-04T12:11:25.002Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -323,21 +245,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
+name = "pkgutil-resolve-name"
+version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload_time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/f2/f2891a9dc37398696ddd945012b90ef8d0a034f0012e3f83c3f7a70b0f79/pkgutil_resolve_name-1.3.10.tar.gz", hash = "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174", size = 5054, upload_time = "2021-07-21T08:19:05.096Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload_time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.3.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351", size = 21291, upload_time = "2025-03-19T20:36:10.989Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/45/59578566b3275b8fd9157885918fcd0c4d74162928a5310926887b856a51/platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94", size = 18499, upload_time = "2025-03-19T20:36:09.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5c/3d4882ba113fd55bdba9326c1e4c62a15e674a2501de4869e6bd6301f87e/pkgutil_resolve_name-1.3.10-py3-none-any.whl", hash = "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e", size = 4734, upload_time = "2021-07-21T08:19:03.106Z" },
 ]
 
 [[package]]
@@ -359,24 +272,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f0/5d/49ba324ad4ae5b1a4caefafbce7a1648540129344481f2ed4ef6bb68d451/plumbum-1.9.0.tar.gz", hash = "sha256:e640062b72642c3873bd5bdc3effed75ba4d3c70ef6b6a7b907357a84d909219", size = 319083, upload_time = "2024-10-05T05:59:27.059Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/9d/d03542c93bb3d448406731b80f39c3d5601282f778328c22c77d270f4ed4/plumbum-1.9.0-py3-none-any.whl", hash = "sha256:9fd0d3b0e8d86e4b581af36edf3f3bbe9d1ae15b45b8caab28de1bcb27aaa7f5", size = 127970, upload_time = "2024-10-05T05:59:25.102Z" },
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/6e/1f4a62078e4d95d82367f24e685aef3a672abfd27d1a868068fed4ed2254/pycodestyle-2.13.0.tar.gz", hash = "sha256:c8415bf09abe81d9c7f872502a6eee881fbe85d8763dd5b9924bb0a01d67efae", size = 39312, upload_time = "2025-03-29T17:33:30.669Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/be/b00116df1bfb3e0bb5b45e29d604799f7b91dd861637e4d448b4e09e6a3e/pycodestyle-2.13.0-py2.py3-none-any.whl", hash = "sha256:35863c5974a271c7a726ed228a14a4f6daf49df369d8c50cd9a6f58a5e143ba9", size = 31424, upload_time = "2025-03-29T17:33:29.405Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/cc/1df338bd7ed1fa7c317081dcf29bf2f01266603b301e6858856d346a12b3/pyflakes-3.3.2.tar.gz", hash = "sha256:6dfd61d87b97fba5dcfaaf781171ac16be16453be6d816147989e7f6e6a9576b", size = 64175, upload_time = "2025-03-31T13:21:20.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/40/b293a4fa769f3b02ab9e387c707c4cbdc34f073f945de0386107d4e669e6/pyflakes-3.3.2-py2.py3-none-any.whl", hash = "sha256:5039c8339cbb1944045f4ee5466908906180f13cc99cc9949348d10f82a5c32a", size = 63164, upload_time = "2025-03-31T13:21:18.503Z" },
 ]
 
 [[package]]
@@ -660,11 +555,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black", version = "24.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "black", version = "25.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "flake8", version = "5.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
-    { name = "flake8", version = "7.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
-    { name = "flake8", version = "7.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
@@ -682,8 +572,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=24.8.0" },
-    { name = "flake8", specifier = ">=5.0.4" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },

--- a/device-connectors/uv.lock
+++ b/device-connectors/uv.lock
@@ -219,15 +219,6 @@ toml = [
 ]
 
 [[package]]
-name = "dill"
-version = "0.3.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/43/86fe3f9e130c4137b0f1b50784dd70a5087b911fe07fa81e53e0c4c47fea/dill-0.3.9.tar.gz", hash = "sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c", size = 187000, upload_time = "2024-09-29T00:03:20.958Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/d1/e73b6ad76f0b1fb7f23c35c6d95dbc506a9c8804f43dda8cb5b0fa6331fd/dill-0.3.9-py3-none-any.whl", hash = "sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a", size = 119418, upload_time = "2024-09-29T00:03:19.344Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -386,25 +377,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/cc/1df338bd7ed1fa7c317081dcf29bf2f01266603b301e6858856d346a12b3/pyflakes-3.3.2.tar.gz", hash = "sha256:6dfd61d87b97fba5dcfaaf781171ac16be16453be6d816147989e7f6e6a9576b", size = 64175, upload_time = "2025-03-31T13:21:20.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/40/b293a4fa769f3b02ab9e387c707c4cbdc34f073f945de0386107d4e669e6/pyflakes-3.3.2-py2.py3-none-any.whl", hash = "sha256:5039c8339cbb1944045f4ee5466908906180f13cc99cc9949348d10f82a5c32a", size = 63164, upload_time = "2025-03-31T13:21:18.503Z" },
-]
-
-[[package]]
-name = "pylint"
-version = "3.3.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astroid" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "dill" },
-    { name = "isort" },
-    { name = "mccabe" },
-    { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tomlkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/a7/113d02340afb9dcbb0c8b25454e9538cd08f0ebf3e510df4ed916caa1a89/pylint-3.3.6.tar.gz", hash = "sha256:b634a041aac33706d56a0d217e6587228c66427e20ec21a019bc4cdee48c040a", size = 1519586, upload_time = "2025-03-20T11:25:38.207Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/21/9537fc94aee9ec7316a230a49895266cf02d78aa29b0a2efbc39566e0935/pylint-3.3.6-py3-none-any.whl", hash = "sha256:8b7c2d3e86ae3f94fb27703d521dd0b9b6b378775991f504d7c3a6275aa0a6a6", size = 522462, upload_time = "2025-03-20T11:25:36.13Z" },
 ]
 
 [[package]]
@@ -688,9 +660,11 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
-    { name = "flake8" },
-    { name = "pylint" },
+    { name = "black", version = "24.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "black", version = "25.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "flake8", version = "5.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
+    { name = "flake8", version = "7.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+    { name = "flake8", version = "7.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
@@ -710,7 +684,6 @@ requires-dist = [
 dev = [
     { name = "black", specifier = ">=24.8.0" },
     { name = "flake8", specifier = ">=5.0.4" },
-    { name = "pylint", specifier = ">=3.2.7" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
@@ -754,15 +727,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload_time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload_time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload_time = "2024-11-27T22:38:35.385Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.13.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b1/09/a439bec5888f00a54b8b9f05fa94d7f901d6735ef4e55dcec9bc37b5d8fa/tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79", size = 192885, upload_time = "2024-08-14T08:19:41.488Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde", size = 37955, upload_time = "2024-08-14T08:19:40.05Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
- Adds Ruff for formatting an linting
- Removed Black and Flake8 as dependencies for dev 
- Formatted files as required by Ruff configuration for formatting and linting rules
- Most of the changes are related to doctrings and formatting (removing/adding blank spaces)
- Other minor modifications include: Logging in proper format (removing f-string/percent format based on Pylint G002 and G004), module import order, exception handling (log warnings instead of just `pass`) and variable name modification inside for loop  whenever possible (otherwise skipped)

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Related to [CERTTF-592](https://warthogs.atlassian.net/browse/CERTTF-592) and [CERTTF-593](https://warthogs.atlassian.net/browse/CERTTF-593)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->

[CERTTF-592]: https://warthogs.atlassian.net/browse/CERTTF-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CERTTF-593]: https://warthogs.atlassian.net/browse/CERTTF-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

