### PR TITLE
feat(cli): add job status information to queue-status command

### DIFF
--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Canonical Ltd.
 """Helpers for the Testflinger CLI."""
 
+from datetime import datetime
 from os import getenv
 from pathlib import Path
 from typing import Optional
@@ -163,3 +164,20 @@ def pretty_yaml_dump(obj, **kwargs) -> str:
     :return: A pretty representation of obj as a YAML string.
     """
     return yaml.dump(obj, **kwargs)
+
+
+def format_timestamp(timestamp_str: str) -> str:
+    """Format timestamp for human reading.
+
+    :param timestamp_str: ISO format timestamp string
+    :return: Formatted timestamp string or original if parsing fails
+    """
+    if not timestamp_str:
+        return "Unknown"
+
+    try:
+        # Parse ISO format timestamp
+        dt = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, AttributeError):
+        return timestamp_str

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -41,13 +41,14 @@ Once the installation is finished, you can execute the ``testflinger-cli`` comma
                         ...
 
   positional arguments:
-    {artifacts,cancel,config,jobs,list-queues,poll,reserve,results,show,status,submit}
+    {artifacts,cancel,config,jobs,list-queues,poll,queue-status,reserve,results,show,status,submit}
       artifacts           Download a tarball of artifacts saved for a specified job
       cancel              Tell the server to cancel a specified JOB_ID
       config              Get or set configuration options
       jobs                List the previously started test jobs
       list-queues         List the advertised queues on the Testflinger server
       poll                Poll for output from a job until it is completed
+      queue-status        Show the status of agents and jobs in a specified queue
       reserve             Install and reserve a system
       results             Get results JSON for a completed JOB_ID
       show                Show the requested job JSON for a specified JOB_ID


### PR DESCRIPTION
## Description

This PR enhances the existing `queue-status` command to display job status information alongside the current agent status, addressing the feature request in issue #116.

Users need a way to get a summary of job statuses in a queue without polling individual job IDs. When running many jobs in sequence, it's difficult to get a quick overview of job progress and identify active work.

The solution extends the existing `queue-status` command to show both agent and job status in unified output, using a simple `--verbose` flag for detailed job information.

## Resolved issues

Fixes #116

## Documentation

- Tutorial updated to include `queue-status` command in CLI help example
- Command help text clearly describes all options and functionality
- Existing documentation patterns and usage remain valid

## Web service API changes

No API changes required. Uses existing endpoints:
- `/v1/queues/{queue}/agents` for agent status information  
- `/v1/queues/{queue}/jobs` for job status information

## Tests

**How this PR was tested:**

1. **Unit Tests (50/50 passing):**
   ```bash
   uv run python -m pytest testflinger_cli/tests/test_cli.py -v
   ```

2. **Linting & Formatting:**
   ```bash
   uvx --with tox-uv tox -e lint
   ```

3. **Manual Testing:**
   ```bash
   # Test basic functionality
   testflinger-cli queue-status my-queue
   
   # Test verbose mode  
   testflinger-cli queue-status --verbose my-queue
   
   # Test JSON output
   testflinger-cli queue-status --json my-queue
   ```

**Test coverage includes:**
- Default output with enhanced job counts
- Verbose mode showing individual job details with timestamps
- JSON output with new job status keys
- Error handling for empty/nonexistent queues
- Backward compatibility validation

**Key features implemented:**
- **Non-breaking**: Existing behavior completely preserved
- **Unified output**: Always shows both agent and job status together  
- **Simple interface**: Single `--verbose` flag for detailed information
- **Smart categorization**: Jobs grouped as waiting/running/completed (cancelled ignored)
- **JSON compatibility**: New keys added while maintaining backward compatibility

**Example outputs:**

Default (enhanced):
```
Agents in queue: 1
Available:       1
Busy:            0
Offline:         0
Jobs waiting:    0
Jobs running:    0    # new
Jobs completed:  2    # new
```

Verbose (new):
```
Agents in queue: 1
Available:       1
Busy:            0
Offline:         0
Jobs waiting:    1
Jobs running:    0
Jobs completed:  2

Waiting:
  de153d8f-7d32-47d7-9a05-a20f2ef6bb35 - 2023-10-13 15:22:46

Completed:
  8b0bb52f-08d8-4671-b275-55d84a965f7c - 2023-10-13 15:22:30
```

This implementation addresses the core need from issue #116 while maintaining full compatibility with existing usage and following established project patterns, and also helps the project close #CERTTF-248 internally.