### PR TITLE
feat(server): Add endpoint to retrieve all the jobs assigned to a queue.

### DIFF
--- a/server/API.md
+++ b/server/API.md
@@ -370,6 +370,31 @@ Example:
 curl http://localhost:8000/v1/queues/foo/agents
 ```
 
+## `[GET] /v1/queues/<queue_name>/jobs`
+
+Search for jobs in a specified queue. 
+
+Parameters:
+
+`queue_name` (string): queue name(s) where to get the jobs. 
+
+Status Codes:
+
+- `HTTP 200 (OK)`
+- `HTTP 204 (NO DATA)`: if there are no jobs in the specified queue. 
+
+Returns:
+
+JSON job data with information about the ID, creation time and state for jobs in the specified queue. 
+
+Example:
+
+```shell
+curl 'http://localhost:8000/v1/queues/foo/jobs'
+```
+
+This will find jobs in the queue `foo` and return its IDs, creation time and state. 
+
 ## `[POST] /v1/oauth2/token`
 
 Authenticate client key and return JWT with permissions

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -839,6 +839,7 @@ def get_agents_on_queue(queue_name):
 @v1.get("/queues/<queue_name>/jobs")
 def get_jobs_by_queue(queue_name):
     """Get the jobs in a specified queue along with its state.
+
     :param queue_name
         String with the queue name where to perform the query.
     :return:
@@ -859,7 +860,6 @@ def get_jobs_by_queue(queue_name):
             }
             for job in jobs
         ]
-
     except KeyError:
         abort(
             HTTPStatus.INTERNAL_SERVER_ERROR,

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -19,6 +19,7 @@ import importlib.metadata
 import os
 import uuid
 from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
 
 import bcrypt
 import jwt
@@ -833,6 +834,39 @@ def queue_wait_time_percentiles_get():
 def get_agents_on_queue(queue_name):
     """Get the list of all data for agents listening to a specified queue."""
     return database.get_agents_on_queue(queue_name)
+
+
+@v1.get("/queues/<queue_name>/jobs")
+def get_jobs_by_queue(queue_name):
+    """Get the jobs in a specified queue along with its state.
+    :param queue_name
+        String with the queue name where to perform the query.
+    :return:
+        JSON data with the jobs allocated to the specified queue.
+    """
+    jobs = database.get_jobs_on_queue(queue_name)
+
+    if not jobs:
+        return {}, HTTPStatus.NO_CONTENT
+
+    try:
+        jobs_in_queue = [
+            {
+                "job_id": job["job_id"],
+                "created_at": job["created_at"],
+                "job_state": job["result_data"]["job_state"],
+                "job_queue": job["job_data"]["job_queue"],
+            }
+            for job in jobs
+        ]
+
+    except KeyError:
+        abort(
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            message="Unable to retrieve information about specified queue.",
+        )
+
+    return jsonify(jobs_in_queue)
 
 
 def generate_token(allowed_resources, secret_key):

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -256,6 +256,12 @@ def get_agents_on_queue(queue: str) -> list[dict]:
     return list(agents)
 
 
+def get_jobs_on_queue(queue: str) -> list[dict]:
+    """Get the jobs that are assigned on a specific queue."""
+    jobs = mongo.db.jobs.find({"job_data.job_queue": queue})
+    return list(jobs)
+
+
 def calculate_percentiles(data: list) -> dict:
     """
     Calculate the percentiles of the wait times for each queue.

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -1132,9 +1132,9 @@ def test_get_jobs_on_queue(mongo_app):
 
     # Validate the number of jobs on the queue is accurate
     output = app.get("/v1/queues/test/jobs")
-    assert 200 == output.status_code
+    assert output.status_code == HTTPStatus.OK
     assert len(output.json) == 2
 
     # Confirm  the status code returned if there are no jobs in queue
     output = app.get("/v1/queues/test2/jobs")
-    assert 204 == output.status_code
+    assert output.status_code == HTTPStatus.NO_CONTENT


### PR DESCRIPTION
## Description
This is a spinoff PR based on #680 this way we can focus on review on that PR for CLI changes while this PR can help to review the changes introduced to the API in the server. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-634](https://warthogs.atlassian.net/browse/CERTTF-634)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
New endpoint was added to be able to retrieve the amount of jobs that are available in queue.

This endpoint `/queues/<queue_name>/jobs` will return a JSON with all the jobs assigned to a queue. 

```
curl http://localhost:5000/v1/queues/test_queue7/jobs | jq
[
  {
    "job_id": "6625cafa-c81b-446a-884f-bb0477934a5e",
    "created_at": {
      "$date": "2025-05-21T15:03:47.361Z"
    },
    "job_state": "waiting",
    "job_queue": "test_queue7"
  }
]
```

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-634]: https://warthogs.atlassian.net/browse/CERTTF-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ