### PR TITLE
fix(agent): send a heartbeat to server to prevent database TTL

### DIFF
--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from .client import TestflingerClient
 
@@ -85,6 +85,7 @@ class AgentStatusHandler:
         """Retrieve the comment on the state."""
         return self._comment
 
+
 class AgentHeartbeatHandler:
     """Handler to determine if agent needs to send a heartbeat signal."""
 
@@ -98,7 +99,7 @@ class AgentHeartbeatHandler:
         self.heartbeat_frequency = heartbeat_frequency
         self._agent_data = {}
         # Agent sent heartbeat upon initialization or restart
-        self._last_heartbeat = datetime.now(UTC)
+        self._last_heartbeat = datetime.now(timezone.utc)
 
     def update(self, agent_data: dict):
         """Update agent_data retrieved from server.
@@ -118,9 +119,10 @@ class AgentHeartbeatHandler:
         if "updated_at" in self._agent_data:
             # Parse ISO format timestamp
             timestamp = self._agent_data["updated_at"]
-            self._last_heartbeat = datetime.fromisoformat(
-                timestamp.replace("Z", "+00:00")
-            )
+            if isinstance(timestamp, str):
+                self._last_heartbeat = datetime.fromisoformat(
+                    timestamp.replace("Z", "+00:00")
+                )
 
     def _send_heartbeat(self) -> None:
         """Send a heartbeat to the server if needed.
@@ -140,7 +142,7 @@ class AgentHeartbeatHandler:
 
         :return: True or False if heartbeat is required
         """
-        time_delta = datetime.now(UTC) - self._last_heartbeat
+        time_delta = datetime.now(timezone.utc) - self._last_heartbeat
         # Heartbeat is required at least once per heartbeat frequency
         if time_delta.days >= self.heartbeat_frequency:
             return True

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -12,6 +12,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
+from datetime import UTC, datetime
+
 from .client import TestflingerClient
 
 
@@ -82,3 +84,60 @@ class AgentStatusHandler:
     def comment(self) -> str:
         """Retrieve the comment on the state."""
         return self._comment
+
+class AgentHeartbeatHandler:
+    """Handler to determine if agent needs to send a heartbeat signal."""
+
+    def __init__(self, client: TestflingerClient, heartbeat_frequency: int):
+        """Initialize handler with default values."""
+        self.client = client
+        self.heartbeat_frequency = heartbeat_frequency
+        self._agent_data = {}
+        # Agent sent heartbeat upon initialization or restart
+        self._last_heartbeat = datetime.now(UTC)
+
+    def update(self, agent_data: dict):
+        """Update agent_data retrieved from server.
+
+        :param agent_data: Agent information retrieved from server.
+        """
+        if agent_data:
+            self._agent_data = agent_data
+            self._refresh_last_heartbeat()
+            self._send_heartbeat()
+
+    def _refresh_last_heartbeat(self) -> None:
+        """Update heartbeat from agent_data.
+
+        :param agent_data: All agent information retrieved from server.
+        """
+        if "updated_at" in self._agent_data:
+            # Parse ISO format timestamp
+            timestamp = self._agent_data["updated_at"]
+            self._last_heartbeat = datetime.fromisoformat(
+                timestamp.replace("Z", "+00:00")
+            )
+
+    def _send_heartbeat(self) -> None:
+        """Send a heartbeat to the server if needed.
+
+        Heartbeat signal is current agent status and comment.
+        """
+        if self.is_heartbeat_required():
+            comment = self._agent_data.get("comment", "")
+            if "state" in self._agent_data:
+                agent_state = self._agent_data["state"]
+                self.client.post_agent_data(
+                    {"state": agent_state, "comment": comment}
+                )
+
+    def is_heartbeat_required(self) -> bool:
+        """Determine if heartbeat is required to send to server.
+
+        :return: True or False if heartbeat is required
+        """
+        time_delta = datetime.now(UTC) - self._last_heartbeat
+        # Heartbeat is required at least once per heartbeat frequency
+        if time_delta.days >= self.heartbeat_frequency:
+            return True
+        return False

--- a/agent/src/testflinger_agent/handlers.py
+++ b/agent/src/testflinger_agent/handlers.py
@@ -89,7 +89,11 @@ class AgentHeartbeatHandler:
     """Handler to determine if agent needs to send a heartbeat signal."""
 
     def __init__(self, client: TestflingerClient, heartbeat_frequency: int):
-        """Initialize handler with default values."""
+        """Initialize handler with default values.
+
+        :param client: client used to connect to server
+        :param heartbeat_frequency: Frequency in days to send heartbeat
+        """
         self.client = client
         self.heartbeat_frequency = heartbeat_frequency
         self._agent_data = {}


### PR DESCRIPTION
## Description
MongoDB is configured with a TTL (time to live) of 7 days after which if the agent has not sent any update to the server, it will be automatically removed. This can happen if agent does not receive any job during that period or restarted. 

This PR allows to send a heartbeat to the server at least once per day by getting the last time it sent its state to the server. This new logic is only being made while job is "waiting" for jobs or if the agent has been "offline" and if needed, it will send the same state and comment it retrieved from the server (to preserve offline). Server automatically adds the `updated_at` key to each request
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-703](https://warthogs.atlassian.net/browse/CERTTF-703)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit test for this new behavior
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
