### PR TITLE
Update agent ports assignment method

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_data/agent1.conf
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_data/agent1.conf
@@ -1,0 +1,6 @@
+[program:agent1]
+startsecs=0
+redirect_stderr=true
+environment=USER="ubuntu",HOME="/home/ubuntu",PYTHONIOENCODING=utf-8
+user=ubuntu
+command=/srv/testflinger-venv/bin/testflinger-agent -c /srv/agent-configs/ce-cert/data-tel-l2/agent1/testflinger-agent.conf -p 8000

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_data/agent2.conf
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_data/agent2.conf
@@ -1,0 +1,6 @@
+[program:agent2]
+startsecs=0
+redirect_stderr=true
+environment=USER="ubuntu",HOME="/home/ubuntu",PYTHONIOENCODING=utf-8
+user=ubuntu
+command=/srv/testflinger-venv/bin/testflinger-agent -c /srv/agent-configs/ce-cert/data-tel-l2/agent2/testflinger-agent.conf -p 8001

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_data/agent_no_port.conf
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_data/agent_no_port.conf
@@ -1,0 +1,5 @@
+[program:agent-no-port]
+startsecs=0
+redirect_stderr=true
+user=ubuntu
+command=/srv/testflinger-venv/bin/testflinger-agent -c /srv/config/test.conf

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_port_validation.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_port_validation.py
@@ -1,0 +1,192 @@
+# Copyright 2025 Canonical
+# See LICENSE file for licensing details.
+
+import os
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+from charm import TestflingerAgentHostCharm
+from ops.testing import Harness
+
+SUPERVISOR_CONF_DIR = "/etc/supervisor/conf.d"
+
+
+class TestPortValidation(unittest.TestCase):
+    """Test suite for process-based port validation and assignment logic."""
+
+    def setUp(self):
+        self.harness = Harness(TestflingerAgentHostCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.charm = self.harness.charm
+
+    @patch("pathlib.Path.iterdir")
+    @patch("pathlib.Path.exists")
+    def test_get_supervisor_agents_port_mapping(
+        self, mock_exists, mock_iterdir
+    ):
+        """Test getting configured agents from supervisor config files."""
+        mock_exists.return_value = True
+
+        # Create mock Path objects for the config files
+        mock_agent1_path = MagicMock()
+        mock_agent1_path.suffix = ".conf"
+        mock_agent1_path.__str__ = MagicMock(
+            return_value=f"{SUPERVISOR_CONF_DIR}/agent1.conf"
+        )
+
+        mock_agent2_path = MagicMock()
+        mock_agent2_path.suffix = ".conf"
+        mock_agent2_path.__str__ = MagicMock(
+            return_value=f"{SUPERVISOR_CONF_DIR}/agent2.conf"
+        )
+
+        mock_other_path = MagicMock()
+        mock_other_path.suffix = ".txt"
+
+        mock_iterdir.return_value = [
+            mock_agent1_path,
+            mock_agent2_path,
+            mock_other_path,
+        ]
+
+        test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
+
+        with open(os.path.join(test_data_dir, "agent1.conf"), "r") as f:
+            agent1_config = f.read()
+        with open(os.path.join(test_data_dir, "agent2.conf"), "r") as f:
+            agent2_config = f.read()
+
+        config_files = {
+            f"{SUPERVISOR_CONF_DIR}/agent1.conf": agent1_config,
+            f"{SUPERVISOR_CONF_DIR}/agent2.conf": agent2_config,
+        }
+
+        def mock_open_file(filename, mode="r", encoding=None):
+            if str(filename) in config_files:
+                return mock_open(read_data=config_files[str(filename)])()
+            raise FileNotFoundError()
+
+        with patch("builtins.open", mock_open_file):
+            mapping = self.charm.get_supervisor_agents_port_mapping()
+
+        expected = {"agent1": 8000, "agent2": 8001}
+        self.assertEqual(mapping, expected)
+
+    def test_parse_supervisor_config_file_invalid(self):
+        """Test parsing invalid supervisor config file."""
+        config_content = """
+                        [program:invalid]
+                        command=some-other-process
+                        """
+
+        with patch("builtins.open", mock_open(read_data=config_content)):
+            agent_name, port = self.charm.parse_supervisor_config_file(
+                f"{SUPERVISOR_CONF_DIR}/invalid.conf"
+            )
+            self.assertIsNone(agent_name)
+            self.assertIsNone(port)
+
+    def test_parse_supervisor_config_file_missing_port(self):
+        """Test parsing config file with testflinger-agent but no port."""
+        test_data_dir = os.path.join(os.path.dirname(__file__), "test_data")
+        with open(os.path.join(test_data_dir, "agent_no_port.conf"), "r") as f:
+            config_content = f.read()
+
+        with patch("builtins.open", mock_open(read_data=config_content)):
+            agent_name, port = self.charm.parse_supervisor_config_file(
+                f"{SUPERVISOR_CONF_DIR}/agent-no-port.conf"
+            )
+            self.assertIsNone(agent_name)
+            self.assertIsNone(port)
+
+    def test_parse_supervisor_config_file_file_error(self):
+        """Test parsing config file when file cannot be read."""
+        with patch("builtins.open", side_effect=OSError("Permission denied")):
+            agent_name, port = self.charm.parse_supervisor_config_file(
+                f"{SUPERVISOR_CONF_DIR}/unreadable.conf"
+            )
+            self.assertIsNone(agent_name)
+            self.assertIsNone(port)
+
+    @patch("socket.socket")
+    def test_find_available_port_success(self, mock_socket):
+        """Test finding an available port successfully."""
+        mock_sock = MagicMock()
+        mock_socket.return_value.__enter__.return_value = mock_sock
+        mock_sock.bind.return_value = None
+
+        used_ports = set()
+        port = self.charm.find_available_port(used_ports, 8000, 8010)
+        self.assertEqual(port, 8000)
+        mock_sock.bind.assert_called_once_with(("localhost", 8000))
+
+    @patch("socket.socket")
+    def test_find_available_port_skip_used(self, mock_socket):
+        """Test finding port skips already used ports."""
+        mock_sock = MagicMock()
+        mock_socket.return_value.__enter__.return_value = mock_sock
+        mock_sock.bind.return_value = None
+
+        used_ports = {8000, 8001}
+        port = self.charm.find_available_port(used_ports, 8000, 8010)
+        self.assertEqual(port, 8002)
+        mock_sock.bind.assert_called_once_with(("localhost", 8002))
+
+    @patch("socket.socket")
+    def test_find_available_port_exhausted(self, mock_socket):
+        """Test when no ports are available in the range."""
+        mock_sock = MagicMock()
+        mock_socket.return_value.__enter__.return_value = mock_sock
+        mock_sock.bind.side_effect = OSError()
+
+        used_ports = set()
+        with self.assertRaises(RuntimeError) as cm:
+            self.charm.find_available_port(used_ports, 8000, 8002)
+
+        self.assertIn("No available ports found", str(cm.exception))
+
+    def test_assign_metrics_port_existing_agent(self):
+        """Test assigning port to existing configured agent."""
+        configured_agents = {"existing_agent": 8000}
+        used_ports = {8000}
+
+        port = self.charm.assign_metrics_port(
+            "existing_agent", configured_agents, used_ports
+        )
+
+        self.assertEqual(port, 8000)
+
+    @patch.object(TestflingerAgentHostCharm, "find_available_port")
+    def test_assign_metrics_port_finds_new_port(self, mock_find_port):
+        """Test port assignment finds new port for new agent."""
+        mock_find_port.return_value = 8002
+
+        configured_agents = {"agent1": 8000, "agent2": 8001}
+        used_ports = {8000, 8001}
+        port = self.charm.assign_metrics_port(
+            "new_agent", configured_agents, used_ports
+        )
+
+        self.assertEqual(port, 8002)
+        mock_find_port.assert_called_once_with(used_ports)
+
+    @patch.object(
+        TestflingerAgentHostCharm, "get_supervisor_agents_port_mapping"
+    )
+    def test_port_assignment_avoids_used_ports(self, mock_get_supervisor):
+        """Test that port assignment avoids ports already in use."""
+        mock_get_supervisor.return_value = {"agent2": 8001}
+
+        used_ports = {8001}
+
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value.__enter__.return_value = mock_sock
+            mock_sock.bind.return_value = None
+
+            port = self.charm.assign_metrics_port(
+                "new_agent", {"agent2": 8001}, used_ports
+            )
+
+            self.assertNotEqual(port, 8001)


### PR DESCRIPTION
## Description
This PR fixes the issue of agent port conflict introduced by #736. The `update_config` action regenerates the supervisor service files, and it might assign a different port to the same agent service. If agents restart at different times, some get new ports while others keep old ports, causing the conflict. 

The updated port assignment applies the following
- Keep the ports for existing agents by parsing the original agent service files
- Check port availability before assign to new agents

## Resolved issues
```
[25-07-16 09:33:48]   ERROR: (client.py:73)| InfluxDB host undefined
[25-07-16 09:33:49]   ERROR: (metrics.py:61)| Unable to start metrics endpoint: [Errno 98] Address already in use
[25-07-16 09:33:49]   ERROR: (cmd.py:32)| [Errno 98] Address already in use
Traceback (most recent call last):
  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/cmd.py", line 27, in main
    start_agent()
  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/__init__.py", line 127, in start_agent
    agent = TestflingerAgent(client)
  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/agent.py", line 103, in __init__
    self.metrics_handler = PrometheusHandler(
  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/metrics.py", line 59, in __init__
    start_http_server(port)
  File "/srv/testflinger-venv/lib/python3.10/site-packages/prometheus_client/exposition.py", line 234, in start_wsgi_server
    httpd = make_server(addr, port, app, TmpServer, handler_class=_SilentHandler)
  File "/usr/lib/python3.10/wsgiref/simple_server.py", line 154, in make_server
    server = server_class((host, port), handler_class)
  File "/usr/lib/python3.10/socketserver.py", line 452, in __init__
    self.server_bind()
  File "/usr/lib/python3.10/wsgiref/simple_server.py", line 50, in server_bind
    HTTPServer.server_bind(self)
  File "/usr/lib/python3.10/http/server.py", line 137, in server_bind
    socketserver.TCPServer.server_bind(self)
  File "/usr/lib/python3.10/socketserver.py", line 466, in server_bind
    self.socket.bind(self.server_address)
OSError: [Errno 98] Address already in use
```
## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Add unit tests for port assignment.