### PR TITLE
feat(server): introduce secrets store based on CSFLE in MongoDB

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -21,8 +21,9 @@ services:
       MONGODB_HOST: mongo
       MONGODB_PASSWORD: testflinger
       MONGODB_USERNAME: testflinger
-      TESTFLINGER_VAULT_TOKEN: myroot
-      TESTFLINGER_VAULT_URL: http://vault:8200
+      MONGO_MASTER_KEY: +HQgnGBgPmmvoYB82nGbKERUp15bZOrNyDxHb3mMfx8+jrn4KbPBGOh7GRWDSGrSa1qOq/ibTThG+b7JGDRo0hgLinpFz5uz+8TWJdXbTGb24Qw+tuyH7kcPRPBMU3br
+      # TESTFLINGER_VAULT_TOKEN: myroot
+      # TESTFLINGER_VAULT_URL: http://vault:8200
       WEB_SECRET_KEY: my_web_secret_key
       OIDC_CLIENT_ID: testflinger-client
       OIDC_CLIENT_SECRET: my-oidc-secret

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "testflinger"
 description = "Testflinger Server"
 readme = "README.md"
-version = "1.3.0"
+version = "1.4.0"
 authors = []
 requires-python = ">=3.10"
 dependencies = [
@@ -20,7 +20,7 @@ dependencies = [
     "prometheus-client>=0.21.0",
     "prometheus-flask-exporter>=0.23.1",
     "pyjwt>=2.8.0",
-    "pymongo<4.9.0",
+    "pymongo[encryption]<4.9.0",
     "pyyaml>=6.0.1",
     "requests>=2.31.0",
     "sentry-sdk>= 2.0.1",

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -1253,3 +1253,22 @@ def secrets_delete(client_id, path):
         abort(HTTPStatus.INTERNAL_SERVER_ERROR, message=str(error))
 
     return "OK"
+
+
+@v1.get("/secrets/<client_id>/<path:path>")
+@authenticate
+def secrets_get(client_id, path):
+    """Read a secret value for the specified client_id and path."""
+    if current_app.secrets_store is None:
+        abort(HTTPStatus.BAD_REQUEST, message="No secrets store")
+    if client_id != g.client_id:
+        abort(
+            HTTPStatus.FORBIDDEN,
+            message=f"'{client_id}' doesn't match authenticated client id",
+        )
+    try:
+        return current_app.secrets_store.read(client_id, path)
+    except AccessError as error:
+        abort(HTTPStatus.BAD_REQUEST, message=str(error))
+    except (StoreError, UnexpectedError) as error:
+        abort(HTTPStatus.INTERNAL_SERVER_ERROR, message=str(error))

--- a/server/src/testflinger/secrets/__init__.py
+++ b/server/src/testflinger/secrets/__init__.py
@@ -15,24 +15,48 @@
 
 """Default setup for the Testflinger secrets store."""
 
+import base64
+import logging
 import os
+from contextlib import suppress
 
 import requests
+from bson.codec_options import CodecOptions
 from hvac import Client
+from pymongo import MongoClient
+from pymongo.encryption import ClientEncryption
+from pymongo.errors import EncryptionError
 
+from testflinger.database import get_mongo_uri
 from testflinger.secrets.exceptions import StoreError
+from testflinger.secrets.mongo import MongoStore
 from testflinger.secrets.store import SecretsStore
 from testflinger.secrets.vault import VaultStore
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+formatter = logging.Formatter(
+    "[%(asctime)s] [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S %z",
+)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
-def setup_secrets_store() -> SecretsStore | None:
+
+def setup_vault_store() -> VaultStore:
     """
-    Create and return a store for secrets, if possible.
+    Set up HashiCorp Vault-based secrets store.
 
-    Currently, the store returned is an instance of `VaultStore`.
+    Creates a VaultStore instance using environment variables for
+    configuration.
 
-    Not setting up a secrets store is not an error: it just means that
-    Testflinger jobs will not be able to use secrets.
+    Returns:
+        A VaultStore, if the appropriate environment variables have been set
+        or None otherwise.
+
+    Raises:
+        StoreError: If Vault client authentication fails
     """
     vault_url = os.environ.get("TESTFLINGER_VAULT_URL")
     vault_token = os.environ.get("TESTFLINGER_VAULT_TOKEN")
@@ -44,6 +68,107 @@ def setup_secrets_store() -> SecretsStore | None:
         if not client.is_authenticated():
             raise StoreError("Vault client not authenticated")
     except requests.exceptions.ConnectionError as error:
-        raise StoreError("Unable to create Vault client") from error
+        raise StoreError("Vault client unable to connect") from error
 
     return VaultStore(client)
+
+
+def setup_mongo_store() -> MongoStore | None:
+    """
+    Set up MongoDB-based secrets store with Client-Side Field Level Encryption.
+
+    Creates a MongoStore instance using explicit CSFLE for secret storage.
+    The function handles data encryption key creation/rotation.
+
+    Returns:
+        A MongoStore, if the appropriate environment variables have been set
+        or None otherwise.
+
+    Raises:
+        StoreError: If master key is missing/invalid or encryption setup fails
+    """
+    try:
+        mongo_url = get_mongo_uri()
+    except SystemExit:
+        return None
+
+    master_key_b64 = os.environ.get("MONGO_MASTER_KEY")
+    if not master_key_b64:
+        return None
+
+    try:
+        master_key = base64.b64decode(master_key_b64)
+    except Exception as error:
+        raise StoreError(
+            "Environment variables with Mongo credentials are incorrect"
+        ) from error
+
+    # Explit Client-Side Field-Level Encryption
+    # Reference: https://www.mongodb.com/docs/manual/core/csfle/fundamentals/manual-encryption/
+    # PyMongo docs: https://pymongo.readthedocs.io/en/stable/examples/encryption.html#explicit-encryption-and-decryption
+    client = MongoClient(mongo_url)
+
+    """
+    try:
+        client.admin.command('ping')
+    except pymongo.errors.ConnectionFailure as error:
+         raise StoreError(
+            f"Mongo client unable to ping database at {mongo_url}"
+         ) from error
+    """
+
+    kms_providers = {"local": {"key": master_key}}
+    # database and collection where secrets are stored (the "vault")
+    key_vault_db = "encryption"
+    key_vault_collection = "__keyVault"
+    # human-readable name for the data key that encrypts the secrets
+    key_name = "testflinger-secrets"
+    # all encryption/decryption of secret values goes through the cipher
+    # (i.e. a `ClientEncryption` object)
+    cipher = ClientEncryption(
+        kms_providers=kms_providers,
+        key_vault_namespace=f"{key_vault_db}.{key_vault_collection}",
+        key_vault_client=client,
+        codec_options=CodecOptions(),
+    )
+
+    # create data encryption key, if none exists
+    key_vault = client[key_vault_db][key_vault_collection]
+    existing_key = key_vault.find_one({"keyAltNames": key_name})
+    if not existing_key:
+        try:
+            cipher.create_data_key("local", key_alt_names=[key_name])
+        except EncryptionError as error:
+            raise StoreError(
+                f"Failed to create data encryption key: {error}"
+            ) from error
+
+    return MongoStore(client, cipher, key_name)
+
+
+def setup_secrets_store() -> SecretsStore | None:
+    """
+    Create and return a store for secrets, if possible.
+
+    Currently, the store returned is an instance of `VaultStore`.
+
+    Not setting up a secrets store is not an error: it just means that
+    Testflinger jobs will not be able to use secrets.
+    """
+    with suppress(StoreError):
+        store = setup_vault_store()
+        if store is not None:
+            logger.info(
+                "Successfully initialized the secrets store (Vault-based)"
+            )
+            return store
+
+    with suppress(StoreError):
+        store = setup_mongo_store()
+        if store is not None:
+            logger.info(
+                "Successfully initialized the secrets store (Mongo-based)"
+            )
+            return store
+
+    logger.warning("The secrets store has not been initialized")

--- a/server/src/testflinger/secrets/mongo.py
+++ b/server/src/testflinger/secrets/mongo.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2025 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A Mongo-based implementation for the Testflinger secrets store."""
+
+from pymongo import MongoClient
+from pymongo.encryption import Algorithm, ClientEncryption
+from pymongo.errors import ConnectionFailure, EncryptionError, OperationFailure
+
+from testflinger.secrets.exceptions import AccessError, StoreError
+from testflinger.secrets.store import SecretsStore
+
+
+class MongoStore(SecretsStore):
+    """MongoDB-based secrets store using explicit Client-Side Field Level
+    Encryption.
+
+    References for Explicit CSFLE (Client-Side Field-Level Encryption):
+    https://www.mongodb.com/docs/manual/core/csfle/fundamentals/manual-encryption/
+    https://pymongo.readthedocs.io/en/4.13.2/examples/encryption.html#explicit-client-side-encryption
+    """
+
+    def __init__(
+        self,
+        client: MongoClient,
+        cipher: ClientEncryption,
+        data_key_name: str,
+    ):
+        """Initialize MongoStore with client, cipher, and data key name."""
+        self.database = client.get_default_database()
+        self.cipher = cipher
+        self.data_key_name = data_key_name
+        self.algorithm = Algorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Random
+
+    def read(self, namespace: str, key: str) -> str:
+        """Return the stored value for `key` under `namespace`."""
+        try:
+            result = self.database.secrets[namespace].find_one({"key": key})
+        except OperationFailure as error:
+            raise AccessError(
+                f"Unable to access '{key}' under '{namespace}'"
+            ) from error
+        except ConnectionFailure as error:
+            raise StoreError(
+                f"Unable to access store for '{key}' under '{namespace}'"
+            ) from error
+        if result is None:
+            raise AccessError(f"Unable to access '{key}' under '{namespace}'")
+
+        encrypted_value = result["value"]
+        try:
+            decrypted_value = self.cipher.decrypt(encrypted_value)
+        except EncryptionError as error:
+            raise StoreError(
+                f"Failed to decrypt value for '{key}' under '{namespace}'"
+            ) from error
+        if decrypted_value is None:
+            raise StoreError(
+                f"Failed to decrypt value for '{key}' under '{namespace}'"
+            )
+        try:
+            return decrypted_value.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise StoreError(
+                f"Failed to decrypt value for '{key}' under '{namespace}'"
+            ) from error
+
+    def write(self, namespace: str, key: str, value: str):
+        """Write the `value` for `key` under `namespace`."""
+        try:
+            encrypted_value = self.cipher.encrypt(
+                value=value.encode("utf-8"),
+                algorithm=self.algorithm,
+                key_alt_name=self.data_key_name,
+            )
+        except (EncryptionError, UnicodeEncodeError) as error:
+            raise StoreError(
+                f"Failed to encrypt value for '{key}' under '{namespace}'"
+            ) from error
+
+        try:
+            self.database.secrets[namespace].replace_one(
+                {"key": key},
+                {"key": key, "value": encrypted_value},
+                upsert=True,
+            )
+        except OperationFailure as error:
+            raise AccessError(
+                f"Unable to access '{key}' under '{namespace}'"
+            ) from error
+        except ConnectionFailure as error:
+            raise StoreError(
+                f"Unable to access store for '{key}' under '{namespace}'"
+            ) from error
+
+    def delete(self, namespace: str, key: str):
+        """Delete the value for `key` under `namespace`, if any."""
+        try:
+            self.database.secrets[namespace].delete_one({"key": key})
+        except OperationFailure as error:
+            raise AccessError(
+                f"Unable to access '{key}' under '{namespace}'"
+            ) from error
+        except ConnectionFailure as error:
+            raise StoreError(
+                f"Unable to access store for '{key}' under '{namespace}'"
+            ) from error

--- a/server/tests/test_mongo_store.py
+++ b/server/tests/test_mongo_store.py
@@ -1,0 +1,451 @@
+# Copyright (C) 2025 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the MongoDB-based implementation of the secrets store."""
+
+import base64
+import os
+
+import pytest
+from bson.binary import Binary
+from pymongo import MongoClient
+from pymongo.encryption import ClientEncryption
+from pymongo.errors import ConnectionFailure, EncryptionError, OperationFailure
+
+from testflinger.secrets import setup_mongo_store
+from testflinger.secrets.exceptions import (
+    AccessError,
+    StoreError,
+)
+from testflinger.secrets.mongo import MongoStore
+
+
+class TestMongoStore:
+    """Test cases for MongoStore class."""
+
+    @pytest.fixture
+    def mock_client(self, mocker):
+        """Mock MongoClient."""
+        return mocker.Mock(spec=MongoClient)
+
+    @pytest.fixture
+    def mock_client_encryption(self, mocker):
+        """Mock ClientEncryption."""
+        return mocker.Mock(spec=ClientEncryption)
+
+    @pytest.fixture
+    def mock_database(self, mocker):
+        """Mock database object."""
+        return mocker.Mock()
+
+    @pytest.fixture
+    def mongo_store(self, mock_client, mock_client_encryption, mock_database):
+        """MongoStore instance with mocked dependencies."""
+        mock_client.get_default_database.return_value = mock_database
+        return MongoStore(mock_client, mock_client_encryption, "test-key")
+
+    @pytest.fixture
+    def mock_collection(self, mock_database, mocker):
+        """Mock collection object."""
+        collection = mocker.Mock()
+        mock_database.secrets.__getitem__ = mocker.Mock(
+            return_value=collection
+        )
+        return collection
+
+    def test_read_success(
+        self, mongo_store, mock_collection, mock_client_encryption
+    ):
+        """Test successful secret read."""
+        encrypted_value = Binary(b"encrypted_data")
+        mock_collection.find_one.return_value = {
+            "key": "test-key",
+            "value": encrypted_value,
+        }
+        mock_client_encryption.decrypt.return_value = b"test-secret-value"
+
+        result = mongo_store.read("test-namespace", "test-key")
+
+        assert result == "test-secret-value"
+        mock_collection.find_one.assert_called_once_with({"key": "test-key"})
+        mock_client_encryption.decrypt.assert_called_once_with(encrypted_value)
+
+    def test_read_document_not_found(self, mongo_store, mock_collection):
+        """Test read when document doesn't exist raises AccessError."""
+        mock_collection.find_one.return_value = None
+
+        with pytest.raises(
+            AccessError,
+            match="Unable to access 'test-key' under 'test-namespace'",
+        ):
+            mongo_store.read("test-namespace", "test-key")
+
+    def test_read_operation_failure(self, mongo_store, mock_collection):
+        """Test read with OperationFailure raises AccessError."""
+        mock_collection.find_one.side_effect = OperationFailure(
+            "Permission denied"
+        )
+
+        with pytest.raises(
+            AccessError,
+            match="Unable to access 'test-key' under 'test-namespace'",
+        ):
+            mongo_store.read("test-namespace", "test-key")
+
+    def test_read_connection_failure(self, mongo_store, mock_collection):
+        """Test read with ConnectionFailure raises StoreError."""
+        mock_collection.find_one.side_effect = ConnectionFailure(
+            "Connection lost"
+        )
+
+        with pytest.raises(
+            StoreError,
+            match="Unable to access store for 'test-key' under "
+            "'test-namespace'",
+        ):
+            mongo_store.read("test-namespace", "test-key")
+
+    def test_read_encryption_error(
+        self, mongo_store, mock_collection, mock_client_encryption
+    ):
+        """Test read with EncryptionError raises StoreError."""
+        encrypted_value = Binary(b"encrypted_data")
+        mock_collection.find_one.return_value = {
+            "key": "test-key",
+            "value": encrypted_value,
+        }
+        mock_client_encryption.decrypt.side_effect = EncryptionError(
+            "Decryption failed"
+        )
+
+        with pytest.raises(
+            StoreError,
+            match="Failed to decrypt value for 'test-key' under "
+            "'test-namespace'",
+        ):
+            mongo_store.read("test-namespace", "test-key")
+
+    def test_read_unicode_decode_error(
+        self, mongo_store, mock_collection, mock_client_encryption
+    ):
+        """Test read with UnicodeDecodeError raises StoreError."""
+        encrypted_value = Binary(b"encrypted_data")
+        mock_collection.find_one.return_value = {
+            "key": "test-key",
+            "value": encrypted_value,
+        }
+        mock_client_encryption.decrypt.return_value = b"\xff\xfe"
+
+        with pytest.raises(
+            StoreError,
+            match="Failed to decrypt value for 'test-key' under "
+            "'test-namespace'",
+        ):
+            mongo_store.read("test-namespace", "test-key")
+
+    def test_read_decrypt_none(
+        self, mongo_store, mock_collection, mock_client_encryption
+    ):
+        """Test read when decrypt returns None raises StoreError."""
+        encrypted_value = Binary(b"encrypted_data")
+        mock_collection.find_one.return_value = {
+            "key": "test-key",
+            "value": encrypted_value,
+        }
+        mock_client_encryption.decrypt.return_value = None
+
+        with pytest.raises(
+            StoreError,
+            match="Failed to decrypt value for 'test-key' under "
+            "'test-namespace'",
+        ):
+            mongo_store.read("test-namespace", "test-key")
+
+    def test_write_success(
+        self, mongo_store, mock_collection, mock_client_encryption
+    ):
+        """Test successful secret write."""
+        encrypted_value = Binary(b"encrypted_data")
+        mock_client_encryption.encrypt.return_value = encrypted_value
+
+        mongo_store.write("test-namespace", "test-key", "test-value")
+
+        mock_client_encryption.encrypt.assert_called_once_with(
+            value="test-value".encode("utf-8"),
+            algorithm=mongo_store.algorithm,
+            key_alt_name="test-key",
+        )
+        mock_collection.replace_one.assert_called_once_with(
+            {"key": "test-key"},
+            {"key": "test-key", "value": encrypted_value},
+            upsert=True,
+        )
+
+    def test_write_encryption_error(
+        self, mongo_store, mock_collection, mock_client_encryption
+    ):
+        """Test write with EncryptionError raises StoreError."""
+        mock_client_encryption.encrypt.side_effect = EncryptionError(
+            "Encryption failed"
+        )
+
+        with pytest.raises(
+            StoreError,
+            match="Failed to encrypt value for 'test-key' under "
+            "'test-namespace'",
+        ):
+            mongo_store.write("test-namespace", "test-key", "test-value")
+
+    def test_write_unicode_encode_error(
+        self, mongo_store, mock_collection, mock_client_encryption
+    ):
+        """Test write with UnicodeEncodeError raises StoreError."""
+        mock_client_encryption.encrypt.side_effect = UnicodeEncodeError(
+            "utf-8", "", 0, 1, "Invalid encoding"
+        )
+
+        with pytest.raises(
+            StoreError,
+            match="Failed to encrypt value for 'test-key' under "
+            "'test-namespace'",
+        ):
+            mongo_store.write("test-namespace", "test-key", "test-value")
+
+    def test_write_operation_failure(
+        self, mongo_store, mock_collection, mock_client_encryption
+    ):
+        """Test write with OperationFailure raises AccessError."""
+        encrypted_value = Binary(b"encrypted_data")
+        mock_client_encryption.encrypt.return_value = encrypted_value
+        mock_collection.replace_one.side_effect = OperationFailure(
+            "Permission denied"
+        )
+
+        with pytest.raises(
+            AccessError,
+            match="Unable to access 'test-key' under 'test-namespace'",
+        ):
+            mongo_store.write("test-namespace", "test-key", "test-value")
+
+    def test_write_connection_failure(
+        self, mongo_store, mock_collection, mock_client_encryption
+    ):
+        """Test write with ConnectionFailure raises StoreError."""
+        encrypted_value = Binary(b"encrypted_data")
+        mock_client_encryption.encrypt.return_value = encrypted_value
+        mock_collection.replace_one.side_effect = ConnectionFailure(
+            "Connection lost"
+        )
+
+        with pytest.raises(
+            StoreError,
+            match="Unable to access store for 'test-key' under "
+            "'test-namespace'",
+        ):
+            mongo_store.write("test-namespace", "test-key", "test-value")
+
+    def test_delete_success(self, mongo_store, mock_collection):
+        """Test successful secret delete."""
+        mongo_store.delete("test-namespace", "test-key")
+
+        mock_collection.delete_one.assert_called_once_with({"key": "test-key"})
+
+    def test_delete_operation_failure(self, mongo_store, mock_collection):
+        """Test delete with OperationFailure raises AccessError."""
+        mock_collection.delete_one.side_effect = OperationFailure(
+            "Permission denied"
+        )
+
+        with pytest.raises(
+            AccessError,
+            match="Unable to access 'test-key' under 'test-namespace'",
+        ):
+            mongo_store.delete("test-namespace", "test-key")
+
+    def test_delete_connection_failure(self, mongo_store, mock_collection):
+        """Test delete with ConnectionFailure raises StoreError."""
+        mock_collection.delete_one.side_effect = ConnectionFailure(
+            "Connection lost"
+        )
+
+        with pytest.raises(
+            StoreError,
+            match="Unable to access store for 'test-key' under "
+            "'test-namespace'",
+        ):
+            mongo_store.delete("test-namespace", "test-key")
+
+    def test_delete_nonexistent_key(self, mongo_store, mock_collection):
+        """Test delete of non-existent key succeeds silently."""
+        mock_collection.delete_one.return_value.deleted_count = 0
+
+        mongo_store.delete("test-namespace", "nonexistent-key")
+
+        mock_collection.delete_one.assert_called_once_with(
+            {"key": "nonexistent-key"}
+        )
+
+    def test_initialization(
+        self, mock_client, mock_client_encryption, mock_database
+    ):
+        """Test MongoStore initialization."""
+        mock_client.get_default_database.return_value = mock_database
+
+        store = MongoStore(
+            mock_client, mock_client_encryption, "test-data-key"
+        )
+
+        assert store.database == mock_database
+        assert store.cipher == mock_client_encryption
+        assert store.data_key_name == "test-data-key"
+        assert store.algorithm is not None
+
+    def test_namespace_collection_access(
+        self, mongo_store, mock_database, mocker
+    ):
+        """Test that namespaces create proper collection access."""
+        namespace = "production"
+        key = "api-key"
+
+        mock_collection = mocker.Mock()
+        mock_database.secrets.__getitem__ = mocker.Mock(
+            return_value=mock_collection
+        )
+        mock_collection.find_one.return_value = None
+
+        with pytest.raises(AccessError):
+            mongo_store.read(namespace, key)
+
+        mock_database.secrets.__getitem__.assert_called_with(namespace)
+        mock_collection.find_one.assert_called_once_with({"key": key})
+
+
+class TestSetupMongoStore:
+    """Test cases for setup_mongo_store function."""
+
+    @pytest.fixture
+    def valid_master_key(self, mocker):
+        """Set up valid master key in environment."""
+        key = base64.b64encode(os.urandom(96)).decode("utf-8")
+        mocker.patch.dict("os.environ", {"MONGO_MASTER_KEY": key}, clear=True)
+        return key
+
+    @pytest.fixture
+    def mock_mongo_setup(self, mocker):
+        """Mock common setup for setup_mongo_store tests."""
+        mocker.patch(
+            "testflinger.secrets.get_mongo_uri",
+            return_value="mongodb://localhost:27017/test",
+        )
+
+        mock_client = mocker.Mock(spec=MongoClient)
+        mock_cipher = mocker.Mock(spec=ClientEncryption)
+        mock_store = mocker.Mock(spec=MongoStore)
+
+        mocker.patch(
+            "testflinger.secrets.MongoClient", return_value=mock_client
+        )
+        mocker.patch(
+            "testflinger.secrets.ClientEncryption", return_value=mock_cipher
+        )
+        mocker.patch("testflinger.secrets.MongoStore", return_value=mock_store)
+
+        return mock_client, mock_cipher, mock_store
+
+    @pytest.mark.parametrize(
+        "env_vars",
+        [
+            {},
+            {"MONGO_MASTER_KEY": ""},
+            {"MONGO_MASTER_KEY": "invalid-base64!"},
+        ],
+    )
+    def test_setup_mongo_store_error_cases(self, mocker, env_vars):
+        """Test setup_mongo_store error cases."""
+        mocker.patch.dict("os.environ", env_vars, clear=True)
+        assert setup_mongo_store() is None
+
+    def test_setup_mongo_store_success_with_existing_key(
+        self, mocker, valid_master_key, mock_mongo_setup
+    ):
+        """Test successful setup when data encryption key already exists."""
+        mock_client, mock_cipher, mock_store = mock_mongo_setup
+
+        # Mock the key vault to return an existing key
+        mock_key_vault = mocker.Mock()
+        mock_key_vault.find_one.return_value = {"_id": "existing-key"}
+        mock_database = mocker.Mock()
+        mock_database.__getitem__ = mocker.Mock(return_value=mock_key_vault)
+        mock_client.__getitem__ = mocker.Mock(return_value=mock_database)
+
+        result = setup_mongo_store()
+
+        # Verify key vault access
+        mock_key_vault.find_one.assert_called_once_with(
+            {"keyAltNames": "testflinger-secrets"}
+        )
+
+        # Verify no new key creation (existing key found)
+        mock_cipher.create_data_key.assert_not_called()
+
+        # Verify MongoStore creation
+        assert result == mock_store
+
+    def test_setup_mongo_store_success_with_new_key(
+        self, mocker, valid_master_key, mock_mongo_setup
+    ):
+        """Test successful setup when creating new data encryption key."""
+        mock_client, mock_cipher, mock_store = mock_mongo_setup
+
+        # Mock the key vault to return no existing key
+        mock_key_vault = mocker.Mock()
+        mock_key_vault.find_one.return_value = None
+        mock_database = mocker.Mock()
+        mock_database.__getitem__ = mocker.Mock(return_value=mock_key_vault)
+        mock_client.__getitem__ = mocker.Mock(return_value=mock_database)
+
+        result = setup_mongo_store()
+
+        # Verify new key creation
+        mock_cipher.create_data_key.assert_called_once_with(
+            "local", key_alt_names=["testflinger-secrets"]
+        )
+
+        # Verify MongoStore creation
+        assert result == mock_store
+
+    def test_setup_mongo_store_key_creation_error(
+        self, mocker, valid_master_key, mock_mongo_setup
+    ):
+        """Test setup_mongo_store handles EncryptionError in key creation."""
+        mock_client, mock_cipher, mock_store = mock_mongo_setup
+
+        # Mock the key vault to return no existing key
+        mock_key_vault = mocker.Mock()
+        mock_key_vault.find_one.return_value = None
+        mock_database = mocker.Mock()
+        mock_database.__getitem__ = mocker.Mock(return_value=mock_key_vault)
+        mock_client.__getitem__ = mocker.Mock(return_value=mock_database)
+
+        # Mock cipher to raise EncryptionError on key creation
+        mock_cipher.create_data_key.side_effect = EncryptionError(
+            "Key creation failed"
+        )
+
+        with pytest.raises(
+            StoreError,
+            match="Failed to create data encryption key: Key creation failed",
+        ):
+            setup_mongo_store()

--- a/server/tests/test_v1_secrets.py
+++ b/server/tests/test_v1_secrets.py
@@ -26,7 +26,7 @@ import pytest
 
 from testflinger import application, database
 from testflinger.secrets.exceptions import AccessError, StoreError
-from testflinger.secrets.vault import VaultStore
+from testflinger.secrets.store import SecretsStore
 
 
 @pytest.fixture
@@ -56,12 +56,12 @@ def app_with_store(mocker):
         )
 
     # mock store
-    mock_vault_store = mocker.Mock(spec=VaultStore)
+    mock_secrets_store = mocker.Mock(spec=SecretsStore)
 
     # create app
     flask_app = application.create_flask_app(
         type("", (), {"TESTING": True})(),
-        secrets_store=mock_vault_store,
+        secrets_store=mock_secrets_store,
     )
     yield flask_app.test_client()
 

--- a/server/tests/test_vault_store.py
+++ b/server/tests/test_vault_store.py
@@ -19,7 +19,7 @@ import hvac
 import pytest
 import requests.exceptions
 
-from testflinger.secrets import setup_secrets_store
+from testflinger.secrets import setup_secrets_store, setup_vault_store
 from testflinger.secrets.exceptions import (
     AccessError,
     StoreError,
@@ -174,12 +174,12 @@ class TestSecretsInit:
         ],
     )
     def test_setup_secrets_store_missing_config(self, mocker, env_vars):
-        """Test setup_secrets_store returns None when config is incomplete."""
+        """Test setup_vault_store returns None when config is incomplete."""
         # Given: incomplete environment configuration
         mocker.patch.dict("os.environ", env_vars, clear=True)
 
         # When: setup_secrets_store is called
-        result = setup_secrets_store()
+        result = setup_vault_store()
 
         # Then: it returns None
         assert result is None
@@ -211,9 +211,9 @@ class TestSecretsInit:
             url="http://vault", token=token
         )
 
-    def test_setup_secrets_store_not_authenticated(self, mocker):
+    def test_setup_vault_store_not_authenticated(self, mocker):
         """
-        Test setup_secrets_store raises StoreError when the client is not
+        Test setup_vault_store raises StoreError when the client is not
         properly authenticated.
         """
         # Given: environment variables are set but client is not authenticated
@@ -234,7 +234,7 @@ class TestSecretsInit:
         # When: setup_secrets_store is called
         # Then: it raises StoreError about authentication
         with pytest.raises(StoreError, match="Vault client not authenticated"):
-            setup_secrets_store()
+            setup_vault_store()
 
     def test_setup_secrets_store_connection_error(self, mocker):
         """Test setup_secrets_store raises StoreError on ConnectionError."""
@@ -257,5 +257,5 @@ class TestSecretsInit:
 
         # When: setup_secrets_store is called
         # Then: it raises StoreError about unable to create client
-        with pytest.raises(StoreError, match="Unable to create Vault client"):
-            setup_secrets_store()
+        with pytest.raises(StoreError, match="Vault client unable to connect"):
+            setup_vault_store()

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -140,6 +140,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.40.36"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/21/7bc857b155e8264c92b6fa8e0860a67dc01a19cbe6ba4342500299f2ae5b/boto3-1.40.36.tar.gz", hash = "sha256:bfc1f3d5c4f5d12b8458406b8972f8794ac57e2da1ee441469e143bc0440a5c3", size = 111552, upload-time = "2025-09-22T19:26:17.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4c/428b728d5cf9003f83f735d10dd522945ab20c7d67e6c987909f29be12a0/boto3-1.40.36-py3-none-any.whl", hash = "sha256:d7c1fe033f491f560cd26022a9dcf28baf877ae854f33bc64fffd0df3b9c98be", size = 139345, upload-time = "2025-09-22T19:26:15.194Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.40.36"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/30/75fdc75933d3bc1c8dd7fbaee771438328b518936906b411075b1eacac93/botocore-1.40.36.tar.gz", hash = "sha256:93386a8dc54173267ddfc6cd8636c9171e021f7c032aa1df3af7de816e3df616", size = 14349583, upload-time = "2025-09-22T19:26:05.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/51/95c0324ac20b5bbafad4c89dd610c8e0dd6cbadbb2c8ca66dc95ccde98b8/botocore-1.40.36-py3-none-any.whl", hash = "sha256:d6edf75875e4013cb7078875a1d6c289afb4cc6675d99d80700c692d8d8e0b72", size = 14020478, upload-time = "2025-09-22T19:26:02.054Z" },
+]
+
+[[package]]
 name = "cachelib"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -822,6 +850,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
 name = "joserfc"
 version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1236,6 +1273,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/99/1c/f5108dc39450077556844abfd92b768c57775f85270fc0b1dc834ad18113/pymongo-4.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:e84bc7707492f06fbc37a9f215374d2977d21b72e10a67f1b31893ec5a140ad8", size = 680400, upload-time = "2024-06-26T18:46:19.241Z" },
 ]
 
+[package.optional-dependencies]
+encryption = [
+    { name = "certifi", marker = "os_name == 'nt' or sys_platform == 'darwin'" },
+    { name = "pymongo-auth-aws" },
+    { name = "pymongocrypt" },
+]
+
+[[package]]
+name = "pymongo-auth-aws"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/37/ca8d840f322f0047b71afcec7a489b1ea1f59a5f6d29f91ad8004024736f/pymongo_auth_aws-1.3.0.tar.gz", hash = "sha256:d0fa893958dc525ca29f601c34f2ca73c860f66bc6511ec0a7da6eb7ea44e94f", size = 18559, upload-time = "2024-09-11T20:29:17.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/12/a997fc108416f31fac55748e5406c1c8c4e976a4073f07b5553825641611/pymongo_auth_aws-1.3.0-py3-none-any.whl", hash = "sha256:367f6d853da428a02e9e450422756133715d40f8141f47ae5d98f139a88c0ce5", size = 15470, upload-time = "2024-09-11T20:29:16.637Z" },
+]
+
+[[package]]
+name = "pymongocrypt"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "cryptography" },
+    { name = "httpx" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/8e/dd9ed710e8fd4eec127dac1db3b3e9156ffcf340a0463a82087a12ae924e/pymongocrypt-1.16.0.tar.gz", hash = "sha256:0db0812055d00e6f5562a8d66711c4cba4b75014c363306c9b298a9fd68fccdd", size = 65354, upload-time = "2025-09-09T18:54:25.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/8b/dda0f19ce16f7b257e4aa2a8831a1a1307c1ea124a00f571cda83a04adcb/pymongocrypt-1.16.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:fbd85534880ea8525956b96e583a7021c721abbf3b51a6dbe48a57d7eba8e74a", size = 4721169, upload-time = "2025-09-09T18:54:18.642Z" },
+    { url = "https://files.pythonhosted.org/packages/99/48/512a5b597d71407f9b06a14cd8e5ac376e06b780d4d54a4e69726bd48703/pymongocrypt-1.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85df0a78480e91bdd3a5a6da3e4cdc7d9700de8a871aa8168588981c041f1914", size = 4038242, upload-time = "2025-09-09T18:54:20.496Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/67/3bdeda347191d6c1ee257eb3da8c85f1278d86dfb493cc9bc26352a41d0a/pymongocrypt-1.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8d2ebeb1b5e4f4554bf44f726e8009c59c4d7d0b412beebfece875991714676", size = 3775742, upload-time = "2025-09-09T18:54:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/70f6947afbd1ac7be54482b44cb1b99e8e9b9cac41985e6250c4fc279e58/pymongocrypt-1.16.0-py3-none-win_amd64.whl", hash = "sha256:c20afcd89ec5fc53305e924c05c4a0321ddc73f1e4e7c8240ee2fd0123e23609", size = 1607917, upload-time = "2025-09-09T18:54:24.182Z" },
+]
+
 [[package]]
 name = "pytest"
 version = "8.3.5"
@@ -1291,6 +1366,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241, upload-time = "2025-05-26T13:58:45.167Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923, upload-time = "2025-05-26T13:58:43.487Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -1477,6 +1564,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+]
+
+[[package]]
 name = "sentinels"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1542,7 +1641,7 @@ wheels = [
 
 [[package]]
 name = "testflinger"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "apiflask" },
@@ -1557,7 +1656,7 @@ dependencies = [
     { name = "prometheus-client" },
     { name = "prometheus-flask-exporter" },
     { name = "pyjwt" },
-    { name = "pymongo" },
+    { name = "pymongo", extra = ["encryption"] },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sentry-sdk" },
@@ -1597,7 +1696,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "prometheus-flask-exporter", specifier = ">=0.23.1" },
     { name = "pyjwt", specifier = ">=2.8.0" },
-    { name = "pymongo", specifier = "<4.9.0" },
+    { name = "pymongo", extras = ["encryption"], specifier = "<4.9.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "sentry-sdk", specifier = ">=2.0.1" },


### PR DESCRIPTION
## Description


## Resolved issues

This PR doesn't resolve an issue itself, but it will allow testing for CERTTF-443 from the Testflinger staging environment (instead of just locally).

## Tests

