### PR TITLE
Cli check snap confined

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -61,6 +61,7 @@ ignore = [
 "testflinger_cli/tests/*" = [
   "S101", # use of assert
   "S105", # use of harcoded passwords for mock
+  "S108", # use of temporary file or directory
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/cli/testflinger_cli/consts.py
+++ b/cli/testflinger_cli/consts.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2025 Canonical Ltd.
+"""Constants for the Testflinger CLI."""
+
+SNAP_NAME = "testflinger-cli"
+SNAP_PRIVATE_DIRS = [
+    "/tmp",  # noqa: S108
+]

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -15,7 +15,9 @@ def is_snap() -> bool:
 
 def file_is_in_snap_private_dir(file: Path) -> bool:
     """Check if the file is in a snap-confined directory."""
-    return any(file.is_relative_to(path) for path in SNAP_PRIVATE_DIRS)
+    return any(
+        file.resolve().is_relative_to(path) for path in SNAP_PRIVATE_DIRS
+    )
 
 
 def parse_filename(

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2025 Canonical Ltd.
+"""Helpers for the Testflinger CLI."""
+
+from os import getenv
+from pathlib import Path
+from typing import Optional
+
+from testflinger_cli.consts import SNAP_NAME, SNAP_PRIVATE_DIRS
+
+
+def is_snap() -> bool:
+    """Check if the current environment is a snap."""
+    return getenv("SNAP_NAME") == SNAP_NAME
+
+
+def file_is_in_snap_private_dir(file: Path) -> bool:
+    """Check if the file is in a snap-confined directory."""
+    return any(file.is_relative_to(path) for path in SNAP_PRIVATE_DIRS)
+
+
+def parse_filename(
+    filename: str,
+    parse_stdin: bool = False,
+    check_snap_private_dir: bool = True,
+) -> Optional[Path]:
+    """Parse the filename and return a Path object.
+
+    :param filename:
+        The filename to parse.
+    :param parse_stdin:
+        If True, treat "-" as stdin.
+    :param check_snap_private_dir:
+        If True, check if the file is in a snap-confined directory.
+    :return:
+        A Path object representing the filename. None if parse_stdin is True
+        and filename is "-".
+    :raises ValueError:
+        If the file is in a snap-confined directory
+        and check_snap_private_dir is True.
+    """
+    if parse_stdin and filename == "-":
+        return None
+    path = Path(filename)
+    if (
+        check_snap_private_dir
+        and is_snap()
+        and file_is_in_snap_private_dir(path)
+    ):
+        msg = f"File {path} is in a snap-confined directory."
+        raise ValueError(msg)
+    return path

--- a/cli/testflinger_cli/tests/test_helpers.py
+++ b/cli/testflinger_cli/tests/test_helpers.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2025 Canonical Ltd.
+"""Tests for the helpers of Testflinger CLI."""
+
+from pathlib import Path
+
+import pytest
+
+from testflinger_cli.consts import SNAP_NAME
+from testflinger_cli.helpers import (
+    file_is_in_snap_private_dir,
+    is_snap,
+    parse_filename,
+)
+
+
+def test_is_snap(monkeypatch):
+    """Test the is_snap function."""
+    monkeypatch.setenv("SNAP_NAME", "")
+    assert not is_snap()
+
+    monkeypatch.setenv("SNAP_NAME", SNAP_NAME)
+    assert is_snap()
+
+
+def test_is_in_snap_private_dir(monkeypatch):
+    """Test the is_in_snap_private_dir function."""
+    monkeypatch.setenv("SNAP_NAME", SNAP_NAME)
+
+    assert file_is_in_snap_private_dir(Path("/tmp/job.yaml"))
+    assert not file_is_in_snap_private_dir(Path("/home/ubuntu/tmp/job.yaml"))
+
+
+def test_parse_filename_snap_private(monkeypatch):
+    """Test the parse_filename function."""
+    # Raises exception if the file is in a snap-confined directory
+    monkeypatch.setenv("SNAP_NAME", SNAP_NAME)
+    with pytest.raises(ValueError):
+        parse_filename("/tmp/job.yaml", check_snap_private_dir=True)
+
+    # Test that you can override the check_snap_private_dir
+    assert parse_filename(
+        "/tmp/job.yaml", check_snap_private_dir=False
+    ) == Path("/tmp/job.yaml")
+
+    # Test that normal files are not affected
+    assert parse_filename(
+        "/home/ubuntu/tmp/job.yaml", check_snap_private_dir=True
+    ) == Path("/home/ubuntu/tmp/job.yaml")
+
+
+def test_parse_filename_stdin():
+    """Test the parse_filename function with stdin."""
+    assert parse_filename("-", parse_stdin=True) is None


### PR DESCRIPTION
## Description

Check if file arguments are in snap-private directories (at the moment, I'm only aware of `/tmp` being an issue for us.).

## Resolved issues

Resolves #511

## Documentation

## Web service API changes

## Tests

- Added unit tests
- Existing tests CLI should pass.