### PR TITLE
feat: Add a yaml option to the show subcommand

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -325,6 +325,11 @@ class TestflingerCli:
         parser.add_argument("job_id").completer = partial(
             autocomplete.job_ids_completer, history=self.history
         )
+        parser.add_argument(
+            "--yaml",
+            action="store_true",
+            help="Print the job as a YAML document instead of a json object",
+        )
 
     def _add_submit_args(self, subparsers):
         """Command line arguments for submit."""
@@ -832,7 +837,13 @@ class TestflingerCli:
                 exc.status,
             )
             sys.exit(1)
-        print(json.dumps(results, sort_keys=True, indent=4))
+        if self.args.yaml:
+            to_print = yaml.dump(
+                results, sort_keys=True, indent=4, default_style="|"
+            )
+        else:
+            to_print = json.dumps(results, sort_keys=True, indent=4)
+        print(to_print)
 
     def results(self):
         """Get results JSON for a completed JOB_ID."""

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -328,7 +328,7 @@ class TestflingerCli:
         parser.add_argument(
             "--yaml",
             action="store_true",
-            help="Print the job as a YAML document instead of a json object",
+            help="Print the job as a YAML document instead of a JSON object",
         )
 
     def _add_submit_args(self, subparsers):
@@ -838,8 +838,8 @@ class TestflingerCli:
             )
             sys.exit(1)
         if self.args.yaml:
-            to_print = yaml.dump(
-                results, sort_keys=True, indent=4, default_style="|"
+            to_print = helpers.pretty_yaml_dump(
+                results, sort_keys=True, indent=4
             )
         else:
             to_print = json.dumps(results, sort_keys=True, indent=4)

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -153,6 +153,6 @@ def pretty_yaml_dump(obj, **kwargs) -> str:
             )
         return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
-    # dublicated calls to this are no-op
+    # duplicated calls to this are no-op
     yaml.add_representer(str, multiline_str_representer)
     return yaml.dump(obj, **kwargs)

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2025 Canonical Ltd.
 """Helpers for the Testflinger CLI."""
-import yaml
 
 from os import getenv
 from pathlib import Path
 from typing import Optional
+
+import yaml
 
 from testflinger_cli.consts import SNAP_NAME, SNAP_PRIVATE_DIRS
 from testflinger_cli.errors import SnapPrivateFileError
@@ -134,12 +135,11 @@ def prompt_for_queue(queues: dict[str, str]) -> str:
 
 
 def pretty_yaml_dump(obj, **kwargs) -> str:
-    """Creates a pretty YAML representation of obj
+    """Create a pretty YAML representation of obj.
 
-    :param obj: The object to be represented
-    :return: A pretty representation of obj as a YAML string
+    :param obj: The object to be represented.
+    :return: A pretty representation of obj as a YAML string.
     """
-    assert "default_style" not in kwargs, "Style is imposed by the this dumper"
 
     # objective is to get multiline strings as blocks leaving any other string
     # unchanged

--- a/cli/testflinger_cli/tests/test_cli.py
+++ b/cli/testflinger_cli/tests/test_cli.py
@@ -566,6 +566,18 @@ def test_show(capsys, requests_mock):
     assert "completed" in std.out
 
 
+def test_show_yaml(capsys, requests_mock):
+    """Exercise show command."""
+    jobid = str(uuid.uuid1())
+    fake_return = {"job_state": "completed"}
+    requests_mock.get(URL + "/v1/job/" + jobid, json=fake_return)
+    sys.argv = ["", "show", jobid, "--yaml"]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.show()
+    std = capsys.readouterr()
+    assert "completed" in std.out
+
+
 def test_results(capsys, requests_mock):
     """Results should report job_state data."""
     jobid = str(uuid.uuid1())

--- a/cli/testflinger_cli/tests/test_helpers.py
+++ b/cli/testflinger_cli/tests/test_helpers.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Canonical Ltd.
 """Tests for the helpers of Testflinger CLI."""
 
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from testflinger_cli.helpers import (
     file_is_in_snap_private_dir,
     is_snap,
     parse_filename,
+    pretty_yaml_dump,
 )
 
 
@@ -50,3 +52,19 @@ def test_parse_filename_snap_private(monkeypatch):
 def test_parse_filename_stdin():
     """Test the parse_filename function with stdin."""
     assert parse_filename("-", parse_stdin=True) is None
+
+
+def test_pretty_yaml_dump():
+    """Test pretty yaml dumper dumps single/multi line strings correctly."""
+    single_line = {"a": "some"}
+    assert pretty_yaml_dump(single_line).strip() == "a: some"
+
+    multiline = {"a": "some\nother"}
+    result = textwrap.dedent(
+        """
+        a: |-
+            some
+            other
+        """
+    ).strip()
+    assert pretty_yaml_dump(multiline, indent=4).strip() == result


### PR DESCRIPTION
## Description

When iterating on a job, it is often useful to show it (via show) and modify it. This is a bit cumbersome because the command outputs json by default. Editing the `test_cmds` as a string blob is hard. It is easier if they are in a yaml with multiline strings.

To get it, one has to pipe through yq to make it yaml and pretty print with an external tool because multiline strings are not formatted as a block from `yq -P` (they call this a feature, idk).

This adds a `--yaml` option to show that outputs the job formatted with multiline strings as blocks, making the task trivial

## Resolved issues

N/A

## Documentation

This also adds a help message to explain what the option does

## Web service API changes

N/A

## Tests

This adds a test to ensure that the api doesn't change on yaml.dumps

Tested this locally with the following job id: 
```
$ uv run testflinger-cli show ad6b7cc3-c888-49a3-8d6f-94bc158771eb > old_result.json
$ uv run testflinger-cli show ad6b7cc3-c888-49a3-8d6f-94bc158771eb --yaml > new_result.yaml
```

I've also tried to re-submit the yaml to see if it still works and it submitted correctly
