### PR TITLE
add: support "Bearer" prefix in authorization header

### DIFF
--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -242,6 +242,9 @@ def authenticate(func):
         if not auth_token:
             return func(*args, **kwargs)
 
+        if auth_token.startswith("Bearer "):
+            auth_token = auth_token[len("Bearer ") :]
+
         # If there is a token available, attempt to retrieve information
         secret_key = os.environ.get("JWT_SIGNING_KEY")
         decoded_jwt = decode_jwt_token(auth_token, secret_key)
@@ -252,6 +255,7 @@ def authenticate(func):
         g.role = permissions.get("role", ServerRoles.CONTRIBUTOR)
         g.permissions = permissions
         g.is_authenticated = True
+
         return func(*args, **kwargs)
 
     return decorator


### PR DESCRIPTION
## Description
This makes the authenticate() decorator compatible with standard HTTP auth headers like Authorization: Bearer <token>. CLI fallback is preserved for backward compatibility.

## Resolved issues


## Documentation


## Web service API changes


## Tests
Tested locally