### PR TITLE
feat(cli): Extract parts from __init__ to helpers and consts

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -851,7 +851,7 @@ class TestflingerCli:
             timestamp = datetime.fromtimestamp(
                 jobdata.get("submission_time"), tz=timezone.utc
             )
-            queue = jobdata.get("queue")
+            queue = jobdata["queue"]
             print(f"{job_id} {job_state:9} {timestamp:%a %b %d %H:%M} {queue}")
         print()
 

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -57,21 +57,14 @@ def cli():
     """Generate the TestflingerCli instance and run it."""
     try:
         tfcli = TestflingerCli()
-        configure_logging()
+        logging.basicConfig(
+            level=logging.WARNING,
+            format=consts.LOG_FORMAT,
+            datefmt=consts.LOG_DATE_FORMAT,
+        )
         tfcli.run()
     except KeyboardInterrupt:
         sys.exit("Received KeyboardInterrupt")
-
-
-def configure_logging():
-    """Configure default logging."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format=(
-            "%(levelname)s: %(asctime)s %(filename)s:%(lineno)d -- %(message)s"
-        ),
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
 
 
 class TestflingerCli:

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -56,13 +56,13 @@ if os.path.exists(os.path.join(basedir, "setup.py")):
 
 def cli():
     """Generate the TestflingerCli instance and run it."""
+    tfcli = TestflingerCli()
+    logging.basicConfig(
+        level=logging.WARNING,
+        format=consts.LOG_FORMAT,
+        datefmt=consts.LOG_DATE_FORMAT,
+    )
     try:
-        tfcli = TestflingerCli()
-        logging.basicConfig(
-            level=logging.WARNING,
-            format=consts.LOG_FORMAT,
-            datefmt=consts.LOG_DATE_FORMAT,
-        )
         tfcli.run()
     except KeyboardInterrupt:
         sys.exit("Received KeyboardInterrupt")

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -103,7 +103,7 @@ class TestflingerCli:
         if not server.startswith(("http://", "https://")):
             sys.exit(
                 'Server must start with "http://" or "https://" '
-                '- currently set to: "{}"'.format(server)
+                f'- currently set to: "{server}"'
             )
         self.client = client.Client(server, error_threshold=error_threshold)
 
@@ -371,14 +371,12 @@ class TestflingerCli:
                 self.config.set(*setting)
                 return
             if len(setting) == 1:
-                print(
-                    "{} = {}".format(setting[0], self.config.get(setting[0]))
-                )
+                print(f"{setting[0]} = {self.config.get(setting[0])}")
                 return
         print("Current Configuration")
         print("---------------------")
         for k, v in self.config.data.items():
-            print("{} = {}".format(k, v))
+            print(f"{k} = {v}")
         print()
 
     @staticmethod
@@ -511,7 +509,7 @@ class TestflingerCli:
             print(job_id)
         else:
             print("Job submitted successfully!")
-            print("job_id: {}".format(job_id))
+            print(f"job_id: {job_id}")
         if self.args.poll:
             self.do_poll(job_id)
 
@@ -793,7 +791,7 @@ class TestflingerCli:
                     queue_pos = self.client.get_job_position(job_id)
                     if int(queue_pos) != prev_queue_pos:
                         prev_queue_pos = int(queue_pos)
-                        print("Jobs ahead in queue: {}".format(queue_pos))
+                        print(f"Jobs ahead in queue: {queue_pos}")
                 time.sleep(10)
                 output = ""
                 output = self.get_latest_output(job_id)
@@ -805,8 +803,8 @@ class TestflingerCli:
                     logger.exception("Error polling for job output")
             except KeyboardInterrupt:
                 choice = input(
-                    "\nCancel job {} before exiting "
-                    "(y)es/(N)o/(c)ontinue? ".format(job_id)
+                    f"\nCancel job {job_id} before exiting "
+                    "(y)es/(N)o/(c)ontinue? "
                 )
                 if choice:
                     choice = choice[0].lower()
@@ -840,11 +838,7 @@ class TestflingerCli:
         """List the previously started test jobs."""
         # Getting job state may be slow, only include if requested
         status_text = "Status" if self.args.status else ""
-        print(
-            "{:36} {:9} {}  {}".format(
-                "Job ID", status_text, "Submission Time", "Queue"
-            )
-        )
+        print(f"{'Job ID':36} {status_text:9} Submission Time  Queue")
         print("-" * 79)
         for job_id, jobdata in self.history.history.items():
             if self.args.status:
@@ -854,16 +848,11 @@ class TestflingerCli:
                     self.history.update(job_id, job_state)
             else:
                 job_state = ""
-            print(
-                "{} {:9} {} {}".format(
-                    job_id,
-                    job_state,
-                    datetime.fromtimestamp(
-                        jobdata.get("submission_time"), tz=timezone.utc
-                    ).strftime("%a %b %d %H:%M"),
-                    jobdata.get("queue"),
-                )
+            timestamp = datetime.fromtimestamp(
+                jobdata.get("submission_time"), tz=timezone.utc
             )
+            queue = jobdata.get("queue")
+            print(f"{job_id} {job_state:9} {timestamp:%a %b %d %H:%M} {queue}")
         print()
 
     def list_queues(self):
@@ -884,7 +873,7 @@ class TestflingerCli:
         else:
             print("Advertised queues on this server:")
             for name, description in sorted(queues.items()):
-                print(" {} - {}".format(name, description))
+                print(f" {name} - {description}")
 
     def reserve(self):
         """Install and reserve a system."""
@@ -929,7 +918,7 @@ class TestflingerCli:
                                         ssh_keys:"""
         )
         for ssh_key in ssh_keys:
-            template += "\n      - {}".format(ssh_key)
+            template += f"\n      - {ssh_key}"
         job_data = template.format(queue=queue, image=image)
         print("\nThe following yaml will be submitted:")
         print(job_data)
@@ -939,7 +928,7 @@ class TestflingerCli:
         if answer in ("Y", "y", ""):
             job_id = self.submit_job_data(job_data)
             print("Job submitted successfully!")
-            print("job_id: {}".format(job_id))
+            print(f"job_id: {job_id}")
             self.do_poll(job_id)
 
     def get_latest_output(self, job_id):

--- a/cli/testflinger_cli/autocomplete.py
+++ b/cli/testflinger_cli/autocomplete.py
@@ -27,7 +27,7 @@ def job_ids_completer(
     **kwargs,
 ):
     """Completer for job identifiers."""
-    for job_id in history.history.keys():
+    for job_id in history.history:
         if not job_id.startswith(prefix):
             continue
         yield job_id

--- a/cli/testflinger_cli/consts.py
+++ b/cli/testflinger_cli/consts.py
@@ -6,6 +6,11 @@ SNAP_PRIVATE_DIRS = [
     "/tmp",  # noqa: S108
 ]
 
+LOG_FORMAT = (
+    "%(levelname)s: %(asctime)s %(filename)s:%(lineno)d -- %(message)s"
+)
+LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
 TESTFLINGER_SERVER = "https://testflinger.canonical.com"
 TESTFLINGER_ERROR_THRESHOLD = 3
 

--- a/cli/testflinger_cli/consts.py
+++ b/cli/testflinger_cli/consts.py
@@ -5,3 +5,12 @@ SNAP_NAME = "testflinger-cli"
 SNAP_PRIVATE_DIRS = [
     "/tmp",  # noqa: S108
 ]
+
+TESTFLINGER_SERVER = "https://testflinger.canonical.com"
+TESTFLINGER_ERROR_THRESHOLD = 3
+
+ADVERTISED_QUEUES_MESSAGE = (
+    "ATTENTION: This only shows a curated list of queues with "
+    "descriptions, not ALL queues. If you can't find the queue you want "
+    "to use, a job can still be submitted for queues not listed here.\n"
+)

--- a/cli/testflinger_cli/consts.py
+++ b/cli/testflinger_cli/consts.py
@@ -13,9 +13,3 @@ LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 TESTFLINGER_SERVER = "https://testflinger.canonical.com"
 TESTFLINGER_ERROR_THRESHOLD = 3
-
-ADVERTISED_QUEUES_MESSAGE = (
-    "ATTENTION: This only shows a curated list of queues with "
-    "descriptions, not ALL queues. If you can't find the queue you want "
-    "to use, a job can still be submitted for queues not listed here.\n"
-)

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -94,11 +94,10 @@ def prompt_for_ssh_keys() -> list[str]:
 
     :return: A list of SSH keys in the form of gh:user or lp:user.
     """
+    input_msg = "\nEnter the key(s) you wish to use (ex: 'lp:user,gh:user'): "
     ssh_keys: list[str] = []
     while not ssh_keys:
-        keys = input(
-            "\nEnter the SSH key(s) you wish to use (ex: 'lp:user, gh:user'): "
-        ).strip()
+        keys = input(input_msg).strip()
         if not keys:
             continue
         ssh_keys = [key.strip() for key in keys.split(",")]
@@ -114,11 +113,10 @@ def prompt_for_queue(queues: dict[str, str]) -> str:
     :param queues: A mapping of queue name to descripton to choose from.
     :return: The selected queue.
     """
+    input_msg = "\nEnter the queue you wish to use ('?' to list): "
     queue = ""
     while not queue:
-        queue = input(
-            "\nEnter the queue you wish to use ('?' to list): "
-        ).strip()
+        queue = input(input_msg).strip()
         if not queue:
             continue
         if queue == "?":

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -73,7 +73,7 @@ def prompt_for_image(images: dict[str, str]) -> str:
                 print(
                     "WARNING: No images defined for this device. You may also "
                     "provide the URL to an image that can be booted with this "
-                    "deivce though."
+                    "device though."
                 )
             else:
                 print("\n".join(sorted(images)))

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -102,13 +102,9 @@ def prompt_for_ssh_keys() -> list[str]:
         if not keys:
             continue
         ssh_keys = [key.strip() for key in keys.split(",")]
-        for key in ssh_keys:
-            if not key.startswith(("gh:", "lp:")):
-                print(
-                    "Please enter keys in the form of 'gh:user' or 'lp:user'."
-                )
-                ssh_keys = []
-                break
+        if not all(key.startswith(("gh:", "lp:")) for key in ssh_keys):
+            print("Please enter keys in the form of 'gh:user' or 'lp:user'.")
+            ssh_keys = []
     return ssh_keys
 
 

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -66,7 +66,7 @@ def prompt_for_image(images: list[dict[str, str]]) -> str:
     image = ""
     while not image:
         image = input(
-            f"\nEnter the name of the image you want to use {flex_url} ('?' to list): "
+            f"\nEnter the image you wish to use {flex_url} ('?' to list): "
         ).strip()
         if not image:
             continue
@@ -123,7 +123,7 @@ def prompt_for_queue(queues: list[dict[str, str]]) -> str:
     queue = ""
     while not queue:
         queue = input(
-            "\nEnter the name of the queue you want to use ('?' to list): "
+            "\nEnter the queue you wish to use ('?' to list): "
         ).strip()
         if not queue:
             continue

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -60,7 +60,7 @@ def prompt_for_image(images: dict[str, str]) -> str:
     :return: The selected image.
     """
     input_msg = "\nEnter the image you wish to use"
-    if images and images[list(images)[0]].startswith("url:"):
+    if images and any(value.startswith("url:") for value in images.values()):
         input_msg += " or a URL for a valid image, starting with http(s)://"
     input_msg += " ('?' to list): "
     image = ""

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -51,3 +51,90 @@ def parse_filename(
     ):
         raise SnapPrivateFileError(path)
     return path
+
+
+def prompt_for_image(images: list[dict[str, str]]) -> str:
+    """Prompt the user to select an image from a list.
+
+    :param images: A list of images to choose from.
+    :return: The selected image.
+    """
+    flex_url = ""
+    if images and images[list(images)[0]].startswith("url:"):
+        flex_url = "or a URL for a valid image, starting with http(s):// "
+
+    image = ""
+    while not image:
+        image = input(
+            f"\nEnter the name of the image you want to use {flex_url} ('?' to list): "
+        ).strip()
+        if not image:
+            continue
+        if image == "?":
+            if not images:
+                print(
+                    "WARNING: No images defined for this device. You may also "
+                    "provide the URL to an image that can be booted with this "
+                    "deivce though."
+                )
+            else:
+                print("\n".join(sorted(images)))
+            image = ""
+        elif image.startswith(("http://", "https://")):
+            return image
+        elif image not in images:
+            print(
+                f"ERROR: '{image}' is not in the list of known images for "
+                "that queue, please select another."
+            )
+            image = ""
+    return image
+
+
+def prompt_for_ssh_keys() -> list[str]:
+    """Prompt the user to select SSH keys.
+
+    :return: A list of SSH keys in the form of gh:user or lp:user.
+    """
+    ssh_keys = []
+    while not ssh_keys:
+        keys = input(
+            "\nEnter the SSH key(s) you wish to use (ex: 'lp:user, gh:user'): "
+        ).strip()
+        if not keys:
+            continue
+        ssh_keys = [key.strip() for key in keys.split(",")]
+        for key in ssh_keys:
+            if not key.startswith(("gh:", "lp:")):
+                print(
+                    "Please enter keys in the form of 'gh:user' or 'lp:user'."
+                )
+                ssh_keys = []
+                break
+    return ssh_keys
+
+
+def prompt_for_queue(queues: list[dict[str, str]]) -> str:
+    """Prompt the user to select a queue from a list.
+
+    :param queues: A list of queues to choose from.
+    :return: The selected queue.
+    """
+    queue = ""
+    while not queue:
+        queue = input(
+            "\nEnter the name of the queue you want to use ('?' to list): "
+        ).strip()
+        if not queue:
+            continue
+        if queue == "?":
+            print("\nAdvertised queues on this server:")
+            for name, description in queues.items():
+                print(f" {name} - {description}")
+            queue = ""
+        elif queue not in queues:
+            print(f"WARNING: '{queue}' is not in the list of known queues")
+            answer = input("Do you still want to use it? (y/N) ").strip()
+            if answer.lower() != "y":
+                queue = ""
+    return queue

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -53,10 +53,10 @@ def parse_filename(
     return path
 
 
-def prompt_for_image(images: list[dict[str, str]]) -> str:
+def prompt_for_image(images: dict[str, str]) -> str:
     """Prompt the user to select an image from a list.
 
-    :param images: A list of images to choose from.
+    :param images: A mapping of image name to image job line to choose from.
     :return: The selected image.
     """
     flex_url = ""
@@ -96,7 +96,7 @@ def prompt_for_ssh_keys() -> list[str]:
 
     :return: A list of SSH keys in the form of gh:user or lp:user.
     """
-    ssh_keys = []
+    ssh_keys: list[str] = []
     while not ssh_keys:
         keys = input(
             "\nEnter the SSH key(s) you wish to use (ex: 'lp:user, gh:user'): "
@@ -114,10 +114,10 @@ def prompt_for_ssh_keys() -> list[str]:
     return ssh_keys
 
 
-def prompt_for_queue(queues: list[dict[str, str]]) -> str:
+def prompt_for_queue(queues: dict[str, str]) -> str:
     """Prompt the user to select a queue from a list.
 
-    :param queues: A list of queues to choose from.
+    :param queues: A mapping of queue name to descripton to choose from.
     :return: The selected queue.
     """
     queue = ""

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -59,15 +59,13 @@ def prompt_for_image(images: dict[str, str]) -> str:
     :param images: A mapping of image name to image job line to choose from.
     :return: The selected image.
     """
-    flex_url = ""
+    input_msg = "\nEnter the image you wish to use"
     if images and images[list(images)[0]].startswith("url:"):
-        flex_url = "or a URL for a valid image, starting with http(s):// "
-
+        input_msg += " or a URL for a valid image, starting with http(s)://"
+    input_msg += " ('?' to list): "
     image = ""
     while not image:
-        image = input(
-            f"\nEnter the image you wish to use {flex_url} ('?' to list): "
-        ).strip()
+        image = input(input_msg).strip()
         if not image:
             continue
         if image == "?":

--- a/cli/testflinger_cli/tests/test_cli.py
+++ b/cli/testflinger_cli/tests/test_cli.py
@@ -23,6 +23,7 @@ import re
 import sys
 import tarfile
 import uuid
+from http import HTTPStatus
 from pathlib import Path
 
 import pytest
@@ -591,11 +592,12 @@ def test_list_queues(capsys, requests_mock):
 
 def test_list_queues_connection_error(caplog, requests_mock):
     """list_queues should report queues."""
-    requests_mock.get(URL + "/v1/agents/queues", status_code=400)
+    requests_mock.get(
+        URL + "/v1/agents/queues", status_code=HTTPStatus.NOT_FOUND
+    )
     sys.argv = ["", "list-queues"]
     tfcli = testflinger_cli.TestflingerCli()
-    with pytest.raises(SystemExit):
-        tfcli.list_queues()
+    tfcli.list_queues()
     assert "Unable to get a list of queues from the server." in caplog.text
 
 


### PR DESCRIPTION
## Description

#668 introduced `helpers.py` and `consts.py`. This PR moves more elements out of the bloated `__init__.py` into these modules.

This PR also simplifies some code by:

- using the ternary operator
- using `contextlib.suppress` where we just ignore an error
- using f-strings in more places
- using `x in dictionary` instead of `x in dictionary.keys()`

## Resolved issues

## Documentation

## Web service API changes

## Tests

