### PR TITLE
fix(agent): Bug fix for unhandled exception

### DIFF
--- a/agent/src/testflinger_agent/__init__.py
+++ b/agent/src/testflinger_agent/__init__.py
@@ -127,7 +127,7 @@ def start_agent():
     agent = TestflingerAgent(client)
     while True:
         # Only check agent status and process jobs if server is available
-        if client.is_server_reacheable():
+        if client.is_server_reachable():
             is_offline, offline_comment = agent.check_offline()
             if is_offline:
                 logger.error(

--- a/agent/src/testflinger_agent/__init__.py
+++ b/agent/src/testflinger_agent/__init__.py
@@ -127,27 +127,25 @@ def start_agent():
     agent = TestflingerAgent(client)
     while True:
         # Only check agent status and process jobs if server is available
-        if client.is_server_reachable():
-            is_offline, offline_comment = agent.check_offline()
-            if is_offline:
-                logger.error(
-                    "Agent %s is offline, not processing jobs! "
-                    "Reason: %s\n"
-                    "Please contact TF Admin if you require assistance.",
-                    config.get("agent_id"),
-                    offline_comment or "Unknown",
-                )
-                while agent.check_offline()[0]:
-                    time.sleep(check_interval)
-            # Refresh the updated_at timestamp on advertised queues
-            client.post_advertised_queues()
-            logger.info("Checking jobs")
-            agent.process_jobs()
-            logger.info("Sleeping for %d", check_interval)
-            time.sleep(check_interval)
-        else:
-            # Waiting until we restore connectivity
-            client.wait_for_server_connectivity()
+        client.wait_for_server_connectivity()
+
+        is_offline, offline_comment = agent.check_offline()
+        if is_offline:
+            logger.error(
+                "Agent %s is offline, not processing jobs! "
+                "Reason: %s\n"
+                "Please contact TF Admin if you require assistance.",
+                config.get("agent_id"),
+                offline_comment or "Unknown",
+            )
+            while agent.check_offline()[0]:
+                time.sleep(check_interval)
+        # Refresh the updated_at timestamp on advertised queues
+        client.post_advertised_queues()
+        logger.info("Checking jobs")
+        agent.process_jobs()
+        logger.info("Sleeping for %d", check_interval)
+        time.sleep(check_interval)
 
 
 def load_config(configfile):

--- a/agent/src/testflinger_agent/__init__.py
+++ b/agent/src/testflinger_agent/__init__.py
@@ -134,7 +134,7 @@ def start_agent():
             logger.error(
                 "Agent %s is offline, not processing jobs! "
                 "Reason: %s\n"
-                "Please contact TF Admin if you require assistance.",
+                "Please contact Testflinger Admin if you require assistance.",
                 config.get("agent_id"),
                 offline_comment or "Unknown",
             )

--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -416,8 +416,7 @@ class TestflingerAgent:
                 shutil.move(rundir, results_basedir)
 
             # Complete cleanup only if server is reachable
-            if not self.client.is_server_reachable():
-                self.client.wait_for_server_connectivity()
+            self.client.wait_for_server_connectivity()
 
             # clear job id
             self.client.post_agent_data({"job_id": ""})

--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -415,8 +415,8 @@ class TestflingerAgent:
                 results_basedir = self.client.config.get("results_basedir")
                 shutil.move(rundir, results_basedir)
 
-            # Complete cleanup only if server is reacheable
-            if not self.client.is_server_reacheable():
+            # Complete cleanup only if server is reachable
+            if not self.client.is_server_reachable():
                 self.client.wait_for_server_connectivity()
 
             # clear job id

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -482,8 +482,8 @@ class TestflingerClient:
                 exc,
             )
 
-    def is_server_reacheable(self, timeout=10) -> bool:
-        """Check if server is reacheable by doing a health check.
+    def is_server_reachable(self, timeout=10) -> bool:
+        """Check if server is reachable by doing a health check.
 
         :param timeout: timeout for completing HTTP request
         :returns: True if server is reachable, False otherwise
@@ -508,7 +508,7 @@ class TestflingerClient:
         retry_count = 0
         while True:
             time.sleep(interval)
-            if self.is_server_reacheable():
+            if self.is_server_reachable():
                 logger.info("Testflinger server connectivity restored")
                 break
             else:

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -509,11 +509,10 @@ class TestflingerClient:
         while True:
             if self.is_server_reachable():
                 break
-            else:
-                logger.warning(
-                    "Testflinger server unreachable, waiting for connectivity"
-                )
-                time.sleep(interval)
-                # Exponentially increase interval between rechecks
-                interval = min(interval * (2**retry_count), max_interval)
-                retry_count += 1
+            logger.warning(
+                "Testflinger server unreachable, waiting for connectivity"
+            )
+            time.sleep(interval)
+            # Exponentially increase interval between rechecks
+            interval = min(interval * (2**retry_count), max_interval)
+            retry_count += 1

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -507,14 +507,13 @@ class TestflingerClient:
         """
         retry_count = 0
         while True:
-            time.sleep(interval)
             if self.is_server_reachable():
-                logger.info("Testflinger server connectivity restored")
                 break
             else:
                 logger.warning(
                     "Testflinger server unreachable, waiting for connectivity"
                 )
+                time.sleep(interval)
                 # Exponentially increase interval between rechecks
                 interval = min(interval * (2**retry_count), max_interval)
                 retry_count += 1

--- a/agent/src/testflinger_agent/job.py
+++ b/agent/src/testflinger_agent/job.py
@@ -125,7 +125,16 @@ class TestflingerJob:
         # Retrieve device info and send it to /result/<job_id> endpoint
         device_info = self.get_device_info(rundir)
         if device_info:
-            self.client.post_result(self.job_id, device_info)
+            try:
+                # raises TFServerError upon HTTP failure
+                self.client.post_result(self.job_id, device_info)
+            except TFServerError as exc:
+                logger.warning(
+                    "Failed to post device info during %s for job %s: %s",
+                    phase,
+                    self.job_id,
+                    exc,
+                )
 
         try:
             # Set exit_event to fail for this phase in case of an exception

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -929,7 +929,7 @@ class TestClient:
         # Mock server connectivity
         with patch("time.sleep"):
             # Server should be unavailable on first check
-            assert not agent.client.is_server_reacheable()
+            assert not agent.client.is_server_reachable()
 
             # Wait for connectivity to be restored
             agent.client.wait_for_server_connectivity(interval=1)

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -157,6 +157,7 @@ class TestClient:
         with rmock.Mocker() as mocker:
             mocker.post(rmock.ANY, status_code=200)
             # mock response to requesting jobs
+            mocker.get(f"{agent.client.server}/v1", status_code=200)
             mocker.get(
                 re.compile(r"/v1/job\?queue=\w+"),
                 [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
@@ -220,6 +221,7 @@ class TestClient:
         with rmock.Mocker() as mocker:
             mocker.post(rmock.ANY, status_code=200)
             # mock response to requesting jobs
+            mocker.get(f"{agent.client.server}/v1", status_code=200)
             mocker.get(
                 re.compile(r"/v1/job\?queue=\w+"),
                 [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
@@ -282,6 +284,7 @@ class TestClient:
         with rmock.Mocker() as mocker:
             mocker.post(rmock.ANY, status_code=200)
             # mock response to requesting jobs
+            mocker.get(f"{agent.client.server}/v1", status_code=200)
             mocker.get(
                 re.compile(r"/v1/job\?queue=\w+"),
                 [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
@@ -453,6 +456,7 @@ class TestClient:
         # In this case we are making sure that the repost job request
         # gets good status
         with rmock.Mocker() as m:
+            m.get(f"{agent.client.server}/v1", status_code=200)
             m.get(
                 "http://127.0.0.1:8000/v1/job?queue=test", json=fake_job_data
             )
@@ -894,6 +898,7 @@ class TestClient:
             "job_queue": "test",
             "provision_data": {"url": "foo"},
         }
+        requests_mock.get(f"{agent.client.server}/v1", status_code=200)
         requests_mock.get(
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
@@ -906,4 +911,3 @@ class TestClient:
         with patch("shutil.rmtree"):
             agent.process_jobs()
         assert "Failed to retrieve agent data" in caplog.text
-        assert "Taking agent offline" in caplog.text

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -935,5 +935,3 @@ class TestClient:
             agent.client.wait_for_server_connectivity(interval=1)
             # First attempt is also unsuccessful
             assert "Testflinger server unreachable" in caplog.text
-            # Server should recover in second attempt
-            assert "Testflinger server connectivity restored" in caplog.text

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -2237,7 +2237,7 @@ dev = [
 
 [[package]]
 name = "testflinger-common"
-version = "1.1.1"
+version = "1.1.2"
 source = { directory = "../common" }
 dependencies = [
     { name = "strenum" },

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "testflinger-common"
 description = "Testflinger common modules"
 readme = "README.md"
-version = "1.1.1"
+version = "1.1.2"
 requires-python = ">=3.10"
 dependencies = ["strenum>=0.4.15"]
 

--- a/common/src/testflinger_common/enums.py
+++ b/common/src/testflinger_common/enums.py
@@ -90,3 +90,4 @@ class AgentState(StrEnum):
     OFFLINE = "offline"
     MAINTENANCE = "maintenance"
     RESTART = "restart"
+    UNKNOWN = "unknown"

--- a/common/uv.lock
+++ b/common/uv.lock
@@ -100,7 +100,7 @@ wheels = [
 
 [[package]]
 name = "testflinger-common"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "strenum" },


### PR DESCRIPTION
## Description
Agents are showing as EXITED due to an unhandled exception when processing a job. 

During any test phase, the agent is resilient enough to handle HTTP errors and continue job processing, however, when getting to the cleanup phase, this forces the agent to raise a TFServerError Exception that is not handled properly. 

Traceback: 
```
requests.exceptions.RetryError: HTTPSConnectionPool(host='testflinger.canonical.com', port=443): Max retries exceeded with url: /v1/result/1dd65a8a-e1a0-4c89-8990-7ac7f8479156

  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/__init__.py", line 143, in start_agent
    agent.process_jobs()
  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/agent.py", line 400, in process_jobs
    exit_code, _, _ = job.run_test_phase(TestPhase.CLEANUP, rundir)
  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/job.py", line 128, in run_test_phase
    self.client.post_result(self.job_id, device_info)
  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/client.py", line 198, in post_result
    raise TFServerError("other exception") from exc
testflinger_agent.errors.TFServerError: HTTP Status: other exception
```

The `client.post_result()` in `run_test_phase()` was not wrapped in a try-except block and the only reason why the other phases work are due to the general exception... Cleanup is handled differently in a `finally` block

Additionally to handling the TFServerError, this PR also addressed the following when the server is unreachable:

Before job:
The agent will simply go to sleep until the server is reachable again, in the meantime, will log that the server couldn't be reached.

During job:
Since now at every stage it attempts to get the status of the agent, if its unable to do it, it won't assume is offline, it will get an "unknown" status that is never sent to the server, this is just for agent resiliency, otherwise the agent will be marked as offline and will require manual intervention.
Additionally, the job will not be able to "finish" unless its able to clear the job_id from the database and send its status to the server. This to avoid any inconsistency.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-689](https://warthogs.atlassian.net/browse/CERTTF-689)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-689]: https://warthogs.atlassian.net/browse/CERTTF-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ