### PR TITLE
feat(ci): Split tox tests in workflows

### DIFF
--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -6,31 +6,53 @@ on:
   push:
     branches: [main]
     paths:
-      - common/**  # testflinger-agent depends on testflinger-common
+      - common/** # testflinger-agent depends on testflinger-common
       - agent/**
       - .github/workflows/agent-tox.yml
   pull_request:
     branches: [main]
     paths:
-      - common/**  # testflinger-agent depends on testflinger-common
+      - common/** # testflinger-agent depends on testflinger-common
       - agent/**
       - .github/workflows/agent-tox.yml
 
 jobs:
-  build:
+  test:
+    name: Run unit tests
     defaults:
       run:
         working-directory: agent
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      with:
-        persist-credentials: false
-    - name: Install uv and set up Python
-      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
-    - name: Install concierge
-      run: sudo snap install --classic concierge
-    - name: Prepare Juju
-      run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=latest/stable -p machine
-    - name: Run tests
-      run: uvx --with tox-uv tox
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - name: Install uv and set up Python
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+      - name: Check lock file
+        run: uvx --with tox-uv tox -e lock
+      - name: Check formatting
+        run: uvx --with tox-uv tox -e format
+      - name: Check linting
+        run: uvx --with tox-uv tox -e lint
+      - name: Run unit tests
+        run: uvx --with tox-uv tox -e unit
+
+  test_charm:
+    name: Run charm tests
+    defaults:
+      run:
+        working-directory: agent
+    runs-on: [self-hosted, linux, jammy, X64]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - name: Install uv and set up Python
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+      - name: Install concierge
+        run: sudo snap install --classic concierge
+      - name: Prepare Juju
+        run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=latest/stable -p machine
+      - name: Run charm tests
+        run: uvx --with tox-uv tox -e charm

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -13,7 +13,8 @@ on:
       - cli/**
 
 jobs:
-  build:
+  test:
+    name: Run unit tests
     defaults:
       run:
         working-directory: cli
@@ -24,5 +25,11 @@ jobs:
           persist-credentials: false
       - name: Install uv and set the Python version
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
-      - name: Run tests
-        run: uvx --with tox-uv tox
+      - name: Check lock file
+        run: uvx --with tox-uv tox -e lock
+      - name: Check formatting
+        run: uvx --with tox-uv tox -e format
+      - name: Check linting
+        run: uvx --with tox-uv tox -e lint
+      - name: Run unit tests
+        run: uvx --with tox-uv tox -e unit

--- a/.github/workflows/common-tox.yml
+++ b/.github/workflows/common-tox.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   test:
+    name: Run unit tests
     defaults:
       run:
         working-directory: common
@@ -26,5 +27,11 @@ jobs:
           persist-credentials: false
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
-      - name: Run tests
-        run: uvx --with tox-uv tox
+      - name: Check lock file
+        run: uvx --with tox-uv tox -e lock
+      - name: Check formatting
+        run: uvx --with tox-uv tox -e format
+      - name: Check linting
+        run: uvx --with tox-uv tox -e lint
+      - name: Run unit tests
+        run: uvx --with tox-uv tox -e unit

--- a/.github/workflows/device-tox.yml
+++ b/.github/workflows/device-tox.yml
@@ -15,7 +15,8 @@ on:
       - device-connectors/**
 
 jobs:
-  build:
+  test:
+    name: Run unit tests
     defaults:
       run:
         working-directory: device-connectors
@@ -31,5 +32,11 @@ jobs:
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Run tests
-        run: uvx --with tox-uv tox
+      - name: Check lock file
+        run: uvx --with tox-uv tox -e lock
+      - name: Check formatting
+        run: uvx --with tox-uv tox -e format
+      - name: Check linting
+        run: uvx --with tox-uv tox -e lint
+      - name: Run unit tests
+        run: uvx --with tox-uv tox -e unit

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -13,7 +13,8 @@ on:
       - server/**
 
 jobs:
-  build:
+  test:
+    name: Run unit tests
     defaults:
       run:
         working-directory: server
@@ -24,5 +25,26 @@ jobs:
           persist-credentials: false
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
-      - name: Run tests
-        run: uvx --with tox-uv tox
+      - name: Check lock file
+        run: uvx --with tox-uv tox -e lock
+      - name: Check formatting
+        run: uvx --with tox-uv tox -e format
+      - name: Check linting
+        run: uvx --with tox-uv tox -e lint
+      - name: Run unit tests
+        run: uvx --with tox-uv tox -e unit
+
+  test_charm:
+    name: Run charm tests
+    defaults:
+      run:
+        working-directory: agent
+    runs-on: [self-hosted, linux, jammy, X64]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - name: Install uv and set up Python
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+      - name: Run charm tests
+        run: uvx --with tox-uv tox -e charm

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -46,5 +46,9 @@ jobs:
           persist-credentials: false
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+      - name: Install concierge
+        run: sudo snap install --classic concierge
+      - name: Prepare Juju
+        run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=latest/stable -p machine
       - name: Run charm tests
         run: uvx --with tox-uv tox -e charm

--- a/agent/tox.ini
+++ b/agent/tox.ini
@@ -4,7 +4,6 @@ env_list =
     format
     lint
     unit
-    charm
 no_package = true
 requires = 
     tox-uv>=1.25.0

--- a/common/tox.ini
+++ b/common/tox.ini
@@ -3,6 +3,7 @@ env_list =
     lock
     format
     lint
+    unit
 no_package = true
 requires =
     tox-uv>=1.25.0
@@ -26,4 +27,10 @@ commands =
 description = Run linting tests
 commands =
     ruff check src
+
+[testenv:unit]
+description = Run unit tests
+commands =
+    # XXX: this is a placeholder for unit tests
+    python -c 'print("no unit tests defined")'
 

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -4,7 +4,6 @@ env_list =
     format
     lint
     unit
-    charm
 no_package = true
 requires = 
     tox-uv>=1.25.0
@@ -43,6 +42,9 @@ commands =
 
 [testenv:charm]
 description = Run charm tests
+dependency_groups =
+    dev
+    charm
 set_env =
     PYTHONPATH = {toxinidir}/charm/src:{toxinidir}/charm/lib
 commands =


### PR DESCRIPTION
## Description

This should make parsing what is failing more readable.

I've also separated the charm tests from the main tests so we don't have to wait for concierge setup.

## Resolved issues

## Documentation

## Web service API changes

## Tests
