### PR TITLE
feat(cli): Add JSON output option to list-queues command

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -263,10 +263,9 @@ class TestflingerCli:
         )
         parser.set_defaults(func=self.list_queues)
         parser.add_argument(
-            "--output",
-            choices=["json", "text"],
-            default="text",
-            help="Specify the output format (text or json)"
+            "--json",
+            action="store_true",
+            help="Print output in JSON format"
         )
 
     def _add_poll_args(self, subparsers):
@@ -951,9 +950,8 @@ class TestflingerCli:
                 )
             logger.error("Unable to get a list of queues from the server.")
             sys.exit(1)
-        output_format = self.args.output
-        if output_format == "json":
-            print(json.dumps(queues, sort_keys=True, indent=4))
+        if self.args.json:
+            print(json.dumps(queues))
         else:
             print("Advertised queues on this server:")
             for name, description in sorted(queues.items()):

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -262,6 +262,12 @@ class TestflingerCli:
             help="List the advertised queues on the Testflinger server",
         )
         parser.set_defaults(func=self.list_queues)
+        parser.add_argument(
+            "--output",
+            choices=["json", "text"],
+            default="text",
+            help="Specify the output format (text or json)"
+        )
 
     def _add_poll_args(self, subparsers):
         """Command line arguments for poll."""
@@ -945,9 +951,13 @@ class TestflingerCli:
                 )
             logger.error("Unable to get a list of queues from the server.")
             sys.exit(1)
-        print("Advertised queues on this server:")
-        for name, description in sorted(queues.items()):
-            print(" {} - {}".format(name, description))
+        output_format = self.args.output
+        if output_format == "json":
+            print(json.dumps(queues, sort_keys=True, indent=4))
+        else:
+            print("Advertised queues on this server:")
+            for name, description in sorted(queues.items()):
+                print(" {} - {}".format(name, description))
 
     def reserve(self):
         """Install and reserve a system."""

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -263,9 +263,7 @@ class TestflingerCli:
         )
         parser.set_defaults(func=self.list_queues)
         parser.add_argument(
-            "--json",
-            action="store_true",
-            help="Print output in JSON format"
+            "--json", action="store_true", help="Print output in JSON format"
         )
 
     def _add_poll_args(self, subparsers):


### PR DESCRIPTION
## Description

Added a new `--output` option to the `list-queues` CLI command to support JSON output alongside the default text format. This implements the feature requested in issue #444.

**Note:**  
he API endpoint URL that provides the queue data currently returns a 403 Forbidden response, so full end-to-end testing of this feature was not possible.

## Resolved issues

Closes #444

## Documentation

N/A

## Web service API changes

N/A

## Tests

N/A