### PR TITLE
ci: update workflows to new zizmor recommendations

### DIFF
--- a/.github/workflows/agent-host-charm-check-libs.yml
+++ b/.github/workflows/agent-host-charm-check-libs.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write  # necessary to add label
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/agent-host-charm-check-libs.yml
+++ b/.github/workflows/agent-host-charm-check-libs.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write  # necessary to add label
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/agent-host-charm-release.yml
+++ b/.github/workflows/agent-host-charm-release.yml
@@ -23,9 +23,9 @@ jobs:
     name: Build and Push Charm
     runs-on: [self-hosted, linux, jammy, X64]
     permissions:
-      actions: read
-      contents: write
-      packages: write
+      actions: read  # necessary to get the runner information
+      contents: write  # necessary to create tag(s)
+      packages: write  # necessary to upload image
 
     steps:
       - name: Checkout

--- a/.github/workflows/agent-host-charm-release.yml
+++ b/.github/workflows/agent-host-charm-release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv and set up Python
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
       - name: Check lock file
         run: uvx --with tox-uv tox -e lock
       - name: Check formatting
@@ -58,7 +58,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv and set up Python
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
       - name: Install concierge
         run: sudo snap install --classic concierge
       - name: Prepare Juju

--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python
@@ -54,7 +54,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -48,13 +48,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: ${{ matrix.version }}
 
       - name: Build and push backend Docker image
-        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./agent/extra/testflinger-testenv
           push: true

--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Log in to the Container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: write  # necessary to upload package to ghcr
 
     strategy:
       matrix:

--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -35,7 +35,7 @@ jobs:
               mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/build-testflinger-testenv-container.yml
+++ b/.github/workflows/build-testflinger-testenv-container.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         with:
           cache-binary: false
           config-inline: |

--- a/.github/workflows/charm-promote.yml
+++ b/.github/workflows/charm-promote.yml
@@ -49,7 +49,7 @@ jobs:
             exit 1
           fi
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Promote Charm

--- a/.github/workflows/charm-update-libs.yml
+++ b/.github/workflows/charm-update-libs.yml
@@ -10,8 +10,8 @@ on:
 jobs:
   update-lib:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # necessary to create branches
+      pull-requests: write  # necessary to create PR with updated libs
     strategy:
       fail-fast: false  # Allow all jobs to run even if one fails
       matrix:

--- a/.github/workflows/cli-publish-snap.yml
+++ b/.github/workflows/cli-publish-snap.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Build snap

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
       - name: Check lock file
         run: uvx --with tox-uv tox -e lock
       - name: Check formatting

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Install uv and set the Python version

--- a/.github/workflows/common-tox.yml
+++ b/.github/workflows/common-tox.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/common-tox.yml
+++ b/.github/workflows/common-tox.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv and set up Python
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
       - name: Check lock file
         run: uvx --with tox-uv tox -e lock
       - name: Check formatting

--- a/.github/workflows/device-tox.yml
+++ b/.github/workflows/device-tox.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/device-tox.yml
+++ b/.github/workflows/device-tox.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv and set up Python
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
       - name: Check lock file
         run: uvx --with tox-uv tox -e lock
       - name: Check formatting

--- a/.github/workflows/documentation_checks.yml
+++ b/.github/workflows/documentation_checks.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
 
@@ -48,7 +48,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
 
@@ -70,7 +70,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/server-charm-check-libs.yml
+++ b/.github/workflows/server-charm-check-libs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write  # necessary to add label
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/server-charm-check-libs.yml
+++ b/.github/workflows/server-charm-check-libs.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write  # necessary to add label
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/server-charm-release.yml
+++ b/.github/workflows/server-charm-release.yml
@@ -43,7 +43,7 @@ jobs:
               mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/server-charm-release.yml
+++ b/.github/workflows/server-charm-release.yml
@@ -26,9 +26,9 @@ jobs:
     name: Build and Push Charm
     runs-on: [self-hosted, linux, jammy, X64]
     permissions:
-      actions: read
-      contents: write
-      packages: write
+      actions: read  # necessary to read runner information
+      contents: write  # necessary to create tag(s)
+      packages: write  # necessary to create push image
 
     env:
       IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/server-charm-release.yml
+++ b/.github/workflows/server-charm-release.yml
@@ -56,12 +56,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push backend Docker image
-        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./server
           build-contexts: |

--- a/.github/workflows/server-charm-release.yml
+++ b/.github/workflows/server-charm-release.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Log in to the Container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/server-charm-release.yml
+++ b/.github/workflows/server-charm-release.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         with:
           cache-binary: false
           config-inline: |

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python
@@ -52,7 +52,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv and set up Python
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
       - name: Check lock file
         run: uvx --with tox-uv tox -e lock
       - name: Check formatting
@@ -56,7 +56,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv and set up Python
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
       - name: Install concierge
         run: sudo snap install --classic concierge
       - name: Prepare Juju

--- a/.github/workflows/submit-action-tags.yml
+++ b/.github/workflows/submit-action-tags.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0  # necessary for semantic versioning
           persist-credentials: true  # necessary for pushing tags

--- a/.github/workflows/submit-action-tags.yml
+++ b/.github/workflows/submit-action-tags.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create version tag for the submit action
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write  # necessary for writing tag
 
     steps:
       - name: Checkout code

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv and set up Python
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
       - name: Run zizmor
         run: uvx zizmor --pedantic .
         env:


### PR DESCRIPTION
## Description

- This PR resolves the issues brought up by the `zizmor` update.
- The following changes were made:
  - Added notes to `permissions` changes with explanation for the elevation
  - Updated workflows that were pinned to a major version, pinned to minor version now, to avoid issues with `zizmor` complaining the SHA was pointing to a minor version
  - Updated GH action versions

## Resolved issues

## Documentation

## Web service API changes

## Tests

- Tested with `zizmor` locally
- `zizmor` workflow should pass
- Existing workflows that do not push/release should automatically run with this PR to verify that our CI is not broken by any changes.