### PR TITLE
oem_autoinstall: Disable copy oem public ssh keys after provisioning

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
@@ -24,9 +24,6 @@ autoinstall:
     - "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash nomodeset modprobe.blacklist=nouveau nouveau.modeset=0\" # remove-before-flight' >> /target/etc/default/grub"
     - "curtin in-target --target=/target -- update-grub"
 
-    # Copy /cdrom/ssh-config to /target/etc/ssh, if it exists
-    - "! [ -d /cdrom/ssh-config ] || (mkdir -p /target/etc/ssh && cp -r /cdrom/ssh-config/* /target/etc/ssh)"
-
   shutdown: reboot
 
   user-data:


### PR DESCRIPTION
## Description
This disables the copy of `/etc/ssh/authorized_keys `file to DUT after provisioning. It means that only TF agents keys are copied after provisioning, but all the other users need to login with user/password or use TF reserve function.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
n/a
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
n/a
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
This change was tested in hot lab with user-data file. After provisioning, only agent's keys are added and` /etc/ssh/authorized_keys` doesn't exist.
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
