### PR TITLE
fix(server): prevent client_id to be created from restricted-queue endpoint

### DIFF
--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -882,8 +882,16 @@ def add_restricted_queue(queue_name: str, json_data: dict) -> dict:
     """Add an owner to the specific restricted queue."""
     client_id = json_data.get("client_id", "")
 
+    # Validate client ID is available in request data
     if not client_id:
         abort(HTTPStatus.BAD_REQUEST, "Error: Missing client ID.")
+
+    # Validate client ID exists in database
+    if not database.check_client_exists(client_id):
+        abort(
+            HTTPStatus.NOT_FOUND,
+            "Error: Specified client_id does not exist.",
+        )
 
     if not database.queue_exists(queue_name):
         abort(

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -423,7 +423,6 @@ def add_restricted_queue(queue: str, client_id: str):
     mongo.db.client_permissions.update_one(
         {"client_id": client_id},
         {"$addToSet": {"allowed_queues": queue}},
-        upsert=True,
     )
 
 


### PR DESCRIPTION
## Description
This is a quick fix to prevent the creation of client_ids from the restricted-queues endpoints. The creation of new users is now done through the client-permissions API. 

Current restricted-queues will only add/remove restricted queues to existing client_ids.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
[CERTTF-688](https://warthogs.atlassian.net/browse/CERTTF-688)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
One of the tests was edited to include a test client and also added another unit test to validate the creation of restricted queues does not complete if the client_id does not exist. 
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-688]: https://warthogs.atlassian.net/browse/CERTTF-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ