### PR TITLE
ci: add coverage export and upload to codecov

### DIFF
--- a/.github/workflows/agent-host-charm-release.yml
+++ b/.github/workflows/agent-host-charm-release.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   agent-build-and-push-charm:
+    name: Build and Push Charm
     runs-on: [self-hosted, linux, jammy, X64]
     permissions:
       actions: read

--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -37,6 +37,12 @@ jobs:
         run: uvx --with tox-uv tox -e lint
       - name: Run unit tests
         run: uvx --with tox-uv tox -e unit
+      - name: Upload coverage
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          files: coverage.xml
+          flags: agent
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test_charm:
     name: Run charm tests

--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build-testflinger-testenv:
+    name: Build testflinger-testenv
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -1,4 +1,4 @@
-name: Publish Testflinger CLI Snap
+name: Build Testflinger CLI
 permissions:
   contents: read
 on:
@@ -28,7 +28,8 @@ on:
           - edge
 
 jobs:
-  build:
+  snap:
+    name: Snap
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -35,3 +35,9 @@ jobs:
         run: uvx --with tox-uv tox -e lint
       - name: Run unit tests
         run: uvx --with tox-uv tox -e unit
+      - name: Upload coverage
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          files: coverage.xml
+          flags: cli
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/device-tox.yml
+++ b/.github/workflows/device-tox.yml
@@ -35,3 +35,9 @@ jobs:
         run: uvx --with tox-uv tox -e lint
       - name: Run unit tests
         run: uvx --with tox-uv tox -e unit
+      - name: Upload coverage
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          files: coverage.xml
+          flags: device
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/server-charm-release.yml
+++ b/.github/workflows/server-charm-release.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build-and-push-charm:
+    name: Build and Push Charm
     runs-on: [self-hosted, linux, jammy, X64]
     permissions:
       actions: read

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -35,6 +35,12 @@ jobs:
         run: uvx --with tox-uv tox -e lint
       - name: Run unit tests
         run: uvx --with tox-uv tox -e unit
+      - name: Upload coverage
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          files: coverage.xml
+          flags: server
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test_charm:
     name: Run charm tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Testflinger
 
 [![Documentation status][rtd-badge]][rtd-latest]
+[![codecov][cov-badge]][cov-latest]
 
 **Testflinger** is a system for orchestrating the time-sharing of access to a
 pool of target machines.
@@ -62,6 +63,8 @@ If you're interested, start with the [contribution guide](CONTRIBUTING.md).
 
 [rtd-badge]: https://readthedocs.com/projects/canonical-testflinger/badge/?version=latest
 [rtd-latest]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/
+[cov-badge]: https://codecov.io/gh/canonical/testflinger/graph/badge.svg?token=G8Y0VF2CEY
+[cov-latest]: https://codecov.io/gh/canonical/testflinger
 [github]: https://github.com/canonical/testflinger
 [submit-action]: .github/actions/submit/README.md
 [poll-multi-action]: .github/actions/poll-multi/README.md

--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -1,1 +1,2 @@
 *.coverage.*
+coverage.xml

--- a/agent/README.md
+++ b/agent/README.md
@@ -2,6 +2,7 @@
 
 [![Charmhub][charmhub-badge]][charmhub-site]
 [![Documentation status][rtd-badge]][rtd-latest]
+[![codecov][cov-badge]][cov-latest]
 [![uv status][uv-badge]][uv-site]
 [![Ruff status][ruff-badge]][ruff-site]
 
@@ -63,6 +64,8 @@ If you're interested, start with the [contribution guide](../CONTRIBUTING.md).
 [charmhub-site]: https://charmhub.io/testflinger-agent-host
 [rtd-badge]: https://readthedocs.com/projects/canonical-testflinger/badge/?version=latest
 [rtd-latest]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/
+[cov-badge]: https://codecov.io/gh/canonical/testflinger/graph/badge.svg?token=G8Y0VF2CEY&component=agent
+[cov-latest]: https://codecov.io/gh/canonical/testflinger
 [uv-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json
 [uv-site]: https://github.com/astral-sh/uv
 [configuration]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/testflinger-agent-conf.html

--- a/agent/tox.ini
+++ b/agent/tox.ini
@@ -31,7 +31,13 @@ commands =
 [testenv:unit]
 description = Run unit tests
 commands = 
-    pytest -n auto --doctest-modules --cov=src tests
+    pytest -n auto \
+        --doctest-modules \
+        --cov=src \
+        --cov-branch \
+        --cov-report=term \
+        --cov-report=xml:coverage.xml \
+        tests
 
 [testenv:charm]
 description = Run tests for charm
@@ -47,4 +53,3 @@ commands =
            {posargs} \
            charms/testflinger-agent-host-charm/tests/unit \
            charms/testflinger-agent-host-charm/tests/integration
-

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,2 +1,3 @@
 attachments.tar.gz
 test/test.json
+coverage.xml

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,6 +2,7 @@
 
 [![Snapcraft][snapcraft-badge]][snapcraft-site]
 [![Documentation status][rtd-badge]][rtd-latest]
+[![codecov][cov-badge]][cov-latest]
 [![uv status][uv-badge]][uv-site]
 [![Ruff status][ruff-badge]][ruff-site]
 
@@ -92,6 +93,8 @@ Testflinger CLI is released under the [GPL-3.0 license](COPYING).
 [snapcraft-site]: https://snapcraft.io/testflinger-cli
 [rtd-badge]: https://readthedocs.com/projects/canonical-testflinger/badge/?version=latest
 [rtd-latest]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/
+[cov-badge]: https://codecov.io/gh/canonical/testflinger/graph/badge.svg?token=G8Y0VF2CEY&component=cli
+[cov-latest]: https://codecov.io/gh/canonical/testflinger
 [uv-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json
 [uv-site]: https://github.com/astral-sh/uv
 [job-schema]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/job-schema.html

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -33,4 +33,4 @@ description = Run unit tests
 set_env =
     HOME = {envtmpdir}
 commands =
-    pytest --cov=. --doctest-modules
+    pytest --cov --cov-branch --cov-report=term --cov-report=xml:coverage.xml --doctest-modules

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,19 @@
+comment:
+  layout: "header, diff, flags, components"
+component_management:
+  individual_components:
+    - component_id: agent
+      name: Agent
+      paths: [agent/**]
+    - component_id: cli
+      name: CLI
+      paths: [cli/**]
+    - component_id: common
+      name: Common
+      paths: [common/**]
+    - component_id: device
+      name: Device Connectors
+      paths: [device-connectors/**]
+    - component_id: server
+      name: Server
+      paths: [server/**]

--- a/common/README.md
+++ b/common/README.md
@@ -1,6 +1,7 @@
 # Testflinger Common
 
 [![Documentation status][rtd-badge]][rtd-latest]
+[![codecov][cov-badge]][cov-latest]
 [![uv status][uv-badge]][uv-site]
 
 **Testflinger Common** provides modules, enums, functions, etc. that are useful
@@ -48,6 +49,8 @@ If you're interested, start with the [contribution guide](../CONTRIBUTING.md).
 
 [rtd-badge]: https://readthedocs.com/projects/canonical-testflinger/badge/?version=latest
 [rtd-latest]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/
+[cov-badge]: https://codecov.io/gh/canonical/testflinger/graph/badge.svg?token=G8Y0VF2CEY&component=common
+[cov-latest]: https://codecov.io/gh/canonical/testflinger
 [uv-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json
 [uv-site]: https://github.com/astral-sh/uv
 [github]: https://github.com/canonical/testflinger

--- a/device-connectors/.gitignore
+++ b/device-connectors/.gitignore
@@ -1,2 +1,3 @@
 device-connector-error.json
 device-info.json
+coverage.xml

--- a/device-connectors/README.md
+++ b/device-connectors/README.md
@@ -1,6 +1,7 @@
 # Testflinger Device Connectors
 
 [![Documentation status][rtd-badge]][rtd-latest]
+[![codecov][cov-badge]][cov-latest]
 [![uv status][uv-badge]][uv-site]
 [![Ruff status][ruff-badge]][ruff-site]
 
@@ -89,6 +90,8 @@ Testflinger Device Connectors is released under the [GPL-3.0 license](COPYING).
 
 [rtd-badge]: https://readthedocs.com/projects/canonical-testflinger/badge/?version=latest
 [rtd-latest]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/
+[cov-badge]: https://codecov.io/gh/canonical/testflinger/graph/badge.svg?token=G8Y0VF2CEY&component=device
+[cov-latest]: https://codecov.io/gh/canonical/testflinger
 [uv-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json
 [uv-site]: https://github.com/astral-sh/uv
 [provision-types]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/device-connector-types.html

--- a/device-connectors/tox.ini
+++ b/device-connectors/tox.ini
@@ -31,4 +31,9 @@ commands =
 [testenv:unit]
 description = Run unit tests
 commands =
-    pytest --doctest-modules --cov=src
+    pytest \
+        --doctest-modules \
+        --cov=src \
+        --cov-branch \
+        --cov-report=term \
+        --cov-report=xml:coverage.xml

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,1 @@
+coverage.xml

--- a/server/README.md
+++ b/server/README.md
@@ -2,6 +2,7 @@
 
 [![Charmhub][charmhub-badge]][charmhub-site]
 [![Documentation status][rtd-badge]][rtd-latest]
+[![codecov][cov-badge]][cov-latest]
 [![uv status][uv-badge]][uv-site]
 [![Ruff status][ruff-badge]][ruff-site]
 
@@ -66,6 +67,8 @@ Testflinger Server is released under the [GPL-3.0 license](COPYING).
 [charmhub-site]: https://charmhub.io/testflinger-k8s
 [rtd-badge]: https://readthedocs.com/projects/canonical-testflinger/badge/?version=latest
 [rtd-latest]: https://canonical-testflinger.readthedocs-hosted.com/en/latest/
+[cov-badge]: https://codecov.io/gh/canonical/testflinger/graph/badge.svg?token=G8Y0VF2CEY&component=server
+[cov-latest]: https://codecov.io/gh/canonical/testflinger
 [uv-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json
 [uv-site]: https://github.com/astral-sh/uv
 [flask]: https://flask.palletsprojects.com/en/stable/

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -38,7 +38,13 @@ commands =
 [testenv:unit]
 description = Run unit tests
 commands =
-    pytest --ignore app.py --cov=src tests
+    pytest \
+        --ignore app.py \
+        --cov=src \
+        --cov-branch \
+        --cov-report=term \
+        --cov-report=xml:coverage.xml \
+        tests
 
 [testenv:charm]
 description = Run charm tests


### PR DESCRIPTION
## Description

This PR adds coverage tracking to the Testflinger components.

## Resolved issues

Resolves [CERTTF-607](https://warthogs.atlassian.net/browse/CERTTF-607)

## Documentation

## Web service API changes

## Tests


[CERTTF-607]: https://warthogs.atlassian.net/browse/CERTTF-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ