### PR TITLE
refactor(server): Specify an ordering between roles

### DIFF
--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -288,28 +288,6 @@ def require_role(*roles):
     return decorator
 
 
-def check_role_hierarchy(user_role: str, target_role: str) -> bool:
-    """
-    Check role of current user to validate if authorized to perform action.
-
-    :param user_role: Role of the user making the request.
-    :param target_role: Role being assigned or modified.
-    :return: True if allowed, False otherwise.
-    """
-    role_levels = {
-        ServerRoles.USER: 1,
-        ServerRoles.CONTRIBUTOR: 2,
-        ServerRoles.MANAGER: 3,
-        ServerRoles.ADMIN: 4,
-    }
-
-    current_level = role_levels.get(user_role, 0)
-    target_level = role_levels.get(target_role, 0)
-
-    # Users can modify roles at their level or below
-    return current_level >= target_level
-
-
 def generate_refresh_token(client_id: str, expires_in: int | None) -> str:
     """
     Generate opaque string as a new refresh token.

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -1115,7 +1115,7 @@ def create_client_permissions(json_data: dict) -> str:
 
     # Check role hierarchy
     target_role = json_data.get("role", ServerRoles.CONTRIBUTOR)
-    if not auth.check_role_hierarchy(g.role, target_role):
+    if ServerRoles(g.role) < ServerRoles(target_role):
         abort(
             HTTPStatus.FORBIDDEN,
             (
@@ -1156,7 +1156,7 @@ def edit_client_permissions(client_id: str, json_data: dict) -> str:
     current_role = current_permissions.get("role", ServerRoles.CONTRIBUTOR)
 
     # Check role hierarchy
-    if not auth.check_role_hierarchy(g.role, current_role):
+    if ServerRoles(g.role) < ServerRoles(current_role):
         abort(
             HTTPStatus.FORBIDDEN,
             (
@@ -1177,7 +1177,7 @@ def edit_client_permissions(client_id: str, json_data: dict) -> str:
     # Check role hierarchy for new role if being updated
     if "role" in update_fields:
         new_role = update_fields["role"]
-        if not auth.check_role_hierarchy(g.role, new_role):
+        if ServerRoles(g.role) < ServerRoles(new_role):
             abort(
                 HTTPStatus.FORBIDDEN,
                 f"Insufficient permissions to assign role: {new_role}",

--- a/server/src/testflinger/enums.py
+++ b/server/src/testflinger/enums.py
@@ -19,9 +19,48 @@ from strenum import StrEnum
 
 
 class ServerRoles(StrEnum):
-    """Define roles for restricted endpoints."""
+    """
+    Define roles for restricted endpoints and hierarchy among them.
+
+    Implementing a custom "less-than" operator imposes an order between
+    the roles (a hierarchy) and allows for comparisons between them.
+
+    The remaining comparison operators are implemented in terms of the
+    "less-than" operator.
+
+    Note: functools.total_ordering cannot be used because `StrEnum`
+    is first derived from `str` which already provides comparison
+    operators. Thus, we need to override them explicitly.
+    """
 
     ADMIN = "admin"
     MANAGER = "manager"
     CONTRIBUTOR = "contributor"
     USER = "user"
+
+    def __lt__(self, other: "ServerRoles") -> bool:
+        """Implement of "less-than" between ServerRoles."""
+        if not isinstance(other, ServerRoles):
+            raise TypeError(
+                f"Cannot compare {type(self).__name__} "
+                f"to {type(other).__name__}"
+            )
+        _ranks = {
+            self.ADMIN: 0,
+            self.MANAGER: 1,
+            self.CONTRIBUTOR: 2,
+            self.USER: 3,
+        }
+        return _ranks[self] > _ranks[other]
+
+    def __le__(self, other: "ServerRoles") -> bool:
+        """Implement "less-than-or-equal" between ServerRoles."""
+        return self < other or self == other
+
+    def __gt__(self, other: "ServerRoles") -> bool:
+        """Implement of "greater-than" between ServerRoles."""
+        return not (self < other or self == other)
+
+    def __ge__(self, other: "ServerRoles") -> bool:
+        """Implement of "greater-than-or-equal" between ServerRoles."""
+        return not self < other

--- a/server/tests/test_enums.py
+++ b/server/tests/test_enums.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2024 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""Unit tests for Testflinger enums."""
+
+from itertools import pairwise
+
+import pytest
+
+from testflinger.enums import ServerRoles
+
+
+@pytest.fixture
+def sorted_roles():
+    """Return sorted list of ServerRoles."""
+    return sorted(ServerRoles)
+
+
+class TestServerRoles:
+    """Test ServerRoles enum."""
+
+    def test_compare_with_next(self, sorted_roles):
+        """Test consecutive pairs of roles."""
+        for lower, higher in pairwise(sorted_roles):
+            assert lower < higher
+            assert not (lower >= higher)
+            assert lower <= higher
+            assert not (lower > higher)
+            assert higher > lower
+            assert not (higher <= lower)
+            assert higher >= lower
+            assert not (higher < lower)
+
+    def test_compare_with_self(self, sorted_roles):
+        """Test with same role."""
+        for role in sorted_roles:
+            assert role == role
+            assert role <= role
+            assert role >= role
+            assert not (role != role)
+            assert not (role < role)
+            assert not (role > role)
+
+    def test_comparison_type_error(self):
+        """Test that comparing with non-ServerRoles raises TypeError."""
+        with pytest.raises(
+            TypeError, match="Cannot compare ServerRoles to str"
+        ):
+            ServerRoles.ADMIN < "admin"  # noqa: B015
+
+        with pytest.raises(
+            TypeError, match="Cannot compare ServerRoles to int"
+        ):
+            ServerRoles.ADMIN < 1  # noqa: B015
+
+        with pytest.raises(
+            TypeError, match="Cannot compare ServerRoles to NoneType"
+        ):
+            ServerRoles.ADMIN < None  # noqa: B015
+
+    def test_role_ordering(self, sorted_roles):
+        """Test that roles are ordered correctly."""
+        unsorted_roles = list(reversed(sorted_roles))
+        assert sorted(unsorted_roles) == sorted_roles


### PR DESCRIPTION
## Description

This PR removes the `auth.check_role_hierarchy` function that would compare two instances of `ServerRoles` and refactors its functionality into a "less-than" operator in the `ServerRoles` class. This allows code that previously used `auth.check_role_hierarchy` to become more readable and explicit, e.g.:

```
    if not auth.check_role_hierarchy(g.role, current_role):
```

now becomes:

```
    if ServerRoles(g.role) < ServerRoles(current_role):
```


## Resolved issues

None, this is a minor untracked modification.

## Tests

Introduced unit tests for the comparison operators, The tests in `test_v1_authorization` for the `client-permissions` endpoints remain unchanged and still pass.