### PR TITLE
change: make serial-logger log and error only the first time

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -99,11 +99,18 @@ class RealSerialLogger:
 
         def reconnector():
             """Reconnect when needed."""
+            logged = False
             while True:
                 try:
                     self._log_serial()
                 except Exception:
-                    logger.error("Error connecting to serial logging server")
+                    if not logged:
+                        error = (
+                            "Error connecting to serial logging server. "
+                            + "Retrying in the background..."
+                        )
+                        logger.error(error)
+                        logged = True
 
                 # Keep trying if we can't connect, but sleep between attempts
                 time.sleep(30)


### PR DESCRIPTION
## Description

Most of the time the configuration lies: there's no serial logger active, and the result is:
```
14:51:12 rpi3bp001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
14:51:42 rpi3bp001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
14:52:12 rpi3bp001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
14:52:42 rpi3bp001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
14:53:12 rpi3bp001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
14:54:42 rpi3bp001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
```
It's confusing, it's been reported many times.

Considering we log on success and on any connection drop, I think we can log this error only once.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

Running from source.
