### PR TITLE
refactor(agent): Modify agent status handling by removing tmp files. 

### DIFF
--- a/agent/src/testflinger_agent/__init__.py
+++ b/agent/src/testflinger_agent/__init__.py
@@ -126,13 +126,11 @@ def start_agent():
     client = TestflingerClient(config)
     agent = TestflingerAgent(client)
     while True:
-        offline_file = agent.check_offline()
-        if offline_file:
+        if agent.check_offline():
             logger.error(
                 "Agent %s is offline, not processing jobs! "
-                "Remove %s to resume processing",
+                "Please contact Tesflinger Admin to enable agent.",
                 config.get("agent_id"),
-                offline_file,
             )
             while agent.check_offline():
                 time.sleep(check_interval)

--- a/agent/src/testflinger_agent/__init__.py
+++ b/agent/src/testflinger_agent/__init__.py
@@ -126,13 +126,16 @@ def start_agent():
     client = TestflingerClient(config)
     agent = TestflingerAgent(client)
     while True:
-        if agent.check_offline():
+        is_offline, offline_comment = agent.check_offline()
+        if is_offline:
             logger.error(
                 "Agent %s is offline, not processing jobs! "
-                "Please contact Tesflinger Admin to enable agent.",
+                "Reason: %s\n"
+                "Please contact Tesflinger Admin if you require assistance.",
                 config.get("agent_id"),
+                offline_comment or "Unknown",
             )
-            while agent.check_offline():
+            while agent.check_offline()[0]:
                 time.sleep(check_interval)
         # Refresh the updated_at timestamp on advertised queues
         client.post_advertised_queues()

--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -205,6 +205,8 @@ class TestflingerAgent:
         """
         logger.info("Taking agent offline")
         self.set_agent_state(AgentState.OFFLINE, comment)
+        # Need to set the offline flag to False to allow recovery
+        self.status_handler.update(offline=False, comment=comment)
 
     def unpack_attachments(self, job_data: dict, cwd: Path):
         """Download and unpack the attachments associated with a job."""

--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -183,7 +183,10 @@ class TestflingerAgent:
         agent = self.client.config.get("agent_id")
         agent_state = self.get_agent_state(agent)
 
-        if agent_state == AgentState.OFFLINE:
+        if (
+            agent_state == AgentState.OFFLINE
+            or agent == AgentState.MAINTENANCE
+        ):
             return True
         else:
             return False

--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -124,9 +124,13 @@ class TestflingerAgent:
 
         self.client.post_agent_data(agent_data)
 
-    def set_agent_state(self, state):
-        """Send the agent state to the server."""
-        self.client.post_agent_data({"state": state})
+    def set_agent_state(self, state: str, comment: str = "") -> None:
+        """Send the agent state to the server.
+
+        :param state: Agent state to report to the server.
+        :param comment: Reason for changing the state. Defaults to empty str.
+        """
+        self.client.post_agent_data({"state": state, "comment": comment})
         self.client.post_influx(state)
 
     def get_agent_state(self, agent: str) -> str:
@@ -318,7 +322,11 @@ class TestflingerAgent:
                         # exit code 46 is our indication that recovery failed!
                         # In this case, we need to mark the device offline
                         if exit_code == 46:
-                            self.set_agent_state(AgentState.OFFLINE)
+                            self.set_agent_state(
+                                state=AgentState.OFFLINE,
+                                comment="Set to offline by agent. Recovery "
+                                f"Failed found during {job.job_id} execution.",
+                            )
                             exit_event = TestEvent.RECOVERY_FAIL
                         else:
                             exit_event = TestEvent(phase + "_fail")

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -377,23 +377,6 @@ class TestflingerClient:
         except requests.exceptions.RequestException as exc:
             logger.error(exc)
 
-    def get_agent_data(self, agent: str) -> dict:
-        """Get the data information for an agent from Testflinger Server.
-
-        :param agent: The agent to retrieve data from
-        :return: Information about the agent.
-        """
-        agent_data_uri = urljoin(self.server, "/v1/agents/data/")
-        agent_data_url = urljoin(agent_data_uri, agent)
-
-        try:
-            response = self.session.get(agent_data_url, timeout=30)
-            response.raise_for_status()
-            return response.json()
-        except (requests.exceptions.RequestException, ValueError) as exc:
-            logger.error("Failed to retrieve agent data: %s", exc)
-            return {}
-
     def post_influx(self, phase, result=None):
         """Post the relevant data points to testflinger server.
 

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -387,12 +387,12 @@ class TestflingerClient:
         agent_data_url = urljoin(agent_data_uri, agent)
 
         try:
-            agent_data = self.session.get(agent_data_url, timeout=30)
-        except requests.exceptions.RequestException as exc:
-            agent_data = {}
-            logger.error(exc)
-
-        return agent_data
+            response = self.session.get(agent_data_url, timeout=30)
+            response.raise_for_status()
+            return response.json()
+        except (requests.exceptions.RequestException, ValueError) as exc:
+            logger.error("Failed to retrieve agent data: %s", exc)
+            return {}
 
     def post_influx(self, phase, result=None):
         """Post the relevant data points to testflinger server.

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -377,6 +377,23 @@ class TestflingerClient:
         except requests.exceptions.RequestException as exc:
             logger.error(exc)
 
+    def get_agent_data(self, agent: str) -> dict:
+        """Get the data information for an agent from Testflinger Server.
+
+        :param agent: The agent to retrieve data from
+        :return: Information about the agent.
+        """
+        agent_data_uri = urljoin(self.server, "/v1/agents/data/")
+        agent_data_url = urljoin(agent_data_uri, agent)
+
+        try:
+            agent_data = self.session.get(agent_data_url, timeout=30)
+        except requests.exceptions.RequestException as exc:
+            agent_data = {}
+            logger.error(exc)
+
+        return agent_data
+
     def post_influx(self, phase, result=None):
         """Post the relevant data points to testflinger server.
 

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -31,3 +31,38 @@ class LogUpdateHandler:
     def __call__(self, data: str):
         with open(self.log_file, "a") as log:
             log.write(data)
+
+
+class RestartHandler:
+    """Handler to determine if restart is needed at any stage of the agent."""
+
+    def __init__(self):
+        """Initialize handler with default values."""
+        self.needs_restart = False
+        self.comment = ""
+
+    def update(self, restart: bool, comment: str) -> None:
+        """Update the attributes of the class if needed.
+
+        :param restart: Flag to set if agent needs restarting.
+        :param comment: Reason for requesting agent restart.
+        """
+        if restart and not self.needs_restart:
+            self.needs_restart = True
+            self.comment = comment
+        elif self.needs_restart and comment:
+            self.comment = f"Restart Pending: {comment}"
+
+    def marked_for_restart(self) -> bool:
+        """Indicate the current restart state of the restart handler.
+
+        :return: True if a restart is neeeded, False otherwise.
+        """
+        return self.needs_restart
+
+    def get_comment(self) -> str:
+        """Retrieve the comment from the restart handler.
+
+        :return: Preserved comment if an agent was set to restart.
+        """
+        return self.comment

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -33,25 +33,31 @@ class LogUpdateHandler:
             log.write(data)
 
 
-class RestartHandler:
+class AgentStatusHandler:
     """Handler to determine if restart is needed at any stage of the agent."""
 
     def __init__(self):
         """Initialize handler with default values."""
         self.needs_restart = False
+        self.needs_offline = False
         self.comment = ""
 
-    def update(self, restart: bool, comment: str) -> None:
+    def update(
+        self, comment: str, restart: bool = False, offline: bool = False
+    ) -> None:
         """Update the attributes of the class if needed.
 
         :param restart: Flag to set if agent needs restarting.
-        :param comment: Reason for requesting agent restart.
+        :param offline: Flag to set if agent needs offlining.
+        :param comment: Reason for requesting agent status change.
         """
         if restart and not self.needs_restart:
             self.needs_restart = True
+            if not self.needs_offline:
+                self.comment = comment
+        if offline and not self.needs_offline:
+            self.needs_offline = True
             self.comment = comment
-        elif self.needs_restart and comment:
-            self.comment = f"Restart Pending: {comment}"
 
     def marked_for_restart(self) -> bool:
         """Indicate the current restart state of the restart handler.
@@ -60,9 +66,16 @@ class RestartHandler:
         """
         return self.needs_restart
 
-    def get_comment(self) -> str:
-        """Retrieve the comment from the restart handler.
+    def marked_for_offline(self) -> bool:
+        """Indicate the current offline state of the offline handler.
 
-        :return: Preserved comment if an agent was set to restart.
+        :return: True if a offline is neeeded, False otherwise.
+        """
+        return self.needs_offline
+
+    def get_comment(self) -> str:
+        """Retrieve the comment from the status handler.
+
+        :return: Preserved comment if an agent status was modified.
         """
         return self.comment

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -43,7 +43,10 @@ class AgentStatusHandler:
         self.comment = ""
 
     def update(
-        self, comment: str, restart: bool = False, offline: bool = False
+        self,
+        comment: str,
+        restart: bool | None = None,
+        offline: bool | None = None,
     ) -> None:
         """Update the attributes of the class if needed.
 
@@ -58,6 +61,9 @@ class AgentStatusHandler:
         if offline and not self.needs_offline:
             self.needs_offline = True
             self.comment = comment
+        # Clear the flag if received an offline False
+        elif not offline and self.needs_offline:
+            self.needs_offline = False
 
     def marked_for_restart(self) -> bool:
         """Indicate the current restart state of the restart handler.

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -65,12 +65,15 @@ class TestClient:
         self.config["setup_command"] = "echo setup1"
         fake_job_data = {"job_id": str(uuid.uuid1()), "job_queue": "test"}
         requests_mock.get(
-            f"http://127.0.0.1:8000/v1/agents/data/{self.config['agent_id']}",
-            json={"restricted_to": {}},
-        )
-        requests_mock.get(
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+            re.compile(r".*/(?!v1/agents/data/\w+$).*"),
+            [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+        )
+        # For mocking, we can simplify the agent state by setting as waiting
+        requests_mock.get(
+            re.compile(r"/v1/agents/data/\w+"),
+            text=json.dumps({"state": "waiting", "restricted_to": {}}),
         )
         requests_mock.post(rmock.ANY, status_code=200)
         with patch("shutil.rmtree"):
@@ -88,12 +91,15 @@ class TestClient:
             "provision_data": {"url": "foo"},
         }
         requests_mock.get(
-            f"http://127.0.0.1:8000/v1/agents/data/{self.config['agent_id']}",
-            json={"restricted_to": {}},
-        )
-        requests_mock.get(
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+            re.compile(r".*/(?!v1/agents/data/\w+$).*"),
+            [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+        )
+        # For mocking, we can simplify the agent state by setting as waiting
+        requests_mock.get(
+            re.compile(r"/v1/agents/data/\w+"),
+            text=json.dumps({"state": "waiting"}),
         )
         requests_mock.post(rmock.ANY, status_code=200)
         with patch("shutil.rmtree"):
@@ -113,12 +119,13 @@ class TestClient:
             "test_data": {"test_cmds": "foo"},
         }
         requests_mock.get(
-            f"http://127.0.0.1:8000/v1/agents/data/{self.config['agent_id']}",
-            json={"restricted_to": {}},
-        )
-        requests_mock.get(
-            "http://127.0.0.1:8000/v1/job?queue=test",
+            re.compile(r".*/(?!v1/agents/data/\w+$).*"),
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
+        )
+        # For mocking, we can simplify the agent state by setting as waiting
+        requests_mock.get(
+            re.compile(r"/v1/agents/data/\w+"),
+            text=json.dumps({"state": "waiting", "restricted_to": {}}),
         )
         requests_mock.post(rmock.ANY, status_code=200)
         with patch("shutil.rmtree"):
@@ -171,6 +178,12 @@ class TestClient:
             mocker.get(
                 "http://127.0.0.1:8000/v1/agents/data/test01",
                 json={"restricted_to": {}},
+            )
+
+            # mock response to get agent status
+            mocker.get(
+                re.compile(r"/v1/agents/data/\w+"),
+                text=json.dumps({"state": "waiting"}),
             )
 
             # request and process the job (should unpack the archive)
@@ -235,6 +248,12 @@ class TestClient:
                 json={"restricted_to": {}},
             )
 
+            # mock response to get agent status
+            mocker.get(
+                re.compile(r"/v1/agents/data/\w+"),
+                text=json.dumps({"state": "waiting"}),
+            )
+
             # request and process the job (should unpack the archive)
             with patch("shutil.rmtree"):
                 agent.process_jobs()
@@ -297,6 +316,12 @@ class TestClient:
                 json={"restricted_to": {}},
             )
 
+            # mock response to get agent status
+            mocker.get(
+                re.compile(r"/v1/agents/data/\w+"),
+                text=json.dumps({"state": "waiting"}),
+            )
+
             # request and process the job (should unpack the archive)
             with patch("shutil.rmtree"):
                 agent.process_jobs()
@@ -322,12 +347,13 @@ class TestClient:
             "test_data": {"test_cmds": "foo"},
         }
         requests_mock.get(
-            f"http://127.0.0.1:8000/v1/agents/data/{self.config['agent_id']}",
-            json={"restricted_to": {}},
-        )
-        requests_mock.get(
-            "http://127.0.0.1:8000/v1/job?queue=test",
+            re.compile(r".*/(?!v1/agents/data/\w+$).*"),
             [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
+        )
+        # For mocking, we can simplify the agent state by setting as waiting
+        requests_mock.get(
+            re.compile(r"/v1/agents/data/\w+"),
+            text=json.dumps({"state": "waiting", "restricted_to": {}}),
         )
         requests_mock.post(rmock.ANY, status_code=200)
         with patch("shutil.rmtree"):
@@ -348,12 +374,13 @@ class TestClient:
             "test_data": {"test_cmds": "foo"},
         }
         requests_mock.get(
-            f"http://127.0.0.1:8000/v1/agents/data/{self.config['agent_id']}",
-            json={"restricted_to": {}},
-        )
-        requests_mock.get(
-            "http://127.0.0.1:8000/v1/job?queue=test",
+            re.compile(r".*/(?!v1/agents/data/\w+$).*"),
             [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
+        )
+        # For mocking, we can simplify the agent state by setting as waiting
+        requests_mock.get(
+            re.compile(r"/v1/agents/data/\w+"),
+            text=json.dumps({"state": "waiting", "restricted_to": {}}),
         )
         requests_mock.post(rmock.ANY, status_code=200)
         with patch("shutil.rmtree"), patch("os.unlink"):
@@ -380,12 +407,13 @@ class TestClient:
             "test_data": {"test_cmds": "foo"},
         }
         requests_mock.get(
-            f"http://127.0.0.1:8000/v1/agents/data/{self.config['agent_id']}",
-            json={"restricted_to": {}},
-        )
-        requests_mock.get(
-            "http://127.0.0.1:8000/v1/job?queue=test",
+            re.compile(r".*/(?!v1/agents/data/\w+$).*"),
             [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
+        )
+        # For mocking, we can simplify the agent state by setting as waiting
+        requests_mock.get(
+            re.compile(r"/v1/agents/data/\w+"),
+            text=json.dumps({"state": "waiting", "restricted_to": {}}),
         )
         requests_mock.post(rmock.ANY, status_code=200)
         with patch("shutil.rmtree"), patch("os.unlink"):
@@ -408,16 +436,17 @@ class TestClient:
         mock_job_data = {"job_id": str(uuid.uuid1()), "job_queue": "test"}
         # Send an extra empty data since we will be calling get 3 times
         requests_mock.get(
-            "http://127.0.0.1:8000/v1/job?queue=test",
+            re.compile(r".*/(?!v1/agents/data/\w+$).*"),
             [
                 {"text": json.dumps(mock_job_data)},
                 {"text": "{}"},
                 {"text": "{}"},
             ],
         )
+        # For mocking, we can simplify the agent state by setting as waiting
         requests_mock.get(
-            f"http://127.0.0.1:8000/v1/agents/data/{self.config['agent_id']}",
-            json={"restricted_to": {}},
+            re.compile(r"/v1/agents/data/\w+"),
+            text=json.dumps({"state": "waiting", "restricted_to": {}}),
         )
         requests_mock.post(rmock.ANY, status_code=200)
         with patch.object(
@@ -440,9 +469,6 @@ class TestClient:
 
     def test_recovery_failed(self, agent, requests_mock):
         # Make sure we stop processing jobs after a device recovery error
-        offline_file = "/tmp/TESTFLINGER-DEVICE-OFFLINE-test001"
-        if os.path.exists(offline_file):
-            os.unlink(offline_file)
         self.config["agent_id"] = "test001"
         self.config["provision_command"] = "bash -c 'exit 46'"
         self.config["test_command"] = "echo test1"
@@ -471,14 +497,18 @@ class TestClient:
                 text="OK",
             )
             m.get(
-                "http://127.0.0.1:8000/v1/agents/data/test001",
-                json={"restricted_to": {}},
+                "http://127.0.0.1:8000/v1/agents/data/"
+                + self.config.get("agent_id"),
+                [
+                    {"text": json.dumps({"state": "waiting",
+                                          "restricted_to": {}})},
+                    {"text": json.dumps({"state": "offline",
+                                         "restricted_to": {}})},
+                ],
             )
 
             agent.process_jobs()
             assert agent.check_offline()
-        if os.path.exists(offline_file):
-            os.unlink(offline_file)
 
     def test_post_agent_data(self, agent):
         # Make sure we post the initial agent data

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -469,7 +469,6 @@ class TestClient:
 
     def test_recovery_failed(self, agent, requests_mock):
         # Make sure we stop processing jobs after a device recovery error
-        self.config["agent_id"] = "test001"
         self.config["provision_command"] = "bash -c 'exit 46'"
         self.config["test_command"] = "echo test1"
         job_id = str(uuid.uuid1())

--- a/agent/tests/test_agent_process.py
+++ b/agent/tests/test_agent_process.py
@@ -44,7 +44,6 @@ def test_restart_signal_handler(tmp_path):
         os.kill(agent_process.pid, signal.SIGUSR1)
         time.sleep(1)
 
-        assert os.path.exists("/tmp/TESTFLINGER-DEVICE-RESTART-test-agent-1")
         assert (
             "Marked agent for restart" in agent_process.stderr.read().decode()
         )


### PR DESCRIPTION
## Description
The purpose of this PR is to improve the status handling for an agent. This is being done by removing the necessity of the creation/deletion of temporary files that can only be available by accessing the agent Charm Unit. 

The agent will now be able to get its state directly by querying the MongoDB by using server recent endpoint addition `GET /agents/data/<agent_name>` and process jobs depending on the state retrieved. 

Non breaking changes are introduced to perform the follows:
1. Whenever setting an agent state, the reason for the state is displayed in the UI. 
2. Agent is now able to detect if state is either `offline` or `maintenance` directly from the DB, in any case, the agent will stop looking for available jobs. 
3. Restart is also handled directly by temporarily setting a `restart` status on the agent. 
4. If at any point an offline/restart is detected, the new AgentStatusHandler will be able to carry over the reason for the offline/restart and only perform the action after the agent is not processing any job. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-645](https://warthogs.atlassian.net/browse/CERTTF-645)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
Documention needs to be updated to reflect how the agent is set to offline/restart/online, however, I'm making those modification once I completed the PR for the CLI changes. 
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
This was tested and validated in Staging

Agent Offline:
![Screenshot from 2025-06-17 14-44-28](https://github.com/user-attachments/assets/12a048df-5092-40ed-8c67-26e8c0b7bb68)

Attempting to submit job
```
testflinger-cli --server=https://testflinger-staging.canonical.com submit -p ~/Desktop/staging.yaml
ERROR: No online agents available for queue 202409-35503. If you want to wait for agents to become available, use the --wait-for-available-agents option.
```

If at any point the restart is detected, a note will be shown with the current phase state:
![Screenshot from 2025-06-17 15-02-14](https://github.com/user-attachments/assets/6c579a22-a247-47bd-a01c-c9be3f23409f)

Agent will continue processing the job and restart only when its safe to do so:
```
[25-06-17 20:48:50]    INFO: (agent.py:259)| Starting job 0268999f-01b0-4512-8736-b02a2312a8c0
[25-06-17 20:48:52]    INFO: (job.py:87)| Running setup_command: tf-setup
[25-06-17 20:49:07]    INFO: (job.py:87)| Running provision_command: tf-provision
[25-06-17 21:01:51]    INFO: (job.py:64)| No firmware_update_command configured, skipping...
[25-06-17 21:01:51]    INFO: (job.py:87)| Running test_command: tf-test
[25-06-17 21:04:34]    INFO: (job.py:74)| No allocate_data defined in job data, skipping...
[25-06-17 21:04:36]    INFO: (job.py:87)| Running reserve_command: tf-reserve
[25-06-17 21:05:33]    INFO: (job.py:87)| Running cleanup_command: tf-cleanup
[25-06-17 21:05:49]    INFO: (client.py:252)| Submitting job outcome for job: 0268999f-01b0-4512-8736-b02a2312a8c0
[25-06-17 21:05:50]    INFO: (agent.py:186)| Restarting agent
[25-06-17 21:05:53]   ERROR: (client.py:73)| InfluxDB host undefined
[25-06-17 21:05:53]    INFO: (__init__.py:138)| Checking jobs
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-645]: https://warthogs.atlassian.net/browse/CERTTF-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ