### PR TITLE
fix(agent): Include install_dependencies during upgrade_charm. 

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -258,6 +258,7 @@ class TestflingerAgentHostCharm(CharmBase):
         self.unit.status = MaintenanceStatus("Handling upgrade_charm hook")
         self.install_dependencies()
         self.update_tf_cmd_scripts()
+        self.update_testflinger_repo()
         self.unit.status = ActiveStatus()
 
     def on_start(self, _):

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -256,6 +256,7 @@ class TestflingerAgentHostCharm(CharmBase):
     def on_upgrade_charm(self, _):
         """Upgrade hook."""
         self.unit.status = MaintenanceStatus("Handling upgrade_charm hook")
+        self.install_dependencies()
         self.update_tf_cmd_scripts()
         self.unit.status = ActiveStatus()
 


### PR DESCRIPTION
## Description
Currently the function `install_dependencies()` is only getting called during `on_install`  hook. This PR also adds it to the `on_upgrade` hook.  This is needed due to recent addition of `pipx` in the `install_dependencies()` function.

The impact was low because the following error is only found with the `update-testflinger` action. 

`on_update_testflinger_action()` -> `testflinger_source.clone_repo()` -> `clone_repo()`:

```
for directory in ("common", "agent", "device-connectors"):
        logger.debug("Installing Python package: %s", directory)
        run_with_logged_errors(
            [
                "/root/.local/bin/uv", <---- Problematic line
                "pip",
                "install",
                "--python",
                f"{VIRTUAL_ENV_PATH}/bin/python3",
                "-U",
                f"{local_path}/{directory}",
            ]
        )
```

Since UV is installed with pipx, the following traceback is found:
```
File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/root/.local/bin/uv'
unit-agent-host-tor3-staging-0: 23:22:52 WARNING unit.agent-host-tor3-staging/0.update-testflinger Uncaught FileNotFoundError in charm code: [Errno 2] No such file or directory: '/root/.local/bin/uv'
```
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Tested by releasing the charm to Edge channel and validate with the staging repo:
```
App                      Version  Status  Scale  Charm                   Channel      Rev  Exposed  Message
agent-host-tor3-staging           active      1  testflinger-agent-host  latest/edge   47  no      
``` 

```
ubuntu@juju-17da54-12:~$ sudo pipx list
venvs are in /root/.local/pipx/venvs
apps are exposed on your $PATH at /root/.local/bin
   package uv 0.7.13, installed using Python 3.10.12
    - uv
    - uvx
```

From unit with latest Stable version:
```
App                  Version  Status  Scale  Charm                   Channel        Rev  Exposed  Message
agent-host-tor5-dh3           active      1  testflinger-agent-host  latest/stable   45  no     
```
```
ubuntu@juju-17da54-13:~$ sudo pipx list
sudo: pipx: command not found
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
