### PR TITLE
oem_autointall: Add default user-data and grub.cfg for stock provisioning

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/stock/default-grub.cfg
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/stock/default-grub.cfg
@@ -1,0 +1,30 @@
+set timeout=3
+
+loadfont unicode
+
+set menu_color_normal=white/black
+set menu_color_highlight=black/light-gray
+
+menuentry "Autoinstall Ubuntu" {
+	set gfxpayload=keep
+	linux	/casper/vmlinuz autoinstall ds=nocloud\;s=/cdrom/cloud-configs/ --- quiet splash
+	initrd	/casper/initrd
+}
+menuentry "Ubuntu (safe graphics)" {
+	set gfxpayload=keep
+	linux	/casper/vmlinuz nomodeset  --- quiet splash
+	initrd	/casper/initrd
+}
+grub_platform
+if [ "$grub_platform" = "efi" ]; then
+menuentry 'Boot from next volume' {
+	exit 1
+}
+menuentry 'UEFI Firmware Settings' {
+	fwsetup
+}
+else
+menuentry 'Test memory' {
+	linux16 /boot/memtest86+x64.bin
+}
+fi

--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/stock/default-user-data
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/stock/default-user-data
@@ -1,0 +1,86 @@
+#cloud-config
+autoinstall:
+  version: 1
+  # https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html
+
+  identity:
+    hostname: stock-desktop
+    username: ubuntu
+    password: $6$rounds=4096$XhTD78VC52s0Aev8$EGh9Mp2UtGnwMXbffUXLG1nzpiA9i1AasFDo1VXlQ5QrpJBrofW77P1Twr4iuqqTPdZ3EGH.UsTT19DWkWcNC0
+  user-data:
+    users:
+      - name: ubuntu
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        groups: sudo, adm
+    write_files:
+      - content: |
+          [org.gnome.settings-daemon.plugins.power]
+          sleep-inactive-ac-timeout=0
+          sleep-inactive-battery-timeout=0
+          sleep-inactive-battery-type='nothing'
+          sleep-inactive-ac-type='nothing'
+          idle-dim=false
+          [org.gnome.desktop.session]
+          idle-delay=0
+          [org.gnome.desktop.screensaver]
+          ubuntu-lock-on-suspend=false
+          lock-enabled=false
+          idle-activation-enabled=false
+          [org.gnome.desktop.remote-desktop.rdp]
+          enable=true
+          view-only=false
+        path: /usr/share/glib-2.0/schemas/certification.gschema.override
+      - content: |
+          #!/bin/bash
+          set_usb_boot_first() {
+              local bootnum current_order new_order
+              
+              # Get USB boot number and avoid usb-ethernet dongles
+              bootnum=$(sudo efibootmgr -v | awk 'BEGIN {IGNORECASE=1} /Boot[0-9A-F]+\**[[:space:]]+.*USB/ && !/IP/ && !/MAC/ {print $1}' | head -n1 | cut -c5- | tr -d '*')
+              
+              if [[ -z "$bootnum" ]]; then
+                  echo "No USB boot entry found" >&2
+                  return 1
+              fi
+              
+              echo "USB boot entry found: $bootnum"
+              
+              # Get current boot order and remove USB bootnum from it
+              current_order=$(sudo efibootmgr | grep BootOrder | cut -d: -f2 | tr -d '[:space:]')
+              current_order=${current_order//${bootnum},/}  # Remove if at beginning
+              current_order=${current_order//,${bootnum}/}  # Remove if in middle
+              current_order=${current_order//${bootnum}/}   # Remove if alone
+              
+              # Build new order with USB first
+              new_order="$bootnum"
+              if [[ -n "$current_order" ]]; then
+                  new_order+=",$current_order"
+              fi
+              
+              echo "Setting new boot order: $new_order"
+              sudo efibootmgr -o "$new_order"
+          }
+          
+          set_usb_boot_first
+        path: /tmp/set_usb_boot.sh
+        permissions: '0755'
+    runcmd:
+      # disable power save
+      - ["glib-compile-schemas", "/usr/share/glib-2.0/schemas"]
+      - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.settings-daemon.plugins.power"]
+      - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.desktop.session"]
+      - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.desktop.screensaver"]
+      - ["/tmp/set_usb_boot.sh"]  # set USB boot first (after system has booted successfully)
+      - ["sudo", "apt-get", "update"]
+      - ["sudo", "apt-get", "install", "-y", "openssh-server"]
+  ssh:
+    allow-pw: true
+    authorized-keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCYYa9VOGB5NBJzRQ7OnxG4Z6ynBs+B2+A49RVcNWhzWtwPkEEefsHDIz0VLbVSfGJGQMF2Dsw8PVJWBRTBvc1bkHt3sUCZklAmGVbOhXEaXS/GzCjMEb0Kg8jvEzH3WxLm0X4fIQeIDAE6Za/t5ix3uNwYgzZiGT7isx7aDQtpOrZD+y2n3F1xvDPdySJ304hAkAvMGnkwstNXduUXrnOEoPeOrQbk+k85otyaGqL0C/U+SkeeAKnzikkmvxrZlcp2zxow8iGMTfVNY15nA9BKx4v21nnIKnhVdWZ43ltp9dQoafOXbNtYTxTnFvmaHQ1WFGJ+1/fDAY8tfbjbQaIxPvPJ ubuntu@juju-machine-8-lxc-0
+  early-commands:
+    - "nmcli networking off"  # to prevent online checks and speed up intallation
+  late-commands:
+    # enable auto login
+    - echo "[daemon]" > /target/etc/gdm3/custom.conf
+    - echo "AutomaticLoginEnable=true" >> /target/etc/gdm3/custom.conf
+    - echo "AutomaticLogin=ubuntu" >> /target/etc/gdm3/custom.conf

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/zapper_oem.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/zapper_oem.py
@@ -69,10 +69,18 @@ class ZapperOem(ZapperConnector):
 
         if iso_type == "stock":
             # Stock ISO requires meta-data, user-data and grub.cfg
-            data_path = Path(__file__).parent / "../../data/oem_autoinstall/stock"
-            meta_data_b64 = self._read_file_to_base64(data_path / "default-meta-data")
-            user_data_b64 = self._read_file_to_base64(data_path / "default-user-data")
-            grub_cfg_b64 = self._read_file_to_base64(data_path / "default-grub.cfg")
+            data_path = (
+                Path(__file__).parent / "../../data/oem_autoinstall/stock"
+            )
+            meta_data_b64 = self._read_file_to_base64(
+                data_path / "default-meta-data"
+            )
+            user_data_b64 = self._read_file_to_base64(
+                data_path / "default-user-data"
+            )
+            grub_cfg_b64 = self._read_file_to_base64(
+                data_path / "default-grub.cfg"
+            )
 
         # Optional fields
         test_data = self.job_data.get("test_data", {})
@@ -101,7 +109,9 @@ class ZapperOem(ZapperConnector):
                 content = f.read()
                 return base64.b64encode(content).decode("utf-8")
         except OSError as e:
-            raise ProvisioningError(f"Failed to read file {filepath}: {e}") from e
+            raise ProvisioningError(
+                f"Failed to read file {filepath}: {e}"
+            ) from e
 
     def _post_run_actions(self, args):
         pass


### PR DESCRIPTION
## Description
Allow oem_autoinstall to provision stock ubuntu when Support Machine is connected with dut.
- add grub.cfg - this file overwrites the stock grub.cfg to point to custom user-data
- add user-data - the config to autoinstall stock and set usb stick as first boot after installation completed
- add methods to convert above configs to base64 and send to Support Machine api

<!--
Describe your changes here:
- add default grub.cfg that points to autoinstall user-data
- add default user-data to autoinstall stock and set usb stick as first boot after installation completed
- add methods to convert above configs to base64 to pass to "support" device

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Closes https://warthogs.atlassian.net/browse/OEX86-735
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
- Run user-data with usb installer OK
- Run oem_autoinstall and TF server locally. Submit job and verify that stock provisioning was completed with default user-data and grub.cfg OK
- Run oem_autoinstall to format stock with bootstrap USB and provision OEM image OK
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
