### PR TITLE
[CERTTF-550] Support private-endpoint runners in `submit` action

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -34,6 +34,8 @@ runs:
   steps:
     - name: Bypass aproxy (for private-endpoint runners)
       if: startsWith(runner.name, 'private-')
+      env:
+        SERVER: ${{ inputs.server }}
       shell: bash
       run: |
         echo "::group::Bypass aproxy (private-endpoint runner)"
@@ -41,7 +43,7 @@ runs:
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -qqy dnsutils
         sudo snap set aproxy listen=:28443
         sudo nft -f - << EOF
-        define testflinger-ips = { $(dig +short testflinger.canonical.com | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | tr '\n' ',') }
+        define testflinger-ips = { $(dig +short $SERVER | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | tr '\n' ',') }
         define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
         define exclude-ips = { 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16, \$testflinger-ips }
         table ip aproxy

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -39,10 +39,9 @@ runs:
       shell: bash
       run: |
         echo "::group::Bypass aproxy (private-endpoint runner)"
-        sudo apt-get -qq update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -qqy dnsutils
         sudo snap set aproxy listen=:28443
         sudo nft -f - << EOF
-        define testflinger-ips = { $(dig +short $SERVER | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | tr '\n' ',') }
+        define testflinger-ips = { $(getent ahostsv4 $SERVER | awk '/RAW/ {print $1}' | paste -sd,) }
         define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
         define exclude-ips = { 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16, \$testflinger-ips }
         table ip aproxy
@@ -58,6 +57,7 @@ runs:
           }
         }
         EOF
+        echo Bypass complete
         echo "::endgroup::"
 
     - name: Test connection to Testflinger server

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -36,6 +36,7 @@ runs:
       if: startsWith(runner.name, 'private-')
       shell: bash
       run: |
+        export DEBIAN_FRONTEND=noninteractive 
         sudo apt-get -qqy update && sudo apt-get install -qqy dnsutils
         sudo snap set aproxy listen=:28443
         sudo nft -f - << EOF

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -39,26 +39,12 @@ runs:
       shell: bash
       run: |
         echo "::group::Bypass aproxy (private-endpoint runner)"
-        sudo snap set aproxy listen=:28443
-        sudo nft -f - << EOF
-        define testflinger-ips = { $(getent ahostsv4 $SERVER | awk '/RAW/ {print $1}' | paste -sd,) }
-        define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
-        define exclude-ips = { 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16, \$testflinger-ips }
-        delete chain ip aproxy prerouting
-        delete chain ip aproxy output
-        table ip aproxy {
-          chain prerouting {
-            type nat hook prerouting priority dstnat; policy accept;
-            ct state established,related accept
-            ip daddr != \$exclude-ips tcp dport { 80, 443 } counter dnat to \$default-ip:28443
-          }
-          chain output {
-            type nat hook output priority -100; policy accept;
-            ct state established,related accept
-            ip daddr != \$exclude-ips tcp dport { 80, 443 } counter dnat to \$default-ip:28443
-          }
-        }
-        EOF
+        TESTFLINGER_IPS=$(getent ahostsv4 $SERVER | awk '/RAW/ {print $1}' | paste -sd,)
+        sudo nft list table ip aproxy > aproxy.table
+        sudo nft flush table ip aproxy
+        cat aproxy.table | \
+          sed 's/ip daddr != { \([^}]*\) }/ip daddr != { \1, '$TESTFLINGER_IPS' }/g' | \
+          sudo nft -f -
         echo Bypass complete
         echo "::endgroup::"
 

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -44,15 +44,17 @@ runs:
         define testflinger-ips = { $(getent ahostsv4 $SERVER | awk '/RAW/ {print $1}' | paste -sd,) }
         define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
         define exclude-ips = { 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16, \$testflinger-ips }
-        table ip aproxy
-        flush table ip aproxy
+        delete chain ip aproxy prerouting
+        delete chain ip aproxy output
         table ip aproxy {
           chain prerouting {
             type nat hook prerouting priority dstnat; policy accept;
+            ct state established,related accept
             ip daddr != \$exclude-ips tcp dport { 80, 443 } counter dnat to \$default-ip:28443
           }
           chain output {
             type nat hook output priority -100; policy accept;
+            ct state established,related accept
             ip daddr != \$exclude-ips tcp dport { 80, 443 } counter dnat to \$default-ip:28443
           }
         }

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -32,13 +32,11 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Labels
-      env:
-        LABELS: ${{ toJSON(runner) }}
+    - name: Bypass aproxy (for private-endpoint runners)
+      if: startsWith(runner.name, 'private-')
       shell: bash
       run: |
-        echo $LABELS
-        sudo apt install dnsutils
+        sudo apt-get -qqy update && sudo apt-get install -qqy dnsutils
         sudo snap set aproxy listen=:28443
         sudo nft -f - << EOF
         define testflinger-ips = { $(dig +short testflinger.canonical.com | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | tr '\n' ',') }

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -36,8 +36,9 @@ runs:
       if: startsWith(runner.name, 'private-')
       shell: bash
       run: |
-        export DEBIAN_FRONTEND=noninteractive 
-        sudo apt-get -qqy update && sudo apt-get install -qqy dnsutils
+        echo "::group::Bypass aproxy (private-endpoint runner)"
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy update && \
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -qqy dnsutils
         sudo snap set aproxy listen=:28443
         sudo nft -f - << EOF
         define testflinger-ips = { $(dig +short testflinger.canonical.com | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | tr '\n' ',') }
@@ -56,6 +57,8 @@ runs:
           }
         }
         EOF
+        echo "::endgroup::"
+
     - name: Test connection to Testflinger server
       shell: bash {0}  # allow curl to fail
       env:

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -32,6 +32,13 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Labels
+      env:
+        LABELS: ${{ toJSON(runner) }}
+      shell: bash
+      run:
+        echo $LABELS
+
     - name: Test connection to Testflinger server
       shell: bash {0}  # allow curl to fail
       env:

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -39,13 +39,26 @@ runs:
       shell: bash
       run: |
         echo "::group::Bypass aproxy (private-endpoint runner)"
+        APROXY_IP=$(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
+        APROXY_PORT=$(sudo snap get aproxy listen)
+        APROXY=$APROXY_IP$APROXY_PORT
         TESTFLINGER_IPS=$(getent ahostsv4 $SERVER | awk '/RAW/ {print $1}' | paste -sd,)
-        sudo nft list table ip aproxy > aproxy.table
-        sudo nft flush table ip aproxy
-        cat aproxy.table | \
-          sed 's/ip daddr != { \([^}]*\) }/ip daddr != { \1, '$TESTFLINGER_IPS' }/g' | \
-          sudo nft -f -
+        PRIVATE_IPS=10.0.0.0/8,127.0.0.1/8,172.16.0.0/12,192.168.0.0/16,$TESTFLINGER_IPS
+        sudo nft -f - << EOF
+        flush table ip aproxy
+        table ip aproxy {
+          chain prerouting {
+            type nat hook prerouting priority dstnat; policy accept;
+            ip daddr != { $PRIVATE_IPS } tcp dport { 80, 443 } counter dnat to $APROXY
+          }
+          chain output {
+            type nat hook output priority -100; policy accept;
+            ip daddr != { $PRIVATE_IPS } tcp dport { 80, 443 } counter dnat to $APROXY
+          }
+        }
+        EOF
         echo Bypass complete
+        sudo nft list table ip aproxy
         echo "::endgroup::"
 
     - name: Test connection to Testflinger server

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -39,8 +39,7 @@ runs:
       shell: bash
       run: |
         echo "::group::Bypass aproxy (private-endpoint runner)"
-        sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy update && \
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -qqy dnsutils
+        sudo apt-get -qq update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -qqy dnsutils
         sudo snap set aproxy listen=:28443
         sudo nft -f - << EOF
         define testflinger-ips = { $(dig +short $SERVER | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | tr '\n' ',') }

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -36,9 +36,27 @@ runs:
       env:
         LABELS: ${{ toJSON(runner) }}
       shell: bash
-      run:
+      run: |
         echo $LABELS
-
+        sudo apt install dnsutils
+        sudo snap set aproxy listen=:28443
+        sudo nft -f - << EOF
+        define testflinger-ips = { $(dig +short testflinger.canonical.com | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' | tr '\n' ',') }
+        define default-ip = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
+        define exclude-ips = { 10.0.0.0/8, 127.0.0.1/8, 172.16.0.0/12, 192.168.0.0/16, \$testflinger-ips }
+        table ip aproxy
+        flush table ip aproxy
+        table ip aproxy {
+          chain prerouting {
+            type nat hook prerouting priority dstnat; policy accept;
+            ip daddr != \$exclude-ips tcp dport { 80, 443 } counter dnat to \$default-ip:28443
+          }
+          chain output {
+            type nat hook output priority -100; policy accept;
+            ip daddr != \$exclude-ips tcp dport { 80, 443 } counter dnat to \$default-ip:28443
+          }
+        }
+        EOF
     - name: Test connection to Testflinger server
       shell: bash {0}  # allow curl to fail
       env:


### PR DESCRIPTION
## Description

Github workflows that use the Testflinger `submit` action need to use runners that are able to access the Testflinger server. In order to be able to achieve that in private-endpoint runners, a [workaround](https://chat.canonical.com/canonical/pl/uf7yxdxphinqzmfnwu1eyn158o) to bypass `aproxy` is required.

This PR incorporates the workaround in a new step of the `submit` action. The step is optional; it is only performed when a private-endpoint runner is used. The simplest way to detect that currently is to check that the runner name begins with `private`. 

## Resolved issues

Partly resolves [CERTTF-550](https://warthogs.atlassian.net/browse/CERTTF-550). The original issue is about documenting how to use private-endpoint runners but this PR precedes it as it facilitates their usage (it performs the workaround so that the user doesn't have to).

## Documentation

The documentation for the `submit` action does not need to change. A follow-up PR will extend the documentation available
in the `certification-ops` repo on how to use Testflinger in Github CI workflows.

## Tests

A simple test workflow that uses the `submit` action was created on a branch of the `certification-lab-ci` repo, where Testflinger-enabled runners are available. The runners that are used for running this workflow are controlled through an input parameter. 
```
name: Test submission through private-endpoint runner
run-name: Test submission on runner ${{ inputs.runs-on }}
on:
  workflow_dispatch:
    inputs:
      runs-on:
        type: string
      queue:
        type: string
      dry-run:
        type: boolean
        required: false
        default: true
      server:
        type: string
        required: false
        default: testflinger.canonical.com

jobs:
  generate-submit-job:
    runs-on: ${{ fromJSON(inputs.runs-on) }}
    steps:
    - name: Submit job to Testflinger
      id: submit
      uses: canonical/testflinger/.github/actions/submit@CERTTF-550-support-private-endpoint-submit
      with:
        poll: true
        dry-run: false
        server: ${{ inputs.server }}
        job: |
          job_queue: ${{ inputs.queue }}
          test_data:
            test_cmds:
              echo "Hello world"
```

The sections below describe the different ways that the workflow was triggered, in order to test the `submit` action.

### Testflinger-enabled runner

```
gh workflow run test-private-endpoint-submit.yaml \
--ref CERTTF-550-test-private-endpoint-submit \
--field runs-on='["self-hosted","testflinger"]' \
--field queue=rpi3 \
--field dry-run=false
```

The [log](https://github.com/canonical/certification-lab-ci/actions/runs/15184728765/job/42702357789) shows that the workflow was executed on `gh-runner-certification-lab-ci-...` (a Testflinger-enabled runner deployed specifically for the `certification-lab-ci` repo) and the Testflinger job was submitted successfully _without_ applying the workaround, as expected.

### Private-endpoint runner

```
gh workflow run test-private-endpoint-submit.yaml \
--ref CERTTF-550-test-private-endpoint-submit \
--field runs-on='["self-hosted-linux-amd64-jammy-private-endpoint-medium"]' \
--field queue=rpi3 \
--field dry-run=false
```

The [log](https://github.com/canonical/certification-lab-ci/actions/runs/15184797536/job/42702592367) shows that the workflow was executed on `private-openstack-amd64-jammy-medium-ps6-...` (a Canonical-hosted private-endpoint runner) and the Testflinger job was submitted successfully after applying the workaround.

Similarly for the Testflinger staging server:

```
gh workflow run test-private-endpoint-submit.yaml \
--ref CERTTF-550-test-private-endpoint-submit \
--field runs-on='["self-hosted-linux-amd64-jammy-private-endpoint-medium"]' \
--field server=testflinger-staging.canonical.com \
--field queue=audino \
--field dry-run=false
```
Here is the corresponding [log](https://github.com/canonical/certification-lab-ci/actions/runs/15184825462/job/42702685657).

### "Regular" self-hosted runner

```
gh workflow run test-private-endpoint-submit.yaml \
--ref CERTTF-550-test-private-endpoint-submit \
--field runs-on='["self-hosted","medium","amd64"]' \
--field queue=rpi3 \
--field dry-run=false
```

The [log](https://github.com/canonical/certification-lab-ci/actions/runs/15159871327/job/42623303683) shows that the workflow was executed on a Canonical-hosted runner that doesn't have network access to the Testflinger server and the `submit` action failed at the point where the access to the Testflinger server is checked.

[CERTTF-550]: https://warthogs.atlassian.net/browse/CERTTF-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ