### PR TITLE
feat (devices): Retry importing ssh keys

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -253,7 +253,7 @@ class DefaultDevice:
 
             logger.error("Unable to import ssh key from: %s", key)
             logger.info("Retrying...")
-            time.sleep(min(2**retry, 30))
+            time.sleep(min(2**retry, 100))
         else:
             raise RuntimeError(
                 f"Failed to import ssh key: {key}. Maximum retries reached"

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -226,8 +226,8 @@ class DefaultDevice:
         """Import SSH key provided in Reserve data.
 
         :param key: SSH key to import.
-        :raises RuntimeError: If failure during import ssh keys"""
-
+        :raises RuntimeError: If failure during import ssh keys
+        """
         cmd = ["ssh-import-id", "-o", "key.pub", key]
         for retry in range(10):
             try:
@@ -238,7 +238,7 @@ class DefaultDevice:
                     stderr=subprocess.STDOUT,
                     check=True,
                 )
-                logger.info(f"Successfully imported key: {key}")
+                logger.info("Successfully imported key: %s", key)
                 break
             except (
                 subprocess.CalledProcessError,
@@ -249,10 +249,10 @@ class DefaultDevice:
                     if "status_code=404" in output:
                         raise RuntimeError(
                             f"Failed to import ssh key: {key}. User not found."
-                        )
+                        ) from exc
 
                 # If any other error, attempt to retry
-                logger.error(f"Unable to import ssh key from: {key}")
+                logger.error("Unable to import ssh key from: %s", key)
                 logger.info("Retrying...")
                 time.sleep(min(2**retry, 30))
         else:

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -332,7 +332,7 @@ class DefaultDevice:
 
             try:
                 # Import SSH Keys with ssh-import-id
-                self.import_ssh_key(key)
+                self.import_ssh_key(key, keyfile="key.pub")
 
                 # Attempt to copy keys only if import succeeds
                 with contextlib.suppress(RuntimeError):


### PR DESCRIPTION
## Description
This PR adds a retry to the import SSH command as the only retry currently is from copying ssh keys from the agent to the device. 

This addressed the following:
- If import fails, the copy_ssh will reattempt to copy a nonexistent key.pub (10 min retry just to fail)
- Retry to import the SSH keys from Launchpad in case of a a temporary failure e.g networking blip. 
- Identifies if the ssh key does not exist in source (error404) and aborts the import/copy of the SSH keys. This is not an HTTP error but rather part of the output of the `ssh_import_id
`
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-642](https://warthogs.atlassian.net/browse/CERTTF-642)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
Tested on staging instance. I simulated a failure by adding a sleep command in the first attempt of importing each key: 

```
reserve_data:
  ssh_keys:
    - lp:rene-orozco
    - lp:reneoromar
```

```
2025-06-05 20:18:24,093 audino INFO: DEVICE CONNECTOR: BEGIN reservation
2025-06-05 20:18:54,094 audino ERROR: DEVICE CONNECTOR: Unable to import ssh key from: lp:rene-orozco
2025-06-05 20:18:54,095 audino INFO: DEVICE CONNECTOR: Retrying...
2025-06-05 20:18:55,574 audino INFO: DEVICE CONNECTOR: Successfully imported key: lp:rene-orozco

...

2025-06-05 20:19:26,223 audino ERROR: DEVICE CONNECTOR: Unable to import ssh key from: lp:reneoromar
2025-06-05 20:19:26,223 audino INFO: DEVICE CONNECTOR: Retrying...
2025-06-05 20:19:27,747 audino ERROR: DEVICE CONNECTOR: Failed to import ssh key: lp:reneoromar. User not found.
*** TESTFLINGER SYSTEM RESERVED ***
You can now connect to ubuntu@xx.xxx.x.xx
Current time:           [2025-06-05T20:19:27.748158+00:00]
Reservation expires at: [2025-06-05T22:19:27.748215+00:00]
Reservation will automatically timeout in 7200 seconds
To end the reservation sooner use: testflinger-cli cancel 7c180a02-44ea-419b-b5fd-9664b8218a25
```

[CERTTF-642]: https://warthogs.atlassian.net/browse/CERTTF-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ