### PR TITLE
Add: oem_autoinstall to support dummyefi type

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/zapper_oem.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/zapper_oem.py
@@ -35,7 +35,7 @@ class ZapperOem(ZapperConnector):
         for the Zapper `provision` API.
         """
         logger.info("Validating configuration")
-        supported_iso_types = {"bootstrap", "stock", "bios"}
+        supported_iso_types = {"bootstrap", "stock", "bios", "dummyefi"}
         provision_data = self.job_data["provision_data"]
 
         iso_type = provision_data.get("zapper_iso_type")


### PR DESCRIPTION
## Description
Add `dummyefi` type iso to provision job. This will allow submit jobs to format the USB media on support device side.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
1. Run local agent
2. Submit `job.yaml` with `iso_type: dummyefi` and `iso_url: dummyefi`
3. After job completed verify the efibootmgr order

```
INFO: DEVICE CONNECTOR: USB boot entry found: 0004
Setting new boot order: 0004,0005,0000,0001,0002,0003
BootCurrent: 0005
Timeout: 0 seconds
BootOrder: 0004,0005,0000,0001,0002,0003
Boot0000* UEFI PC811 SED SK hynix 1024GB ASD8N487711108T6H 1	HD(1,GPT,871a6c3d-507d-4799-85c1-e6584fcda8eb,0x800,0x219800)/File(\EFI\Boot\BootX64.efi){auto_created_boot_option}
Boot0001* USB NIC (IPV4)	PciRoot(0x0)/Pci(0x14,0x0)/USB(15,0)/MAC(00e04f8238e1,0)/IPv4(0.0.0.00.0.0.0,0,0){auto_created_boot_option}
Boot0002* USB NIC (IPV6)	PciRoot(0x0)/Pci(0x14,0x0)/USB(15,0)/MAC(00e04f8238e1,0)/IPv6([::]:<->[::]:,0,0){auto_created_boot_option}
Boot0003* UEFI HTTPs Boot (MAC:00E04F8238E1)	PciRoot(0x0)/Pci(0x14,0x0)/USB(15,0)/MAC(00e04f8238e1,0)/IPv4(0.0.0.00.0.0.0,0,0)/Uri(){auto_created_boot_option}
Boot0004* UEFI Samsung Type-C 0396123110007815	PciRoot(0x0)/Pci(0x14,0x0)/USB(13,0)/HD(1,GPT,201adfea-f1cc-48dd-aefa-1fe89186ef42,0x800,0x3bc0800)/File(\EFI\Boot\BootX64.efi){auto_created_boot_option}
Boot0005* Ubuntu	HD(1,GPT,871a6c3d-507d-4799-85c1-e6584fcda8eb,0x800,0x219800)/File(\EFI\ubuntu\shimx64.efi)

```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
