### PR TITLE
fix(oem_autoinstall): Default stock default-user-data to match raid storage

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
@@ -77,7 +77,7 @@ autoinstall:
           }
 
           set_usb_boot_first
-        path: /tmp/set_usb_boot.sh
+        path: /usr/local/bin/set_usb_boot.sh
         permissions: '0755'
 
     users:
@@ -104,7 +104,7 @@ autoinstall:
       - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.settings-daemon.plugins.power"]
       - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.desktop.session"]
       - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.desktop.screensaver"]
-      - ["/tmp/set_usb_boot.sh"]
+      - ["/usr/local/bin/set_usb_boot.sh"]
     # Reboot after early-welcome is done
     power_state:
       mode: "reboot"

--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/stock/default-user-data
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/stock/default-user-data
@@ -6,7 +6,6 @@ autoinstall:
   storage:
     layout:
       name: direct
-      #reset-partition: 12G
       match:
         - path: /dev/dm*
         - path: /dev/md*
@@ -77,7 +76,7 @@ autoinstall:
           }
 
           set_usb_boot_first
-        path: /tmp/set_usb_boot.sh
+        path: /usr/local/bin/set_usb_boot.sh
         permissions: '0755'
     runcmd:
       # enable autologin
@@ -88,7 +87,7 @@ autoinstall:
       - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.settings-daemon.plugins.power"]
       - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.desktop.session"]
       - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.desktop.screensaver"]
-      - ["/tmp/set_usb_boot.sh"]  # set USB boot first (after system has booted successfully)
+      - ["/usr/local/bin/set_usb_boot.sh"]  # set USB boot first
       - ["sudo", "apt-get", "update"]
       - ["sudo", "apt-get", "install", "-y", "openssh-server"]
   ssh:
@@ -97,8 +96,3 @@ autoinstall:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCYYa9VOGB5NBJzRQ7OnxG4Z6ynBs+B2+A49RVcNWhzWtwPkEEefsHDIz0VLbVSfGJGQMF2Dsw8PVJWBRTBvc1bkHt3sUCZklAmGVbOhXEaXS/GzCjMEb0Kg8jvEzH3WxLm0X4fIQeIDAE6Za/t5ix3uNwYgzZiGT7isx7aDQtpOrZD+y2n3F1xvDPdySJ304hAkAvMGnkwstNXduUXrnOEoPeOrQbk+k85otyaGqL0C/U+SkeeAKnzikkmvxrZlcp2zxow8iGMTfVNY15nA9BKx4v21nnIKnhVdWZ43ltp9dQoafOXbNtYTxTnFvmaHQ1WFGJ+1/fDAY8tfbjbQaIxPvPJ ubuntu@juju-machine-8-lxc-0
   early-commands:
     - "nmcli networking off"  # to prevent online checks and speed up intallation
-  # late-commands:
-  #   # enable auto login
-  #   - echo "[daemon]" > /target/etc/gdm3/custom.conf
-  #   - echo "AutomaticLoginEnable=true" >> /target/etc/gdm3/custom.conf
-  #   - echo "AutomaticLogin=ubuntu" >> /target/etc/gdm3/custom.conf


### PR DESCRIPTION
## Description
Changes to default user-data configs in oem_autoinstall connector:
 - stock installer from media to match raid storage first
 - fix autologin
 - change location of set_usb_boot.sh to keep for later use
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Run provision from local agent with updated user-data. Verify stock installer can complete on platform with RAID1
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
