### PR TITLE
Add: preset kwargs to let the user add machine-level customization

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -53,6 +53,9 @@ class DeviceConnector(ZapperConnector):
             "username": username if not ubuntu_sso_email else ubuntu_sso_email,
             "password": password,
             "preset": self.job_data["provision_data"].get("preset"),
+            "preset_kwargs": self.job_data["provision_data"].get(
+                "preset_kwargs"
+            ),
         }
 
         provision_plan = self.job_data["provision_data"].get("provision_plan")

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -16,6 +16,7 @@ class ZapperIoTTests(unittest.TestCase):
         device.job_data = {
             "provision_data": {
                 "preset": "TestPreset",
+                "preset_kwargs": {"arg1": "value1"},
                 "urls": ["http://test.tar.gz"],
             }
         }
@@ -26,6 +27,7 @@ class ZapperIoTTests(unittest.TestCase):
             "username": "ubuntu",
             "password": "ubuntu",
             "preset": "TestPreset",
+            "preset_kwargs": {"arg1": "value1"},
             "urls": ["http://test.tar.gz"],
         }
 
@@ -49,6 +51,7 @@ class ZapperIoTTests(unittest.TestCase):
             "username": "test@example.com",
             "password": "ubuntu",
             "preset": "TestPreset",
+            "preset_kwargs": None,
             "urls": ["http://test.tar.gz"],
         }
 
@@ -102,6 +105,7 @@ class ZapperIoTTests(unittest.TestCase):
             },
             "urls": [],
             "preset": None,
+            "preset_kwargs": None,
         }
         self.maxDiff = None
         self.assertEqual(args, ())
@@ -154,6 +158,7 @@ class ZapperIoTTests(unittest.TestCase):
             },
             "urls": [],
             "preset": None,
+            "preset_kwargs": None,
         }
         self.maxDiff = None
         self.assertEqual(args, ())

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -167,6 +167,7 @@ class ZapperIoTPresetProvisionData(BaseZapperProvisionData):
 
     urls = fields.List(fields.URL(), required=True, validate=Length(min=1))
     preset = fields.String(required=True)
+    preset_kwargs = fields.Dict(required=False)
 
 
 class ZapperIoTCustomProvisionData(BaseZapperProvisionData):


### PR DESCRIPTION
## Description

A `preset` might not be enough, there are details that are machine-specific, like the ethernet MAC address, or the dtbo to load. This kwargs will let the user provide preset-specific keyword arguments.

## Resolved issues

Part of [ZAP-1239](https://warthogs.atlassian.net/browse/ZAP-1239)

## Documentation

Addressed on the service side.

## Web service API changes

N/A

## Tests

Updated unit tests.


[ZAP-1239]: https://warthogs.atlassian.net/browse/ZAP-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ