### PR TITLE
Change: log error on console

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/cmd.py
+++ b/device-connectors/src/testflinger_device_connectors/cmd.py
@@ -80,6 +80,7 @@ def add_exception_logging_to_file(func: Callable, stage: str):
         try:
             return func(*args, **kwargs)
         except Exception as exception:
+            logger.error(exception)
             if exception.__cause__ is None:
                 exception_cause = None
             else:


### PR DESCRIPTION
## Description

As far as I can tell, every exception in `provision` or any other phase is caught by this try/except and logged to a file. 

It's much easier for any user and contributor to just read on console what went wrong.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

Just run locally with `uv run testflinger-device-connectors *args` passing a wrong job definition.

Example:
```
$ uv run testflinger-device-connector zapper_kvm provision -c ../config.yaml ../job.json
2025-06-04 15:46:25,146 local-tf-agent INFO: DEVICE CONNECTOR: BEGIN provision
2025-06-04 15:46:25,146 local-tf-agent INFO: DEVICE CONNECTOR: Provisioning device
2025-06-04 15:46:28,336 local-tf-agent ERROR: DEVICE CONNECTOR: [Errno 113] No route to host
```

