### PR TITLE
fix(server): Add server venv to path

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,10 +2,12 @@ FROM ubuntu:22.04
 
 # Set up uv
 COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /uvx /bin/
-ENV UV_SYSTEM_PYTHON=true
+ENV UV_SYSTEM_PYTHON=true \  # use system installation of python
+    UV_COMPILE_BYTECODE=1 \  # for faster startup times
+    UV_LINK_MODE=copy        # silences cache mount warnings
 
 WORKDIR /srv/testflinger
-ENV PATH="/srv/testflinger:$PATH"
+ENV PATH="/srv/testflinger/.venv/bin:$PATH"
 
 ENV HOME /root
 ENV LC_ALL C.UTF-8
@@ -39,4 +41,4 @@ RUN --mount=type=cache,target=/root/.cache/uv \
   uv sync --frozen --no-dev
 
 # Run the testflinger server
-ENTRYPOINT ["uv", "run", "gunicorn", "--bind", "0.0.0.0:5000", "app:app"]
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:22.04
 
 # Set up uv
 COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /uvx /bin/
-ENV UV_SYSTEM_PYTHON=true \  # use system installation of python
-    UV_COMPILE_BYTECODE=1 \  # for faster startup times
-    UV_LINK_MODE=copy        # silences cache mount warnings
+ENV UV_SYSTEM_PYTHON=true \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
 
 WORKDIR /srv/testflinger
 ENV PATH="/srv/testflinger/.venv/bin:$PATH"

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -165,8 +165,6 @@ class TestflingerCharm(ops.CharmBase):
         keepalive = str(self.config["keepalive"])
         command = " ".join(
             [
-                "uv",
-                "run",
                 "gunicorn",
                 "-k",
                 "gevent",

--- a/server/devel/docker-compose.override.yml
+++ b/server/devel/docker-compose.override.yml
@@ -5,7 +5,7 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=testflinger
 
   testflinger:
-    command: uv run gunicorn --bind 0.0.0.0:5000 --reload app:app
+    command: gunicorn --bind 0.0.0.0:5000 --reload app:app
     environment:
       - MONGODB_USERNAME=testflinger
       - MONGODB_PASSWORD=testflinger


### PR DESCRIPTION
## Description

- Adds the server virtual environment to the container's path
- Adds some optimizations to the startup time (compile bytecode)
- Fixes warnings that might show up when rebuilding with cache

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
