### PR TITLE
fix(ci): Fix the release channels of charms and snaps

### DIFF
--- a/.github/workflows/agent-host-charm-release-edge.yml
+++ b/.github/workflows/agent-host-charm-release-edge.yml
@@ -8,6 +8,15 @@ on:
       - agent/charms/testflinger-agent-host-charm/**
       - .github/workflows/agent-host-charm-release-edge.yml
   workflow_dispatch:
+    inputs:
+      channel:
+        description: The channel to release the charm to
+        required: true
+        default: latest/edge
+        type: choice
+        options:
+          - latest/beta
+          - latest/edge
 
 jobs:
   agent-build-and-push-charm:
@@ -28,5 +37,5 @@ jobs:
           charm-path: agent/charms/testflinger-agent-host-charm
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "latest/edge"
+          channel: ${{ github.event_name == 'push' && 'latest/beta' || github.event.inputs.channel }}
           tag-prefix: "agent-host-charm"

--- a/.github/workflows/charm-promote.yml
+++ b/.github/workflows/charm-promote.yml
@@ -23,7 +23,7 @@ on:
       origin-channel:
         description: The channel to promote from
         required: true
-        default: latest/edge
+        default: latest/beta
         type: choice
         options:
           - latest/candidate

--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -18,6 +18,14 @@ on:
         required: false
         default: false
         type: boolean
+      release:
+        description: The release channel to publish to
+        required: false
+        default: edge
+        type: choice
+        options:
+          - beta
+          - edge
 
 jobs:
   build:
@@ -52,4 +60,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
           snap: ${{ steps.build.outputs.snap }}
-          release: "edge,beta"
+          release: ${{ github.event_name == 'push' && 'beta' || github.event.inputs.release }}

--- a/.github/workflows/server-charm-release-edge.yml
+++ b/.github/workflows/server-charm-release-edge.yml
@@ -8,6 +8,15 @@ on:
       - .github/workflows/server-charm-release-edge.yml
       - server/**
   workflow_dispatch:
+    inputs:
+      channel:
+        description: The channel to release the charm to
+        required: true
+        default: latest/edge
+        type: choice
+        options:
+          - latest/beta
+          - latest/edge
 
 env:
   REGISTRY: ghcr.io
@@ -63,4 +72,4 @@ jobs:
           charm-path: server/charm
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "latest/edge"
+          channel: ${{ github.event_name == 'push' && 'latest/beta' || github.event.inputs.channel }}


### PR DESCRIPTION
## Description

This PR ensures:

- `push` events release to `beta` channels for snaps and charms
- promote workflows defaults to promoting from `beta` channels
- publish workflows allow choice of `beta` or `edge` when manually dispatching

## Resolved issues

## Documentation

## Web service API changes

## Tests

