### PR TITLE
fix(cli): add setuptools_scm section

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -70,3 +70,6 @@ convention = "pep257"
 
 [tool.uv]
 cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true } }]
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -72,4 +72,5 @@ convention = "pep257"
 cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true } }]
 
 [tool.setuptools_scm]
+root = ".."
 fallback_version = "0.0.0"


### PR DESCRIPTION
## Description

A recent `setuptools_scm` update made it so that we can no longer install the `testflinger-cli` tool using 

```
uv tool install git+https://github.com/canonical/testflinger#subdirectory=cli
```

We would get the following error:
```
error: The build backend returned an error
  Caused by: Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

[stderr]
toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
Traceback (most recent call last):
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 113, in read_pyproject
    section = defn.get("tool", {})[tool_name]
KeyError: 'setuptools_scm'
Traceback (most recent call last):
  File "<string>", line 14, in <module>
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=[])
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
    self.run_setup()
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools/build_meta.py", line 317, in run_setup
    exec(code, locals())
  File "<string>", line 1, in <module>
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools/__init__.py", line 115, in setup
    return distutils.core.setup(**attrs)
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 148, in setup
    _setup_distribution = dist = klass(attrs)
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools/dist.py", line 321, in __init__
    _Distribution.__init__(self, dist_attrs)
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 309, in __init__
    self.finalize_options()
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools/dist.py", line 784, in finalize_options
    ep(self)
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools_scm/_integration/setuptools.py", line 129, in infer_version
    result.apply(dist)
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools_scm/_integration/version_inference.py", line 48, in apply
    _version_missing(config)
  File "/home/calinp/.cache/uv/builds-v0/.tmpb5vBYp/lib/python3.10/site-packages/setuptools_scm/_get_version_impl.py", line 188, in _version_missing
    raise LookupError(error_msg)
LookupError: setuptools-scm was unable to detect version for /home/calinp/.cache/uv/git-v0/checkouts/04db69cccab77f75/7a1a7b8/cli.

Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj

Alternatively, set the version with the environment variable SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME} as described in https://setuptools-scm.readthedocs.io/en/latest/config/

hint: This usually indicates a problem with the package or the build environment.
```

Basically it seems the `tool.setuptools_scm` section is no longer optional and neither is specifying a fallback revision (I chose 0.0.0 in this case).


## Resolved issues

N/A

## Documentation

I looked at the [Install in a virtual environment](https://canonical-testflinger.readthedocs-hosted.com/latest/how-to/install-cli/#install-in-virtual-environment) section of the documentation and although I think that should be updated to include `uv`, that particular flow doesn't change. (It was broken before this commit, though)

## Web service API changes

N/A

## Tests

N/A
