### PR TITLE
feat: add restricted_to field to /agents/data API

### DIFF
--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -66,6 +66,7 @@ class AgentOut(Schema):
     provision_type = fields.String(required=False)
     job_id = fields.String(required=False)
     comment = fields.String(required=False)
+    restricted_to = fields.Dict(required=False)
 
 
 class ActionIn(Schema):

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -646,10 +646,10 @@ def agents_get_all():
 
     for agent in agents:
         agent["restricted_to"] = {
-            queue: restricted_queues_owners.get(queue, [])
-            if queue in restricted_queues
-            else []
+            queue: restricted_queues_owners[queue]
             for queue in agent.get("queues", [])
+            if queue in restricted_queues
+            and restricted_queues_owners.get(queue)
         }
 
     return jsonify(agents)

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -670,6 +670,16 @@ def agents_get_one(agent_name):
     if not agent_data:
         return {}, HTTPStatus.NOT_FOUND
 
+    restricted_queues = database.get_restricted_queues()
+    restricted_queues_owners = database.get_restricted_queues_owners()
+
+    agent_data["restricted_to"] = {
+        queue: restricted_queues_owners[queue]
+        for queue in agent_data.get("queues", [])
+        if queue in restricted_queues
+        and restricted_queues_owners.get(queue)
+    }
+
     return jsonify(agent_data)
 
 

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -676,8 +676,7 @@ def agents_get_one(agent_name):
     agent_data["restricted_to"] = {
         queue: restricted_queues_owners[queue]
         for queue in agent_data.get("queues", [])
-        if queue in restricted_queues
-        and restricted_queues_owners.get(queue)
+        if queue in restricted_queues and restricted_queues_owners.get(queue)
     }
 
     return jsonify(agent_data)

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -640,14 +640,18 @@ def images_post():
 @v1.output(schemas.AgentOut(many=True))
 def agents_get_all():
     """Get all agent data."""
-    agents = list(database.mongo.db.agents.find({}, {"_id": False, "log": False}))
+    agents = list(
+        database.mongo.db.agents.find({}, {"_id": False, "log": False})
+    )
 
     restricted_queues = database.get_restricted_queues()
     client_permissions = database.get_client_permissions()
 
     for agent in agents:
         agent["restricted_to"] = {
-            queue: client_permissions.get(queue, []) if queue in restricted_queues else []
+            queue: client_permissions.get(queue, [])
+            if queue in restricted_queues
+            else []
             for queue in agent.get("queues", [])
         }
 

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -640,16 +640,13 @@ def images_post():
 @v1.output(schemas.AgentOut(many=True))
 def agents_get_all():
     """Get all agent data."""
-    agents = list(
-        database.mongo.db.agents.find({}, {"_id": False, "log": False})
-    )
-
+    agents = database.get_agents()
     restricted_queues = database.get_restricted_queues()
-    client_permissions = database.get_client_permissions()
+    restricted_queues_owners = database.get_restricted_queues_owners()
 
     for agent in agents:
         agent["restricted_to"] = {
-            queue: client_permissions.get(queue, [])
+            queue: restricted_queues_owners.get(queue, [])
             if queue in restricted_queues
             else []
             for queue in agent.get("queues", [])

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -368,7 +368,7 @@ def queue_exists(queue: str) -> bool:
 def get_restricted_queues():
     """Return a set of all restricted queues."""
     docs = mongo.db.restricted_queues.find({}, {"queue_name": 1})
-    return set(doc["queue_name"] for doc in docs)
+    return {doc["queue_name"] for doc in docs}
 
 
 def get_client_permissions():

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -363,3 +363,18 @@ def queue_exists(queue: str) -> bool:
     :return: True if exists, False otherwise
     """
     return mongo.db.agents.find_one({"queues": queue}) is not None
+
+def get_restricted_queues():
+    """Return a set of all restricted queues."""
+    docs = mongo.db.restricted_queues.find({}, {"queue_name": 1})
+    return set(doc["queue_name"] for doc in docs)
+
+def get_client_permissions():
+    """Return a mapping of restricted queues and its permitted client IDs."""
+    docs = mongo.db.client_permissions.find({}, {"allowed_queues": 1, "client_id": 1})
+    queue_to_clients = {}
+    for doc in docs:
+        client_id = doc["client_id"]
+        for queue_name in doc.get("allowed_queues", []):
+            queue_to_clients.setdefault(queue_name, []).append(client_id)
+    return queue_to_clients

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -365,13 +365,13 @@ def queue_exists(queue: str) -> bool:
     return mongo.db.agents.find_one({"queues": queue}) is not None
 
 
-def get_restricted_queues():
+def get_restricted_queues() -> set[str]:
     """Return a set of all restricted queues."""
-    docs = mongo.db.restricted_queues.find({}, {"queue_name": 1})
-    return {doc["queue_name"] for doc in docs}
+    restricted_queues = mongo.db.restricted_queues.distinct("queue_name")
+    return set(restricted_queues)
 
 
-def get_client_permissions():
+def get_restricted_queues_owners() -> dict[str, list[str]]:
     """Return a mapping of restricted queues and its permitted client IDs."""
     docs = mongo.db.client_permissions.find(
         {}, {"allowed_queues": 1, "client_id": 1}
@@ -382,3 +382,9 @@ def get_client_permissions():
         for queue_name in doc.get("allowed_queues", []):
             queue_to_clients.setdefault(queue_name, []).append(client_id)
     return queue_to_clients
+
+
+def get_agents() -> list[dict]:
+    """Return a list of all agents."""
+    agents = mongo.db.agents.find({}, {"_id": False, "log": False})
+    return list(agents)

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -364,14 +364,18 @@ def queue_exists(queue: str) -> bool:
     """
     return mongo.db.agents.find_one({"queues": queue}) is not None
 
+
 def get_restricted_queues():
     """Return a set of all restricted queues."""
     docs = mongo.db.restricted_queues.find({}, {"queue_name": 1})
     return set(doc["queue_name"] for doc in docs)
 
+
 def get_client_permissions():
     """Return a mapping of restricted queues and its permitted client IDs."""
-    docs = mongo.db.client_permissions.find({}, {"allowed_queues": 1, "client_id": 1})
+    docs = mongo.db.client_permissions.find(
+        {}, {"allowed_queues": 1, "client_id": 1}
+    )
     queue_to_clients = {}
     for doc in docs:
         client_id = doc["client_id"]

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -1193,7 +1193,6 @@ def test_agents_data_restricted_to(mongo_app):
     result = output.json[0]
     expected_restricted_to = {
         "q1": ["test-client-id"],
-        "q2": [],
     }
     assert result["restricted_to"] == expected_restricted_to
 

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -1168,14 +1168,14 @@ def test_serial_output(mongo_app):
 def test_agents_data_restricted_to(mongo_app):
     """Test restricted_to field in agents data."""
     app, mongo = mongo_app
-    mongo.restricted_queues.insert_one(
-        {"queue_name": "q1"}
-    )
+    mongo.restricted_queues.insert_one({"queue_name": "q1"})
 
-    mongo.client_permissions.insert_one({
-        "client_id": "test-client-id",
-        "allowed_queues": ["q1"],
-    })
+    mongo.client_permissions.insert_one(
+        {
+            "client_id": "test-client-id",
+            "allowed_queues": ["q1"],
+        }
+    )
 
     agent_name = "agent1"
     agent_data = {

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -1165,6 +1165,39 @@ def test_serial_output(mongo_app):
     assert empty_output.text == ""
 
 
+def test_agents_data_restricted_to(mongo_app):
+    """Test restricted_to field in agents data."""
+    app, mongo = mongo_app
+    mongo.restricted_queues.insert_one(
+        {"queue_name": "q1"}
+    )
+
+    mongo.client_permissions.insert_one({
+        "client_id": "test-client-id",
+        "allowed_queues": ["q1"],
+    })
+
+    agent_name = "agent1"
+    agent_data = {
+        "state": "provision",
+        "queues": ["q1", "q2"],
+        "location": "here",
+    }
+
+    output = app.post(f"/v1/agents/data/{agent_name}", json=agent_data)
+    assert output.status_code == HTTPStatus.OK
+
+    output = app.get("/v1/agents/data")
+    assert output.status_code == HTTPStatus.OK
+
+    result = output.json[0]
+    expected_restricted_to = {
+        "q1": ["test-client-id"],
+        "q2": [],
+    }
+    assert result["restricted_to"] == expected_restricted_to
+
+
 def test_result_post_large_payload(mongo_app):
     """Test that posting a result with a payload size of 16MB or more fails."""
     app, _ = mongo_app


### PR DESCRIPTION
## Description

This PR adds a new `restricted_to` field in the `/agents/data` API response,  
which reflects the current queue restriction status for each agent.

Currently, queue restriction info is stored in:
- `restricted_queues` collection: defines which queues are restricted.
- `client_permissions` collection: defines which clients can access restricted queues.

The `agents` collection only holds the list of queues for each agent,  
but there was no way to expose the restriction info to users.

With this changes, each agent's response will now include:

```json
"restricted_to": {
  "q1": ["client-id-1", "client-id-2"],
  "q2": [],
  "q3": []
}
```

## Resolved issues

Resolves [LM-1934](https://warthogs.atlassian.net/browse/LM-1934)

## Documentation

## Web service API changes

## Tests
Added test cases and passed the tests:
```
root@86a8e1f31553:/srv/testflinger# python -m pytest tests/test_v1.py::test_agents_data_restricted_to -v
================================================================= test session starts ==================================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /srv/testflinger/.venv/bin/python
cachedir: .pytest_cache
rootdir: /srv/testflinger
configfile: pyproject.toml
plugins: cov-6.1.1, requests-mock-1.12.1, anyio-4.9.0
collected 1 item                                                                                                                                       

tests/test_v1.py::test_agents_data_restricted_to PASSED                                                                                          [100%]

=================================================================== warnings summary ===================================================================
.venv/lib/python3.10/site-packages/marshmallow/fields.py:1218
  /srv/testflinger/.venv/lib/python3.10/site-packages/marshmallow/fields.py:1218: RemovedInMarshmallow4Warning: The 'default' argument to fields is deprecated. Use 'dump_default' instead.
    super().__init__(**kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================= 1 passed, 1 warning in 0.03s =========================================================
```
Tested response of `http://0.0.0.0:5000/v1/agents/data` in local env:
```
[
  {
    "name": "agent0",
    "queues": [
      "test_queue3"
    ],
    "state": "provision",
    "updated_at": {
      "$date": "2025-06-18T14:43:32.505Z"
    },
    "provision_streak_count": 1,
    "provision_streak_type": "pass",
    "restricted_to": {
      "test_queue3": []
    }
  },
...
```


[LM-1934]: https://warthogs.atlassian.net/browse/LM-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ