### PR TITLE
Fix warnings related to non-test classes picked up by pytest

### DIFF
--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -1,0 +1,1 @@
+*.coverage.*

--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -91,6 +91,9 @@ def parse_error_logs(error_log_path: str, phase: str):
 
 
 class TestflingerAgent:
+    __test__ = False
+    """This prevents pytest from trying to run this class as a test."""
+
     def __init__(self, client):
         self.client = client
         signal.signal(signal.SIGUSR1, self.restart_signal_handler)

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -34,6 +34,9 @@ logger = logging.getLogger(__name__)
 
 
 class TestflingerClient:
+    __test__ = False
+    """This prevents pytest from trying to run this class as a test."""
+
     def __init__(self, config):
         self.config = config
         self.server = self.config.get(

--- a/agent/src/testflinger_agent/job.py
+++ b/agent/src/testflinger_agent/job.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 
 
 class TestflingerJob:
+    __test__ = False
+    """This prevents pytest from trying to run this class as a test."""
+
     def __init__(self, job_data, client):
         """
         :param job_data:

--- a/common/src/testflinger_common/enums.py
+++ b/common/src/testflinger_common/enums.py
@@ -35,6 +35,9 @@ class JobState(StrEnum):
 
 
 class TestPhase(StrEnum):
+    __test__ = False
+    """Prevents pytest from trying to run this class as a test."""
+
     SETUP = "setup"
     PROVISION = "provision"
     FIRMWARE_UPDATE = "firmware_update"
@@ -45,6 +48,9 @@ class TestPhase(StrEnum):
 
 
 class TestEvent(StrEnum):
+    __test__ = False
+    """Prevents pytest from trying to run this class as a test."""
+
     SETUP_START = "setup_start"
     PROVISION_START = "provision_start"
     FIRMWARE_UPDATE_START = "firmware_update_start"

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -35,6 +35,9 @@ logger = logging.getLogger(__name__)
 class TestflingerCharm(ops.CharmBase):
     """Testflinger charm."""
 
+    __test__ = False
+    """Prevents pytest from trying to run this class as a test."""
+
     _stored = ops.framework.StoredState()
 
     def __init__(self, *args):


### PR DESCRIPTION
## Description

This silences some of the warnings we get in `pytest` runs (caused by pytest picking up our `Testflinger*` or `Test*` classes as if they were test classes.

To avoid this, I added `__test__=False` to the affected classes.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
