### PR TITLE
update: add support for provisioning plucky desktop image for RPIs.

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/muxpi/pi-desktop-plucky/meta-data
+++ b/device-connectors/src/testflinger_device_connectors/data/muxpi/pi-desktop-plucky/meta-data
@@ -1,0 +1,1 @@
+instance_id: cloud-image

--- a/device-connectors/src/testflinger_device_connectors/data/muxpi/pi-desktop-plucky/user-data
+++ b/device-connectors/src/testflinger_device_connectors/data/muxpi/pi-desktop-plucky/user-data
@@ -1,0 +1,21 @@
+#cloud-config
+users:
+  - name: ubuntu
+    passwd: "$6$sDvG1B83mkN1/EWZ$4W3KnGmq9II5Yg3PsgNSRbwW2XpsjJqaXT1A.zo1.YsM.MH18I5dWyJnYnLr7XR2vmzaVj9gV6eHEevRXH8Gn."
+    lock_passwd: false
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+
+ssh_pwauth: true
+packages:
+  - openssh-server
+write_files:
+  - path: /etc/gdm3/custom.conf
+    content: |
+      [daemon]
+      AutomaticLoginEnable = true
+      AutomaticLogin = ubuntu
+      [security]
+      [xdmcp]
+      [chooser]
+      [debug]

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -579,8 +579,9 @@ class MuxPi:
                     self._copy_to_control(
                         data_path / "pi-desktop/preseed.cfg", remote_tmp
                     )
-                    cmd = "sudo cp {}/preseed.cfg {}/writable/preseed.cfg".format(
-                        remote_tmp, self.mount_point
+                    cmd = (
+                        f"sudo cp {remote_tmp}/preseed.cfg"
+                        f"{self.mount_point}/writable/preseed.cfg"
                     )
                     self._run_control(cmd)
 

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -542,7 +542,7 @@ class MuxPi:
                     base = self.mount_point / "writable"
                     ci_path = base / "var/lib/cloud/seed/nocloud-net"
                     self._run_control(f"sudo mkdir -p {ci_path}")
-                    self._run_control("mkdir -p {}".format(remote_tmp))
+                    self._run_control(f"mkdir -p {remote_tmp}")
                     self._copy_to_control(
                         data_path / "pi-desktop-plucky/meta-data", remote_tmp
                     )
@@ -555,9 +555,10 @@ class MuxPi:
                     self._run_control(cmd)
                     # This needs to be removed for rpi, else
                     # cloud-init won't find the user-data we give it
-                    rm_cmd = "sudo rm -f {}".format(
+                    cloud_cfg = (
                         base / "etc/cloud/cloud.cfg.d/99-fake?cloud.cfg"
                     )
+                    rm_cmd = f"sudo rm -f {cloud_cfg}"
                     self._run_control(rm_cmd)
 
                 else:
@@ -566,23 +567,22 @@ class MuxPi:
                     self._copy_to_control(
                         data_path / "pi-desktop/oem-config.service", remote_tmp
                     )
-                    cmd = (
-                        "sudo cp {}/oem-config.service "
-                        "{}/writable/etc/systemd/system/"
-                        "oem-config.service".format(
-                            remote_tmp, self.mount_point
-                        )
+
+                    src_service = f"{remote_tmp}/oem-config.service"
+                    dst_service = (
+                        self.mount_point
+                        / "writable/etc/systemd/system/oem-config.service"
                     )
+                    cmd = f"sudo cp {src_service} {dst_service}"
                     self._run_control(cmd)
 
                     # Copy the preseed
                     self._copy_to_control(
                         data_path / "pi-desktop/preseed.cfg", remote_tmp
                     )
-                    cmd = (
-                        f"sudo cp {remote_tmp}/preseed.cfg"
-                        f"{self.mount_point}/writable/preseed.cfg"
-                    )
+                    src_preseed = f"{remote_tmp}/preseed.cfg"
+                    dst_preseed = self.mount_point / "writable/preseed.cfg"
+                    cmd = f"sudo cp {src_preseed} {dst_preseed}"
                     self._run_control(cmd)
 
                 # Make sure NetworkManager is started

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -579,9 +579,8 @@ class MuxPi:
                     self._copy_to_control(
                         data_path / "pi-desktop/preseed.cfg", remote_tmp
                     )
-                    cmd = (
-                        "sudo cp {}/preseed.cfg {}/writable/preseed.cfg"
-                        .format(remote_tmp, self.mount_point)
+                    cmd = "sudo cp {}/preseed.cfg {}/writable/preseed.cfg".format(
+                        remote_tmp, self.mount_point
                     )
                     self._run_control(cmd)
 


### PR DESCRIPTION
## Description

Plucky switched from `oem-config` to `gnome-initial-setup` for the initialization, additionally, plucky now supports cloud-init on desktop image.
Based on this, we should inject cloud-init config when detecting the image version newer than 25.04, instead of using `preseed.cfg`

## Resolved issues

https://warthogs.atlassian.net/browse/CERTTF-625

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

Test this change directly on a real machine.
```
testflinger-device-connector muxpi provision -c default.yaml testflinger.json
2025-06-04 08:30:05,663 rpi5b8g001 INFO: DEVICE CONNECTOR: BEGIN provision
2025-06-04 08:30:05,663 rpi5b8g001 INFO: DEVICE CONNECTOR: Provisioning device
2025-06-04 08:30:05,667 rpi5b8g001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
2025-06-04 08:30:16,298 rpi5b8g001 INFO: DEVICE CONNECTOR: Downloading test image from http://10.102.196.9/cdimage/plucky/ubuntu-25.04-preinstalled-desktop-arm64+raspi.img.xz
2025-06-04 08:30:35,700 rpi5b8g001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
2025-06-04 08:30:46,613 rpi5b8g001 INFO: DEVICE CONNECTOR: Flashing Test image ubuntu-25.04-preinstalled-desktop-arm64+raspi.img.xz on /dev/sda
2025-06-04 08:39:10,132 rpi5b8g001 INFO: DEVICE CONNECTOR: Image type detected: pi-desktop
2025-06-04 08:39:10,133 rpi5b8g001 INFO: DEVICE CONNECTOR: Creating Test User
2025-06-04 08:39:24,923 rpi5b8g001 INFO: DEVICE CONNECTOR: Booting Test Image
2025-06-04 08:39:24,924 rpi5b8g001 INFO: DEVICE CONNECTOR: Running snmpset -c private -v2c 10.102.197.186 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.3 i 0
iso.3.6.1.4.1.13742.6.4.1.2.1.2.1.3 = INTEGER: 0
2025-06-04 08:39:24,940 rpi5b8g001 INFO: DEVICE CONNECTOR: Running sleep 30
2025-06-04 08:39:36,157 rpi5b8g001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
2025-06-04 08:39:54,981 rpi5b8g001 INFO: DEVICE CONNECTOR: Running snmpset -c private -v2c 10.102.197.186 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.3 i 1
iso.3.6.1.4.1.13742.6.4.1.2.1.2.1.3 = INTEGER: 1
2025-06-04 08:39:54,998 rpi5b8g001 INFO: DEVICE CONNECTOR: Checking if test image booted.
2025-06-04 08:40:06,189 rpi5b8g001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
2025-06-04 08:40:26,552 rpi5b8g001 INFO: DEVICE CONNECTOR: ssh-id-copy failed with Command '['sshpass', '-p', 'ubuntu', 'ssh-copy-id', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'ubuntu@10.102.166.37']' returned non-zero exit status 1.
...
...
...
2025-06-04 08:42:33,215 rpi5b8g001 INFO: DEVICE CONNECTOR: ssh-id-copy failed with Command '['sshpass', '-p', 'ubuntu', 'ssh-copy-id', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'ubuntu@10.102.166.37']' returned non-zero exit status 1.
2025-06-04 08:42:36,285 rpi5b8g001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
2025-06-04 08:42:43,679 rpi5b8g001 INFO: DEVICE CONNECTOR: END provision
```
