### PR TITLE
Fix: encoded user data should be a str

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -77,7 +77,7 @@ class DeviceConnector(ZapperConnector):
                 Path(__file__).parent / "../../data/zapper_kvm/user-data-oem"
             )
             user_data = user_data_oem.read_text(encoding="utf-8")
-            encoded_user_data = base64.b64encode(user_data.encode())
+            encoded_user_data = base64.b64encode(user_data.encode()).decode()
 
             user_data = yaml.safe_load(user_data)
             storage = user_data["autoinstall"]["storage"]["layout"]["name"]

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -288,7 +288,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         expected = {
             "storage_layout": "direct",
             "authorized_keys": ["mykey"],
-            "base_user_data": encoded_user_data,
+            "base_user_data": encoded_user_data.decode(),
         }
         self.assertDictEqual(conf, expected)
 

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -186,7 +186,7 @@ class ZapperKVMAutoinstallProvisionData(BaseZapperProvisionData):
 
     url = fields.URL(required=True)
     robot_tasks = fields.List(fields.String(), required=True)
-    autoinstall_storage_layout = fields.String(required=True)
+    autoinstall_storage_layout = fields.String(required=False)
     ubuntu_sso_email = fields.Email(required=False)
     autoinstall_base_user_data = fields.String(required=False)
     autoinstall_oem = fields.Boolean(required=False)


### PR DESCRIPTION
## Description

After encoding bytes to b64, the expectation was to move around a str, not bytes again (which is the return type of `b64encode` for some reason).

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

Tested locally with
```
# job.json
{
    "provision_data": {
      "url": "<tel-cache-iso>",
      "robot_tasks": [
        "hp/Z2/G9/secure_boot/disable.robot",
        "hp/Z2/G9/boot/boot_from_usb.robot",
        "common/grub/autoinstall/http/configure_autoinstall_http.robot",
        "hp/boot/wait_reboot.robot"
        ],
      "autoinstall_oem": true
    }
}

```
