### PR TITLE
infra: Update workflows for more testing

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -89,13 +89,14 @@ runs:
       env:
         JOB: ${{ inputs.job }}
         JOB_PATH: ${{ inputs.job-path }}
+        WORKSPACE: ${{ github.workspace }}
       run: |
         echo "::group::Create job file (if required)"
         if [ -n "$JOB_PATH" ]; then
           echo "job=$JOB_PATH" >> "$GITHUB_OUTPUT"
         else
           # write the inline job text to a file
-          FILE=${{ github.workspace }}/tmp_job.yaml
+          FILE=$WORKSPACE/tmp_job.yaml
           printf "%s" "$JOB" > "$FILE"
           if [[ $(cat "$FILE" | wc -w) == 0 ]]; then
             echo 'Neither of the `job` or `job-path` inputs have been specified'

--- a/.github/workflows/agent-host-charm-check-libs.yml
+++ b/.github/workflows/agent-host-charm-check-libs.yml
@@ -3,8 +3,7 @@ permissions:
   contents: read
 on:
   pull_request:
-    branches:
-      - main
+    branches: [main]
     paths:
       - .github/workflows/agent-host-charm-check-libs.yml
       - agent/charms/testflinger-agent-host-charm/**

--- a/.github/workflows/agent-host-charm-release-edge.yml
+++ b/.github/workflows/agent-host-charm-release-edge.yml
@@ -3,8 +3,7 @@ permissions:
   contents: read
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - agent/charms/testflinger-agent-host-charm/**
       - .github/workflows/agent-host-charm-release-edge.yml
@@ -18,7 +17,7 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false

--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -10,7 +10,6 @@ on:
       - agent/**
       - .github/workflows/agent-tox.yml
   pull_request:
-    branches: ["**"]
     paths:
       - common/** # testflinger-agent depends on testflinger-common
       - agent/**

--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -10,7 +10,7 @@ on:
       - agent/**
       - .github/workflows/agent-tox.yml
   pull_request:
-    branches: [main]
+    branches: ["**"]
     paths:
       - common/** # testflinger-agent depends on testflinger-common
       - agent/**
@@ -24,7 +24,8 @@ jobs:
         working-directory: agent
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: Install uv and set up Python
@@ -45,7 +46,8 @@ jobs:
         working-directory: agent
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -3,8 +3,7 @@ permissions:
   contents: read
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - agent/extra/testflinger-testenv/**
       - .github/workflows/build-testflinger-testenv-container.yml
@@ -34,7 +33,7 @@ jobs:
             [registry."docker.io"]
               mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
 
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false

--- a/.github/workflows/charm-promote.yml
+++ b/.github/workflows/charm-promote.yml
@@ -48,7 +48,8 @@ jobs:
             echo "Error: Destination and origin channels cannot be the same."
             exit 1
           fi
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: Promote Charm

--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -1,25 +1,48 @@
-name: Publish Testflinger CLI snap to edge and beta
+name: Publish Testflinger CLI Snap
 permissions:
   contents: read
 on:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - cli/**
+      - .github/workflows/cli-publish-snap.yml
   push:
     branches: ["main"]
     paths:
       - cli/**
+      - .github/workflows/cli-publish-snap.yml
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
+      - name: Build snap
         id: build
+        uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
         with:
           path: cli
-      - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
+      - name: Upload snapcraft logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runtime-build-log
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: testflinger-cli.snap
+          path: ${{ steps.build.outputs.snap }}
+      - name: Publish snap
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:

--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -13,6 +13,12 @@ on:
       - cli/**
       - .github/workflows/cli-publish-snap.yml
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the snap to the store
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -41,7 +47,7 @@ jobs:
           name: testflinger-cli.snap
           path: ${{ steps.build.outputs.snap }}
       - name: Publish snap
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' }}
         uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}

--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -3,7 +3,6 @@ permissions:
   contents: read
 on:
   pull_request:
-    branches: ["**"]
     paths:
       - cli/**
       - .github/workflows/cli-publish-snap.yml

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -9,7 +9,6 @@ on:
       - .github/workflows/cli-tox.yml
       - cli/**
   pull_request:
-    branches: ["**"]
     paths:
       - .github/workflows/cli-tox.yml
       - cli/**

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -6,10 +6,12 @@ on:
   push:
     branches: [main]
     paths:
+      - .github/workflows/cli-tox.yml
       - cli/**
   pull_request:
-    branches: [main]
+    branches: ["**"]
     paths:
+      - .github/workflows/cli-tox.yml
       - cli/**
 
 jobs:
@@ -20,7 +22,8 @@ jobs:
         working-directory: cli
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: Install uv and set the Python version

--- a/.github/workflows/common-tox.yml
+++ b/.github/workflows/common-tox.yml
@@ -9,7 +9,6 @@ on:
       - .github/workflows/common-tox.yml
       - common/**
   pull_request:
-    branches: ["**"]
     paths:
       - .github/workflows/common-tox.yml
       - common/**

--- a/.github/workflows/common-tox.yml
+++ b/.github/workflows/common-tox.yml
@@ -9,7 +9,7 @@ on:
       - .github/workflows/common-tox.yml
       - common/**
   pull_request:
-    branches: [main]
+    branches: ["**"]
     paths:
       - .github/workflows/common-tox.yml
       - common/**
@@ -22,7 +22,8 @@ jobs:
         working-directory: common
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/device-tox.yml
+++ b/.github/workflows/device-tox.yml
@@ -9,7 +9,6 @@ on:
       - .github/workflows/device-tox.yml
       - device-connectors/**
   pull_request:
-    branches: ["**"]
     paths:
       - .github/workflows/device-tox.yml
       - device-connectors/**

--- a/.github/workflows/device-tox.yml
+++ b/.github/workflows/device-tox.yml
@@ -9,7 +9,7 @@ on:
       - .github/workflows/device-tox.yml
       - device-connectors/**
   pull_request:
-    branches: [main]
+    branches: ["**"]
     paths:
       - .github/workflows/device-tox.yml
       - device-connectors/**
@@ -22,7 +22,8 @@ jobs:
         working-directory: device-connectors
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/documentation_checks.yml
+++ b/.github/workflows/documentation_checks.yml
@@ -2,11 +2,16 @@ name: Documentation checks
 permissions:
   contents: read
 on:
-  pull_request:
-    branches:
-      - main
+  push:
+    branches: [main]
     paths:
-      - "docs/**"
+      - .github/workflows/documentation_checks.yml
+      - docs/**
+  pull_request:
+    branches: ["**"]
+    paths:
+      - docs/**
+      - .github/workflows/documentation_checks.yml
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/documentation_checks.yml
+++ b/.github/workflows/documentation_checks.yml
@@ -8,7 +8,6 @@ on:
       - .github/workflows/documentation_checks.yml
       - docs/**
   pull_request:
-    branches: ["**"]
     paths:
       - docs/**
       - .github/workflows/documentation_checks.yml

--- a/.github/workflows/server-charm-check-libs.yml
+++ b/.github/workflows/server-charm-check-libs.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   pull_request:
-    branches:
-      - main
+    branches: ["**"]
     paths:
+      - .github/workflows/server-charm-check-libs.yml
       - server/charm/**
   workflow_dispatch:
 

--- a/.github/workflows/server-charm-check-libs.yml
+++ b/.github/workflows/server-charm-check-libs.yml
@@ -3,7 +3,6 @@ permissions:
   contents: read
 on:
   pull_request:
-    branches: ["**"]
     paths:
       - .github/workflows/server-charm-check-libs.yml
       - server/charm/**

--- a/.github/workflows/server-charm-release-edge.yml
+++ b/.github/workflows/server-charm-release-edge.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
+      - .github/workflows/server-charm-release-edge.yml
       - server/**
   workflow_dispatch:
 
@@ -31,7 +31,7 @@ jobs:
             [registry."docker.io"]
               mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
 
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -9,7 +9,6 @@ on:
       - .github/workflows/server-tox.yml
       - server/**
   pull_request:
-    branches: ["**"]
     paths:
       - .github/workflows/server-tox.yml
       - server/**

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -4,12 +4,14 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [main, try-self-hosted]
-    paths:
-      - server/**
-  pull_request:
     branches: [main]
     paths:
+      - .github/workflows/server-tox.yml
+      - server/**
+  pull_request:
+    branches: ["**"]
+    paths:
+      - .github/workflows/server-tox.yml
       - server/**
 
 jobs:
@@ -20,7 +22,8 @@ jobs:
         working-directory: server
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: Install uv and set up Python
@@ -41,7 +44,8 @@ jobs:
         working-directory: agent
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -9,7 +9,6 @@ on:
       - .github/workflows/*
       - .github/actions/**
   pull_request:
-    branches: ["**"]
     paths:
       - .github/workflows/*
       - .github/actions/**

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -9,7 +9,7 @@ on:
       - .github/workflows/*
       - .github/actions/**
   pull_request:
-    branches: [main]
+    branches: ["**"]
     paths:
       - .github/workflows/*
       - .github/actions/**
@@ -19,10 +19,12 @@ jobs:
     name: Workflow vulnerability scanning
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+      - name: Install uv and set up Python
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
       - name: Run zizmor
         run: uvx zizmor --pedantic .
         env:


### PR DESCRIPTION
## Description

This updates the workflows to do the following:

- Run tests on any PR anywhere
- CLI snap is built and uploaded as artifact on any PR/workflow-dispatch (useful for testing)
  - The snap is not published unless the workflow is run on the `main` branch
- Ensure workflows are run when the workflow file is changed
- Add `name` fields to make the GH logs easier to read

## Resolved issues

## Documentation

## Web service API changes

## Tests
