### PR TITLE
fix: add attachments to oem autoinstall schema

### DIFF
--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -138,6 +138,7 @@ class OEMAutoinstallProvisionData(Schema):
     """Schema for the `provision_data` section of a OEM Autoinstall job."""
 
     url = fields.URL(required=True)
+    attachments = fields.List(fields.Nested(Attachment), required=False)
     token_file = fields.String(required=False)
     user_data = fields.String(required=False)
     redeploy_cfg = fields.String(required=False)

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -252,7 +252,17 @@ def test_add_job_oem_autoinstall_provision_data(mongo_app):
     app, _ = mongo_app
     output = app.post("/v1/job", json=job_data)
     assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
-    # Valid URL fails
+    # Attachments works
+    provision_data = {
+        "url": "http://example.com/image.img.xz",
+        "token_file": "file",
+        "attachments": [{"agent": "filename"}],
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+    # Valid URL works
     provision_data = {
         "url": "http://example.com/image.img.xz",
         "token_file": "file",


### PR DESCRIPTION
## Description

Adds `attachments` to the `oem_autoinstall` provision data schema.

## Resolved issues

## Documentation

## Web service API changes

## Tests

Added unit test to ensure this field is tested on the schema