### PR TITLE
build packages with uv

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -76,6 +76,7 @@ class TestflingerAgentHostCharm(CharmBase):
             [
                 "python3-pip",
                 "python3-virtualenv",
+                "pipx",
                 "docker.io",
                 "git",
                 "openssh-client",
@@ -84,6 +85,7 @@ class TestflingerAgentHostCharm(CharmBase):
                 "supervisor",
             ]
         )
+        run_with_logged_errors(["pipx", "install", "uv"])
 
     def update_testflinger_repo(self, branch=None):
         """Update the testflinger repo."""
@@ -271,6 +273,7 @@ class TestflingerAgentHostCharm(CharmBase):
             )
             return
         self.copy_ssh_keys()
+        self.update_tf_cmd_scripts()
         self.write_supervisor_service_files()
         self.supervisor_update()
         self.restart_agents()

--- a/agent/charms/testflinger-agent-host-charm/src/testflinger_source.py
+++ b/agent/charms/testflinger-agent-host-charm/src/testflinger_source.py
@@ -40,8 +40,11 @@ def clone_repo(
         logger.debug("Installing Python package: %s", directory)
         run_with_logged_errors(
             [
-                f"{VIRTUAL_ENV_PATH}/bin/pip3",
+                "/root/.local/bin/uv",
+                "pip",
                 "install",
+                "--python",
+                f"{VIRTUAL_ENV_PATH}/bin/python3",
                 "-U",
                 f"{local_path}/{directory}",
             ]

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -21,7 +21,7 @@ if [ -d "$VIRTUAL_ENV_PATH" ]; then
         -v /srv/testflinger:/srv/testflinger \
         -v $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id:$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id \
         $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \
-        bash -c "(cd /srv/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json"
+        bash -c "(cd /srv/testflinger/device-connectors && sudo uv pip install . --system &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json"
 else
     docker run -t --name $AGENT \
         -v $PWD:/home/ubuntu \

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -17,6 +17,7 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
+    @patch("charm.TestflingerAgentHostCharm.update_tf_cmd_scripts")
     @patch("os.chown")
     @patch("os.chmod")
     @patch("shutil.move")
@@ -35,6 +36,7 @@ class TestCharm(unittest.TestCase):
         mock_move,
         mock_chmod,
         mock_chown,
+        mock_update_tf_cmd_scripts,
     ):
         """
         Test the copy_ssh_keys method.

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_source.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_source.py
@@ -26,8 +26,11 @@ def test_clone_repo(mock_run_with_logged_errors, mock_clone_from):
     )
     mock_run_with_logged_errors.assert_called_with(
         [
-            f"{VIRTUAL_ENV_PATH}/bin/pip3",
+            "/root/.local/bin/uv",
+            "pip",
             "install",
+            "--python",
+            f"{VIRTUAL_ENV_PATH}/bin/python3",
             "-U",
             f"{LOCAL_TESTFLINGER_PATH}/device-connectors",
         ]

--- a/agent/extra/testflinger-testenv/Dockerfile
+++ b/agent/extra/testflinger-testenv/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ubuntu:20.04
 FROM ${BASE_IMAGE}
 ENV container=docker
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y expect build-essential curl jq gettext git openssh-client pipx python3-dev python3-pip python3-psutil python3-requests python3-setuptools python3-venv software-properties-common sudo sshpass virtualenv wget 
-RUN pip install --upgrade pip
+RUN pipx install uv && ln -s /root/.local/bin/uv /usr/local/bin/uv
 RUN adduser -u 1000 --disabled-password ubuntu || /bin/true
 RUN echo "ubuntu ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu && \
     chmod 0440 /etc/sudoers.d/ubuntu

--- a/agent/extra/testflinger-testenv/Dockerfile
+++ b/agent/extra/testflinger-testenv/Dockerfile
@@ -2,6 +2,7 @@ ARG BASE_IMAGE=ubuntu:20.04
 FROM ${BASE_IMAGE}
 ENV container=docker
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y expect build-essential curl jq gettext git openssh-client pipx python3-dev python3-pip python3-psutil python3-requests python3-setuptools python3-venv software-properties-common sudo sshpass virtualenv wget 
+RUN pip install --upgrade pip
 RUN adduser -u 1000 --disabled-password ubuntu || /bin/true
 RUN echo "ubuntu ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu && \
     chmod 0440 /etc/sudoers.d/ubuntu


### PR DESCRIPTION
## Description
This PR contains the following changes:
- fix the unrunning test phase caused by the `testflinger-device-connector` build failure. 
- update all package installations with uv. 
- update tf_cmd when config changed


## Resolved issues
`testflinger-device-connector` build failure due to outdated `pip`.
```
> sudo docker run -it -v ~/git/testflinger/:/srv/testflinger/ ghcr.io/canonical/testflinger/testflinger-testenv:jammy bash
ubuntu@d2030075634e:~$ cd /srv/testflinger/device-connectors/
ubuntu@d2030075634e:/srv/testflinger/device-connectors$ sudo pip install .
Processing /srv/testflinger/device-connectors
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [12 lines of output]
      Traceback (most recent call last):
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/tmp/pip-build-env-u1ormcxk/overlay/local/lib/python3.10/dist-packages/uv_build/__init__.py", line 113, in prepare_metadata_for_build_wheel
          return call(args, config_settings)
        File "/tmp/pip-build-env-u1ormcxk/overlay/local/lib/python3.10/dist-packages/uv_build/__init__.py", line 51, in call
          raise RuntimeError(f"{uv_bin_name} was not properly installed")
      RuntimeError: uv-build was not properly installed
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
The `pip` version need to be upgraded (>=23.1) to include improved support for PEP 517 build backends, which `uv-build` utilizes.
```
ubuntu@d2030075634e:/srv/testflinger/device-connectors$ sudo pip install --upgrade pip
Requirement already satisfied: pip in /usr/lib/python3/dist-packages (22.0.2)
Collecting pip
  Downloading pip-25.1.1-py3-none-any.whl (1.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 5.1 MB/s eta 0:00:00
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 22.0.2
    Not uninstalling pip at /usr/lib/python3/dist-packages, outside environment /usr
    Can't uninstall 'pip'. No files were found to uninstall.
Successfully installed pip-25.1.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
ubuntu@d2030075634e:/srv/testflinger/device-connectors$ sudo pip install .
Processing /srv/testflinger/device-connectors
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting jsonschema>=4.23.0 (from testflinger-device-connectors==0.0.2)
  Downloading jsonschema-4.24.0-py3-none-any.whl.metadata (7.8 kB)
Collecting pyyaml>=6.0.2 (from testflinger-device-connectors==0.0.2)
  Downloading PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
Collecting requests>=2.32.3 (from testflinger-device-connectors==0.0.2)
  Downloading requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
Collecting rpyc<6 (from testflinger-device-connectors==0.0.2)
  Downloading rpyc-5.3.1-py3-none-any.whl.metadata (3.4 kB)
Collecting validators>=0.34.0 (from testflinger-device-connectors==0.0.2)
  Downloading validators-0.35.0-py3-none-any.whl.metadata (3.9 kB)
Collecting plumbum (from rpyc<6->testflinger-device-connectors==0.0.2)
  Downloading plumbum-1.9.0-py3-none-any.whl.metadata (10 kB)
Collecting attrs>=22.2.0 (from jsonschema>=4.23.0->testflinger-device-connectors==0.0.2)
  Downloading attrs-25.3.0-py3-none-any.whl.metadata (10 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema>=4.23.0->testflinger-device-connectors==0.0.2)
  Downloading jsonschema_specifications-2025.4.1-py3-none-any.whl.metadata (2.9 kB)
Collecting referencing>=0.28.4 (from jsonschema>=4.23.0->testflinger-device-connectors==0.0.2)
  Downloading referencing-0.36.2-py3-none-any.whl.metadata (2.8 kB)
Collecting rpds-py>=0.7.1 (from jsonschema>=4.23.0->testflinger-device-connectors==0.0.2)
  Downloading rpds_py-0.25.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.1 kB)
Collecting typing-extensions>=4.4.0 (from referencing>=0.28.4->jsonschema>=4.23.0->testflinger-device-connectors==0.0.2)
  Downloading typing_extensions-4.13.2-py3-none-any.whl.metadata (3.0 kB)
Collecting charset-normalizer<4,>=2 (from requests>=2.32.3->testflinger-device-connectors==0.0.2)
  Downloading charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (35 kB)
Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3/dist-packages (from requests>=2.32.3->testflinger-device-connectors==0.0.2) (3.3)
Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/lib/python3/dist-packages (from requests>=2.32.3->testflinger-device-connectors==0.0.2) (1.26.5)
Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python3/dist-packages (from requests>=2.32.3->testflinger-device-connectors==0.0.2) (2020.6.20)
Downloading rpyc-5.3.1-py3-none-any.whl (74 kB)
Downloading jsonschema-4.24.0-py3-none-any.whl (88 kB)
Downloading attrs-25.3.0-py3-none-any.whl (63 kB)
Downloading jsonschema_specifications-2025.4.1-py3-none-any.whl (18 kB)
Downloading PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (751 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 751.2/751.2 kB 3.0 MB/s eta 0:00:00
Downloading referencing-0.36.2-py3-none-any.whl (26 kB)
Downloading requests-2.32.3-py3-none-any.whl (64 kB)
Downloading charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (149 kB)
Downloading rpds_py-0.25.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (386 kB)
Downloading typing_extensions-4.13.2-py3-none-any.whl (45 kB)
Downloading validators-0.35.0-py3-none-any.whl (44 kB)
Downloading plumbum-1.9.0-py3-none-any.whl (127 kB)
Building wheels for collected packages: testflinger-device-connectors
  Building wheel for testflinger-device-connectors (pyproject.toml) ... done
  Created wheel for testflinger-device-connectors: filename=testflinger_device_connectors-0.0.2-py3-none-any.whl size=129927 sha256=6b169659096e0a0e19918bd2d9122812d6e97892c9b717bce2f2c9d54d6e6e8c
  Stored in directory: /root/.cache/pip/wheels/40/70/51/f68d75f27549b4302937597604520f4029957186ed7b7e455c
Successfully built testflinger-device-connectors
Installing collected packages: validators, typing-extensions, rpds-py, pyyaml, plumbum, charset-normalizer, attrs, rpyc, requests, referencing, jsonschema-specifications, jsonschema, testflinger-device-connectors
  Attempting uninstall: pyyaml
    Found existing installation: PyYAML 5.4.1
    Uninstalling PyYAML-5.4.1:
      Successfully uninstalled PyYAML-5.4.1
  Attempting uninstall: requests
    Found existing installation: requests 2.25.1
    Uninstalling requests-2.25.1:
      Successfully uninstalled requests-2.25.1
Successfully installed attrs-25.3.0 charset-normalizer-3.4.2 jsonschema-4.24.0 jsonschema-specifications-2025.4.1 plumbum-1.9.0 pyyaml-6.0.2 referencing-0.36.2 requests-2.32.3 rpds-py-0.25.1 rpyc-5.3.1 testflinger-device-connectors-0.0.2 typing-extensions-4.13.2 validators-0.35.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
```

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Packed the testflinger-agent-host charm locally and validated the packages were installed
