### PR TITLE
Change: pass part of TF configuration to provision API

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -92,6 +92,15 @@ class ZapperConnector(ABC, DefaultDevice):
             },
         )
 
+        kwargs.update(
+            {
+                "agent_name": self.config["agent_name"],
+                "cid": self.config["env"].get("CID"),
+                "device_ip": self.config["device_ip"],
+                "reboot_script": self.config["reboot_script"],
+            }
+        )
+
         connection.root.provision(
             self.PROVISION_METHOD,
             *args,

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -44,11 +44,22 @@ class ZapperConnectorTests(unittest.TestCase):
         args = (1, 2, 3)
         kwargs = {"key1": 1, "key2": 2}
 
-        fake_config = {"device_ip": "1.1.1.1"}
+        fake_config = {
+            "device_ip": "1.1.1.1",
+            "agent_name": "my-agent",
+            "reboot_script": ["cmd1", "cmd2"],
+            "env": {"CID": "202507-01234"},
+        }
         connector = MockConnector(fake_config)
         connector._run("localhost", *args, **kwargs)
 
         api = mock_connect.return_value.root.provision
+
+        kwargs["device_ip"] = "1.1.1.1"
+        kwargs["agent_name"] = "my-agent"
+        kwargs["reboot_script"] = ["cmd1", "cmd2"]
+        kwargs["cid"] = "202507-01234"
+
         api.assert_called_with(
             MockConnector.PROVISION_METHOD,
             *args,

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -53,8 +53,6 @@ class DeviceConnector(ZapperConnector):
             "username": username if not ubuntu_sso_email else ubuntu_sso_email,
             "password": password,
             "preset": self.job_data["provision_data"].get("preset"),
-            "reboot_script": self.config["reboot_script"],
-            "device_ip": self.config["device_ip"],
         }
 
         provision_plan = self.job_data["provision_data"].get("provision_plan")

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -12,11 +12,7 @@ class ZapperIoTTests(unittest.TestCase):
         """Test the function creates a proper provision_data
         dictionary when valid data are provided.
         """
-        fake_config = {
-            "device_ip": "1.1.1.1",
-            "reboot_script": ["cmd1", "cmd2"],
-        }
-        device = DeviceConnector(fake_config)
+        device = DeviceConnector({})
         device.job_data = {
             "provision_data": {
                 "preset": "TestPreset",
@@ -30,8 +26,6 @@ class ZapperIoTTests(unittest.TestCase):
             "username": "ubuntu",
             "password": "ubuntu",
             "preset": "TestPreset",
-            "reboot_script": ["cmd1", "cmd2"],
-            "device_ip": "1.1.1.1",
             "urls": ["http://test.tar.gz"],
         }
 
@@ -40,11 +34,7 @@ class ZapperIoTTests(unittest.TestCase):
 
     def test_validate_configuration_ubuntu_sso_email(self):
         """Test the function username will be ubuntu_sso_email if provided."""
-        fake_config = {
-            "device_ip": "1.1.1.1",
-            "reboot_script": ["cmd1", "cmd2"],
-        }
-        device = DeviceConnector(fake_config)
+        device = DeviceConnector({})
         device.job_data = {
             "provision_data": {
                 "ubuntu_sso_email": "test@example.com",
@@ -59,8 +49,6 @@ class ZapperIoTTests(unittest.TestCase):
             "username": "test@example.com",
             "password": "ubuntu",
             "preset": "TestPreset",
-            "reboot_script": ["cmd1", "cmd2"],
-            "device_ip": "1.1.1.1",
             "urls": ["http://test.tar.gz"],
         }
 
@@ -71,11 +59,7 @@ class ZapperIoTTests(unittest.TestCase):
         """Test the function validates a custom test plan
         when provided.
         """
-        fake_config = {
-            "device_ip": "1.1.1.1",
-            "reboot_script": ["cmd1", "cmd2"],
-        }
-        device = DeviceConnector(fake_config)
+        device = DeviceConnector({})
         device.job_data = {
             "provision_data": {
                 "provision_plan": {
@@ -117,8 +101,6 @@ class ZapperIoTTests(unittest.TestCase):
                 ],
             },
             "urls": [],
-            "reboot_script": ["cmd1", "cmd2"],
-            "device_ip": "1.1.1.1",
             "preset": None,
         }
         self.maxDiff = None
@@ -130,11 +112,7 @@ class ZapperIoTTests(unittest.TestCase):
         when provided and an ubuntu_sso_email is provided.
         The username should be overridden with the ubuntu_sso_email.
         """
-        fake_config = {
-            "device_ip": "1.1.1.1",
-            "reboot_script": ["cmd1", "cmd2"],
-        }
-        device = DeviceConnector(fake_config)
+        device = DeviceConnector({})
         device.job_data = {
             "provision_data": {
                 "ubuntu_sso_email": "test@example.com",
@@ -175,8 +153,6 @@ class ZapperIoTTests(unittest.TestCase):
                 ],
             },
             "urls": [],
-            "reboot_script": ["cmd1", "cmd2"],
-            "device_ip": "1.1.1.1",
             "preset": None,
         }
         self.maxDiff = None

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -139,8 +139,6 @@ class DeviceConnector(ZapperConnector):
             "password": password,
             "robot_retries": retries,
             "autoinstall_conf": self._get_autoinstall_conf(),
-            "reboot_script": self.config["reboot_script"],
-            "device_ip": self.config["device_ip"],
             "robot_tasks": self.job_data["provision_data"]["robot_tasks"],
         }
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -33,12 +33,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         the expected data merging the relevant bits from conf and job
         data when passing only the required arguments.
         """
-        fake_config = {
-            "device_ip": "1.1.1.1",
-            "control_host": "1.1.1.2",
-            "reboot_script": ["cmd1", "cmd2"],
-        }
-        connector = DeviceConnector(fake_config)
+        connector = DeviceConnector({})
         connector.job_data = {
             "job_queue": "queue",
             "provision_data": {
@@ -58,8 +53,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "username": "ubuntu",
             "password": "ubuntu",
             "autoinstall_conf": connector._get_autoinstall_conf.return_value,
-            "reboot_script": ["cmd1", "cmd2"],
-            "device_ip": "1.1.1.1",
             "robot_tasks": ["job.robot", "another.robot"],
             "robot_retries": 1,
         }
@@ -71,12 +64,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         the expected data merging the relevant bits from conf and job
         data when passing all the optional arguments.
         """
-        fake_config = {
-            "device_ip": "1.1.1.1",
-            "control_host": "1.1.1.2",
-            "reboot_script": ["cmd1", "cmd2"],
-        }
-        connector = DeviceConnector(fake_config)
+        connector = DeviceConnector({})
         connector.job_data = {
             "job_queue": "queue",
             "provision_data": {
@@ -107,8 +95,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "username": "username",
             "password": "password",
             "autoinstall_conf": connector._get_autoinstall_conf.return_value,
-            "reboot_script": ["cmd1", "cmd2"],
-            "device_ip": "1.1.1.1",
             "robot_tasks": ["job.robot", "another.robot"],
             "robot_retries": 3,
             "cmdline_append": "more arguments",
@@ -127,12 +113,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         password are hardcoded and the Zapper shall try the procedures
         at least twice because it can fail on purpose.
         """
-        fake_config = {
-            "device_ip": "1.1.1.1",
-            "control_host": "1.1.1.2",
-            "reboot_script": ["cmd1", "cmd2"],
-        }
-        connector = DeviceConnector(fake_config)
+        connector = DeviceConnector({})
         connector.job_data = {
             "job_queue": "queue",
             "provision_data": {
@@ -158,8 +139,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "username": "ubuntu",
             "password": "u",
             "autoinstall_conf": connector._get_autoinstall_conf.return_value,
-            "reboot_script": ["cmd1", "cmd2"],
-            "device_ip": "1.1.1.1",
             "robot_tasks": ["job.robot", "another.robot"],
             "robot_retries": 2,
         }


### PR DESCRIPTION
## Description

The agent name is quite useful on the service side, independently  from the selected method. This API moves part of the arguments definition to the base class, also adding "agent-name" and "cid" to the mix.

## Resolved issues

Part of [ZAP-1235](https://warthogs.atlassian.net/browse/ZAP-1235)

## Documentation

N/A

## Web service API changes

N/A

## Tests

There's nothing on the service side making use of these values yet. Only tested with unit tests.
