### PR TITLE
docs: Small tutorial update

### DIFF
--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -13,6 +13,7 @@ Work with jobs via Testflinger CLI
     change-server
     submit-job
     cancel-job
+    reserve-job
     search-job
     job-priority
     authentication

--- a/docs/how-to/reserve-job.rst
+++ b/docs/how-to/reserve-job.rst
@@ -1,0 +1,33 @@
+Reserve a device
+================
+
+When you only need an SSH access to the DUT to manually interact with it, you can use a reserve job.
+
+To reserve a device, provide a job definition as the following:
+
+.. code-block:: yaml
+
+  job_queue: <queue>
+  provision_data:
+    <providion-data>
+  reserve_data:
+    ssh_keys:
+      - <id-provider>:<your-username>
+    timeout: <maximum-reservation-duration-seconds>
+
+In the ``reserve_data``, you will find:
+
+- ``ssh_keys``: Specifies the list of public SSH keys to use for reserving the device. Each line includes an identity provider name and your username on the provider's system. Supported identities are LaunchPad (``lp``) and GitHub (``gh``).
+- ``timeout``: Specifies the reservation time in seconds, default is 1 hour (3600), maximum is 6 hours (21600) without authentication.
+
+If you need more time, see information on authentication and authorisation at :doc:`../how-to/authentication`.
+
+Then submit the job with:
+
+.. code-block:: shell
+
+  $ testflinger-cli submit --poll reserve-job.yaml
+
+Once the device is ready, Testflinger will print out an SSH command that you can use to to access to the device.
+
+When you are finished with the device, you can end your reservation early by cancelling the job. See :doc:`../how-to/cancel-job`.

--- a/docs/how-to/submit-job.rst
+++ b/docs/how-to/submit-job.rst
@@ -18,4 +18,4 @@ If the job is successful submitted, you will see a ``job_id`` returned by Testfl
   job_id: 2bac1457-0000-0000-0000-15f23f69fd39
 
 
-You can use the ``job_id`` to further monitor and manager the submitted job.
+You can use the ``job_id`` to further monitor and manage the submitted job.

--- a/docs/how-to/submit-job.rst
+++ b/docs/how-to/submit-job.rst
@@ -19,3 +19,18 @@ If the job is successful submitted, you will see a ``job_id`` returned by Testfl
 
 
 You can use the ``job_id`` to further monitor and manage the submitted job.
+
+You can also store the ``job_id`` in an environment variable, to be able to use it in the following commands:
+
+.. code-block:: shell
+
+   $ JOB_ID="$(testflinger-cli submit -q example-job.yaml)"
+   $ testflinger-cli poll "${JOB_ID}"
+
+If you will only need the ``job_id`` for the polling command, you can use:
+
+.. code-block:: shell
+
+   $ testflinger-cli submit --poll example-job.yaml
+
+This will submit and start polling right away.

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -236,7 +236,13 @@ This can be particularly relevant during the ``reserve`` stage as it will provid
       "job_state": "reserve"
   }
 
+You can also view job status and results for a specific queue at ``https://testflinger.example.com/queues/test-queue-1``, where you can select the corresponding job under the “Jobs” list.
 
+You can even monitor the live output of your job using:
+
+.. code-block:: shell
+
+   $ testflinger-cli poll 2bac1457-0000-0000-0000-15f23f69fd39
 
 ---------
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -132,13 +132,13 @@ Test jobs are YAML or JSON files that define the configurations and instructions
 
 A test job might contain a very complex command workflow that includes provisioning a system image onto the device, updating the firmware, executing a series test and more. In this tutorial, you will start with a simple test job.
 
-The following example shows a test job, written in YAML, that provisions an Ubuntu Jammy system image on a MAAS-provisioned device and then prints the distribution information:
+The following example shows a test job, written in YAML, that provisions an Ubuntu Noble system image on a MAAS-provisioned device and then prints the distribution information:
 
 .. code-block:: yaml
 
   job_queue: example-queue-1
   provision_data:
-    distro: jammy
+    distro: noble
   test_data:
     test_cmds: |
       ssh -t ubuntu@$DEVICE_IP lsb_release -a

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -1,5 +1,5 @@
 Get started with Testflinger CLI
-=================================
+================================
 
 Testflinger is a system for orchestrating the time-sharing of access to a pool of target machines. You can use Testflinger to perform remote real-world test jobs on hardware with optimised utilisation of resources.
 
@@ -9,25 +9,25 @@ Each Testflinger system consists of:
 * **Testflinger Agent**: a per-machine management tool that retrieves jobs from associated queues on the server and processes the jobs.
 * **Device Connector**: a device-specific tool that handles provisioning and other device-specific details for each type of device.
 
-The **Testflinger CLI** is a command-line interface that facilitates interactions with a Testflinger Server through integrated APIs. You can use Testflinger CLI to submit test jobs, check job status, and retrieve testing results. 
+The **Testflinger CLI** is a command-line interface that facilitates interactions with a Testflinger Server through integrated APIs. You can use Testflinger CLI to submit test jobs, check job status, and retrieve testing results.
 
-In this tutorial, you will learn how to set up Testflinger CLI, write your first test job, and leverage the CLI to run the test job on a remote Testflinger server. 
+In this tutorial, you will learn how to set up Testflinger CLI, write your first test job, and leverage the CLI to run the test job on a remote Testflinger server.
 
 
 Prerequisite
---------------
+------------
 
 - Python installed on your system
 - Access to a Testflinger server and a device under test (DUT)
 
 
 Install Testflinger CLI
---------------------------
+-----------------------
 
 The most convenient way to install the CLI is through the *Snap Store*. Open a terminal and run the following command:
 
 .. code-block:: shell
-  
+
   $ sudo snap install testflinger-cli
 
 Once the installation is finished, you can execute the ``testflinger-cli`` command to check the installation. For example, you can run with the ``--help`` or ``-h`` option to display the CLI help page, which is useful anytime when you need a reference about how to use the tool:
@@ -65,19 +65,19 @@ Once the installation is finished, you can execute the ``testflinger-cli`` comma
 Congratulations, your Testflinger CLI is ready for use!
 
 .. note::
-  
+
   ``testflinger`` and ``testflinger-cli`` are aliases for the same command. You can use both commands interchangeably.
 
 
 Configure default server
-----------------------------
+------------------------
 
 The default server for Testflinger CLI to use is ``https://testflinger.canonical.com``. Let's assume that you want to connect to another server located in your own hardware laboratory, with the new URI ``https://testflinger.example.com``. We will use this example server URI throughout this tutorial.
 
 To change the default server to connect, set the server URI as an environment variable. In the terminal, run the following command:
 
 .. code-block:: shell
-  
+
   $ export TESTFLINGER_SERVER="https://testflinger.example.com"
 
 To verify that the variable has been set, run:
@@ -91,10 +91,10 @@ Now all the Testflinger requests made from your current terminal session will be
 
 Access to a Testflinger server is usually secured behind a firewall or with additional authentication and authorisation measures. Make sure that you have been granted the right access through your system administrator.
 
-For more information on authentication and authorisation, refer to :doc:`../how-to/authentication`. 
+For more information on authentication and authorisation, refer to :doc:`../how-to/authentication`.
 
 Check available queues on the server
--------------------------------------
+------------------------------------
 
 You can now use the CLI to connect to a Testflinger server and check the availability of remote resources.
 
@@ -107,7 +107,7 @@ Run the following command in the terminal to retrieve the available job queues t
   $ testflinger-cli list-queues
 
 .. note::
-  
+
   If you want to temporarily use another server, add ``--server`` argument and the server URI in the command.
 
 If the connection is successful, a list of job queues is returned with their queue names and short descriptions:
@@ -126,7 +126,7 @@ Alternatively, you can also visit the Web UI of this server at ``https://testfli
 
 
 Define a test job
---------------------
+-----------------
 
 Test jobs are YAML or JSON files that define the configurations and instructions about how the test should run on the target device. Test jobs can be either fully automated scripts or interactive shell sessions.
 
@@ -145,16 +145,16 @@ The following example shows a test job, written in YAML, that provisions an Ubun
 
 In the example job definition file:
 
-- ``job_queue``: specifies the queue name to which you will submit the job 
+- ``job_queue``: specifies the queue name to which you will submit the job
 - ``provision_data``: specifies the source of the system image to be provisioned on the target device. This example uses the ``distro`` key to specify the version of the system image to be downloaded, but this key is specific to MAAS devices. The actual format of this section varies on device type. For more information, refer to :doc:`../reference/device-connector-types`.
-- ``test_data``: contains a ``test_cmds`` section that specifies the list of commands to be executed on the device after the system is provisioned. In this example, the device is instructed to execute the ``lsb_release -a`` command to print the Linux distribution information. 
+- ``test_data``: contains a ``test_cmds`` section that specifies the list of commands to be executed on the device after the system is provisioned. In this example, the device is instructed to execute the ``lsb_release -a`` command to print the Linux distribution information.
 
-You might have noticed that the command is executed over an SSH connection. This is because the Testflinger system uses agents and device connectors to manage test jobs. The test commands are not executed on the test device itself, but on a host system that can reach your test device via SSH. Devices are set up with an SSH key to allow passwordless SSH connection from the test host at the time the provisioning is finished. 
+You might have noticed that the command is executed over an SSH connection. This is because the Testflinger system uses agents and device connectors to manage test jobs. The test commands are not executed on the test device itself, but on a host system that can reach your test device via SSH. Devices are set up with an SSH key to allow passwordless SSH connection from the test host at the time the provisioning is finished.
 
 Modify the strings in the above example as needed, and then save the file on your disk. For example, you can name it as ``test-job.yaml``.
 
 Submit your test job
----------------------
+--------------------
 
 Now that you have a YAML file with your job definition, you can submit it to the Testflinger server by executing the following command:
 
@@ -172,7 +172,7 @@ If the job is submitted successfully, you will see the output with a returned ``
   job_id: 2bac1457-0000-0000-0000-15f23f69fd39
 
 Check job status
------------------------
+----------------
 
 Once the job is submitted to the server, it goes through a series of phases in the lifecycle. You might want to check its status during the processing time. To do so, run the following command with the actual ``job_id`` of your submitted job:
 
@@ -187,7 +187,7 @@ This command provides you with brief information about the job's current status,
 The above output implies that the test job is going through the provisioning phase. If the job is completed, the returned status shows ``complete``.
 
 Check test output
-------------------------
+-----------------
 
 In some cases, you might want to check the device output to know how each job phase runs. You can use Testflinger CLI to collect the job output in a JSON file by running the ``results`` command with the actual ``job_id`` of your submitted job:
 
@@ -200,7 +200,7 @@ In some cases, you might want to check the device output to know how each job ph
     "cleanup_status": 0,
     "job_state": "complete",
 
-    "provision_output": "Starting testflinger provision phase on example-queue-1\n...",     
+    "provision_output": "Starting testflinger provision phase on example-queue-1\n...",
     "provision_serial": "...",
     "provision_status": 0,
 
@@ -221,8 +221,8 @@ Besides the output from the provisioning and testing commands, the returned data
   can be set through the `output_bytes` field of the agent configuration file and its default value
   is 10 MB.
 
-Finally, the ``results`` command can also be used to retrieve relevant information about which agent is processing an specific job. 
-This can be particularly relevant during the ``reserve`` stage as it will provide the ``device_ip`` to use for accessing the device. 
+Finally, the ``results`` command can also be used to retrieve relevant information about which agent is processing an specific job.
+This can be particularly relevant during the ``reserve`` stage as it will provide the ``device_ip`` to use for accessing the device.
 
 .. code-block:: shell
 
@@ -243,7 +243,7 @@ This can be particularly relevant during the ``reserve`` stage as it will provid
 Congratulations! You've successfully set up the Testflinger CLI, created and submitted your first test job, and checked its status. You can now create more complex jobs and manage your test jobs efficiently using the command line tool. Happy testing!
 
 Next steps
---------------
+----------
 
 Now that you've mastered the basic operations you can do with Testflinger CLI, here are some next steps to enhance your experience:
 


### PR DESCRIPTION
## Description

In the tutorial, there were no reference to the `poll` command, nor to "reserve" jobs.
Adding them with a bit of update (jammy -> noble) and format clean up.