### PR TITLE
Feat(cli) Add --json parameter to submit command.

### DIFF
--- a/cli/testflinger_cli/tests/test_cli.py
+++ b/cli/testflinger_cli/tests/test_cli.py
@@ -133,6 +133,25 @@ def test_submit_bad_data(tmp_path, requests_mock):
     )
 
 
+def test_submit_with_json_paramater(capsys, tmp_path, requests_mock):
+    """Make sure jobid is read back from submitted job."""
+    jobid = str(uuid.uuid1())
+    fake_data = {"job_queue": "fake", "provision_data": {"distro": "fake"}}
+    testfile = tmp_path / "test.json"
+    testfile.write_text(json.dumps(fake_data))
+    fake_return = {"job_id": jobid}
+    requests_mock.post(URL + "/v1/job", json=fake_return)
+    requests_mock.get(
+        URL + "/v1/queues/fake/agents",
+        json=[{"name": "fake_agent", "state": "waiting"}],
+    )
+    sys.argv = ["", "submit", "--json", str(testfile)]
+    tfcli = testflinger_cli.TestflingerCli()
+    with pytest.raises(SystemExit) as err:
+        tfcli.submit()
+    assert err.value.code == 1
+
+
 def test_pack_attachments(tmp_path):
     """Make sure attachments are packed correctly."""
     attachments = [


### PR DESCRIPTION
## Description

New `--json` parameter for reservation jobs. Instead of polling job status externally, polling happens in testflinger-cli and prints JSON output without blocking the process when machine is deployed.

## Tests

```
# testflinger submit --json testflinger-racah.yaml | jq .
ca38a7b1-cb12-4a27-9f68-71dce13f2cf4
Job state changed: unknown -> waiting
Job state changed: waiting -> setup
Job state changed: setup -> provision
Job state changed: provision -> reserve
Found IP: 10.241.2.26
{
  "rc": 0,
  "job_id": "ca38a7b1-cb12-4a27-9f68-71dce13f2cf4",
  "ip": "10.241.2.26",
  "job_state": "reserve"
}

# testflinger submit --json testflinger-geminus.yaml | jq .
7d6e0b8d-d442-4d19-948c-9e1ce68a2285
Job state changed: unknown -> waiting
Job state changed: waiting -> provision
Job state changed: provision -> complete
{
  "rc": 1,
  "job_id": "7d6e0b8d-d442-4d19-948c-9e1ce68a2285",
  "ip": "",
  "job_state": "complete"
}

```

