### PR TITLE
fix: change logic for selecting OCI image when releasing server charm

### DIFF
--- a/.github/workflows/server-charm-release.yml
+++ b/.github/workflows/server-charm-release.yml
@@ -17,11 +17,6 @@ on:
         options:
           - latest/beta
           - latest/edge
-      release-from-branch:
-        description: Use the Docker image built from the current branch
-        required: false
-        type: boolean
-        default: false
 
 env:
   REGISTRY: ghcr.io
@@ -76,7 +71,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Modify charmcraft.yaml OCI Image
-        if: fromJSON(inputs.release-from-branch)
+        if: github.event_name == 'workflow_dispatch'
         env:
           IMAGE_FROM_BRANCH: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
         run: sed -i "s|ghcr.io/canonical/testflinger:main|$IMAGE_FROM_BRANCH|g" server/charm/charmcraft.yaml


### PR DESCRIPTION
## Description

#809 modified the workflow for releasing the testflinger-k8s charm, allowing the OCI image included in the release to be built from the branch, rather than `main`. Unfortunately, the modification introduced a bug: it only works when the workflow is triggered through a `workflow_dispatch` event but [breaks](https://github.com/canonical/testflinger/actions/runs/18154188408) when triggered on a `push` event on the main branch.

This PR fixes this bug and rationalizes the workflow: when it is triggered by a `workflow_dispatch` event, the OCI image included is _always_ built from the current branch (there's really no need for the now abolished boolean flag). When triggered by a `push` event on the main branch, the OCI image is always built from the main branch.

## Resolved issues

This is an untracked bug fix.

## Tests

The modified workflow was [triggered on this branch](https://github.com/canonical/testflinger/actions/runs/18163439237/job/51699440281) by a `workflow_dispatch` event. The log indicates that the optional step was performed and the `source` in the `charmcraft,yaml` file was amended to retrieve the OCI image created from this branch. Given the binary nature of the `if` statement in the optional step, it is expected that it will _not_ be performed when the event is a `push`.

<img width="1074" height="110" alt="image" src="https://github.com/user-attachments/assets/5d1181ff-1eb8-48e4-bfe3-420b399c23c5" />

<img width="823" height="65" alt="image" src="https://github.com/user-attachments/assets/17795b37-7620-4b75-bd3a-2a5f90ecb3a9" />

