### PR TITLE
fix: add exception handling for sshpass command timeout.

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -704,6 +704,8 @@ class MuxPi:
                     return True
                 except subprocess.CalledProcessError as e:
                     logger.info("ssh-id-copy failed with %s", e)
+                except subprocess.TimeoutExpired as e:
+                    logger.info("ssh-id-copy timed out after %s", e)
 
         # If we get here, then we didn't boot in time
         raise ProvisioningError("Failed to boot test image!")

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -67,7 +67,9 @@ def test_check_test_image_booted_with_url(mocker):
     """Test check_test_image_booted with a boot_check_url."""
     muxpi = MuxPi()
     muxpi.config = {"device_ip": "1.2.3.4"}
-    muxpi.job_data = {"provision_data": {"boot_check_url": "http://$DEVICE_IP"}}
+    muxpi.job_data = {
+        "provision_data": {"boot_check_url": "http://$DEVICE_IP"}
+    }
     mocker.patch("time.sleep")
     mock_urlopen = mocker.patch("urllib.request.urlopen")
     mock_response = MagicMock()
@@ -87,6 +89,7 @@ def test_check_test_image_booted_with_ssh(mocker):
     assert muxpi.check_test_image_booted() is True
     assert mock_check_output.call_count == 1
 
+
 def test_check_test_image_booted_fails(mocker):
     """Test check_test_image_booted when it fails."""
     muxpi = MuxPi()
@@ -94,7 +97,8 @@ def test_check_test_image_booted_fails(mocker):
     muxpi.job_data = {}
     mocker.patch("time.time", side_effect=[0, 1300, 1300, 1300])
     mocker.patch("time.sleep")
-    mocker.patch("subprocess.check_output", side_effect=CalledProcessError(1, "cmd"))
+    mocker.patch(
+        "subprocess.check_output", side_effect=CalledProcessError(1, "cmd")
+    )
     with pytest.raises(ProvisioningError, match="Failed to boot test image!"):
         muxpi.check_test_image_booted()
-

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -58,7 +58,7 @@ def test_check_ce_oem_iot_image(mocker):
 
     mocker.patch(
         "subprocess.check_output",
-        side_effect=CalledProcessError(1, "cmd"),
+        side_effect=subprocess.CalledProcessError(1, "cmd"),
     )
     muxpi = MuxPi()
     assert muxpi.check_ce_oem_iot_image() is False
@@ -99,7 +99,8 @@ def test_check_test_image_booted_fails(mocker):
     mocker.patch("time.time", side_effect=[0, 1300, 1300, 1300])
     mocker.patch("time.sleep")
     mocker.patch(
-        "subprocess.check_output", side_effect=CalledProcessError(1, "cmd")
+        "subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "cmd"),
     )
     with pytest.raises(ProvisioningError, match="Failed to boot test image!"):
         muxpi.check_test_image_booted()

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -13,8 +13,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for muxpi device connector."""
 
+import urllib.error
+import pytest
 from subprocess import CalledProcessError
-
+from unittest.mock import MagicMock
+from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
 
 
@@ -56,4 +59,42 @@ def test_check_ce_oem_iot_image(mocker):
         "subprocess.check_output",
         side_effect=CalledProcessError(1, "cmd"),
     )
+    muxpi = MuxPi()
     assert muxpi.check_ce_oem_iot_image() is False
+
+
+def test_check_test_image_booted_with_url(mocker):
+    """Test check_test_image_booted with a boot_check_url."""
+    muxpi = MuxPi()
+    muxpi.config = {"device_ip": "1.2.3.4"}
+    muxpi.job_data = {"provision_data": {"boot_check_url": "http://$DEVICE_IP"}}
+    mocker.patch("time.sleep")
+    mock_urlopen = mocker.patch("urllib.request.urlopen")
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_urlopen.return_value.__enter__.return_value = mock_response
+    assert muxpi.check_test_image_booted() is True
+    mock_urlopen.assert_called_once_with("http://1.2.3.4", timeout=5)
+
+
+def test_check_test_image_booted_with_ssh(mocker):
+    """Test check_test_image_booted with ssh."""
+    muxpi = MuxPi()
+    muxpi.config = {"device_ip": "1.2.3.4"}
+    muxpi.job_data = {}
+    mocker.patch("time.sleep")
+    mock_check_output = mocker.patch("subprocess.check_output")
+    assert muxpi.check_test_image_booted() is True
+    assert mock_check_output.call_count == 1
+
+def test_check_test_image_booted_fails(mocker):
+    """Test check_test_image_booted when it fails."""
+    muxpi = MuxPi()
+    muxpi.config = {"device_ip": "1.2.3.4"}
+    muxpi.job_data = {}
+    mocker.patch("time.time", side_effect=[0, 1300, 1300, 1300])
+    mocker.patch("time.sleep")
+    mocker.patch("subprocess.check_output", side_effect=CalledProcessError(1, "cmd"))
+    with pytest.raises(ProvisioningError, match="Failed to boot test image!"):
+        muxpi.check_test_image_booted()
+

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -96,7 +96,7 @@ def test_check_test_image_booted_fails(mocker):
     muxpi = MuxPi()
     muxpi.config = {"device_ip": "1.2.3.4"}
     muxpi.job_data = {}
-    mocker.patch("time.time", side_effect=[0, 1300, 1300, 1300])
+    mocker.patch("time.time", side_effect=[0, 1300])
     mocker.patch("time.sleep")
     mocker.patch(
         "subprocess.check_output",

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -13,7 +13,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for muxpi device connector."""
 
-
 import subprocess
 from unittest.mock import MagicMock
 
@@ -21,6 +20,7 @@ import pytest
 
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
+
 
 def test_check_ce_oem_iot_image(mocker):
     """Test check_ce_oem_iot_image."""

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -13,13 +13,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for muxpi device connector."""
 
-import urllib.error
-import pytest
-from subprocess import CalledProcessError
+
+import subprocess
 from unittest.mock import MagicMock
+
+import pytest
+
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
-
 
 def test_check_ce_oem_iot_image(mocker):
     """Test check_ce_oem_iot_image."""


### PR DESCRIPTION
## Description

@boukeas reported that core24 provisioning on RPI5 kept failing. After investigation, it turned out the `muxpi` device connector didn’t handle `subprocess` call timeout for `sshpass` properly.

## Resolved issues

http://10.102.156.15:8080/job/cert-rpi5b8g-arm64-uc24-snapd-beta/73/console

## Tests

Tested in a local environment and confirmed that provisioning succeeds.

```
2025-10-07 05:57:38,320 rpi5b8g001 INFO: DEVICE CONNECTOR: BEGIN provision
2025-10-07 05:57:38,321 rpi5b8g001 INFO: DEVICE CONNECTOR: Provisioning device
2025-10-07 05:57:38,329 rpi5b8g001 INFO: DEVICE CONNECTOR: Successfully connected to serial logging server
2025-10-07 05:57:48,770 rpi5b8g001 WARNING: DEVICE CONNECTOR: Device /dev/sda might not be mounted
2025-10-07 05:57:48,771 rpi5b8g001 INFO: DEVICE CONNECTOR: Downloading test image from https://tel-image-cache.canonical.com/cdimage/ubuntu-core/24/dangerous-stable/pending/ubuntu-core-24-arm64+raspi.img.xz
2025-10-07 05:57:51,400 rpi5b8g001 INFO: DEVICE CONNECTOR: Flashing Test image ubuntu-core-24-arm64+raspi.img.xz on /dev/sda
2025-10-07 06:01:16,327 rpi5b8g001 WARNING: DEVICE CONNECTOR: Path /mnt/rpi5b8g001/writable/usr/bin/firefox was not found, continue trying others
2025-10-07 06:01:17,163 rpi5b8g001 WARNING: DEVICE CONNECTOR: Path /mnt/rpi5b8g001/writable/etc was not found, continue trying others
2025-10-07 06:01:17,991 rpi5b8g001 WARNING: DEVICE CONNECTOR: Path /mnt/rpi5b8g001/writable/system-data was not found, continue trying others
2025-10-07 06:01:18,822 rpi5b8g001 INFO: DEVICE CONNECTOR: Image type detected: core20
2025-10-07 06:01:18,822 rpi5b8g001 INFO: DEVICE CONNECTOR: Creating Test User
2025-10-07 06:01:27,313 rpi5b8g001 INFO: DEVICE CONNECTOR: Booting Test Image
2025-10-07 06:01:27,313 rpi5b8g001 INFO: DEVICE CONNECTOR: Running snmpset -c private -v2c 10.102.197.186 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.3 i 0
iso.3.6.1.4.1.13742.6.4.1.2.1.2.1.3 = INTEGER: 0
2025-10-07 06:01:27,628 rpi5b8g001 INFO: DEVICE CONNECTOR: Running sleep 30
2025-10-07 06:01:57,661 rpi5b8g001 INFO: DEVICE CONNECTOR: Running snmpset -c private -v2c 10.102.197.186 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.3 i 1
iso.3.6.1.4.1.13742.6.4.1.2.1.2.1.3 = INTEGER: 1
2025-10-07 06:01:57,678 rpi5b8g001 INFO: DEVICE CONNECTOR: Checking if test image booted.
2025-10-07 06:02:13,873 rpi5b8g001 INFO: DEVICE CONNECTOR: ssh-id-copy failed with Command '['sshpass', '-p', 'ubuntu', 'ssh-copy-id', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'ubuntu@10.102.166.37']' returned non-zero exit status 1.
2025-10-07 06:02:27,831 rpi5b8g001 INFO: DEVICE CONNECTOR: ssh-id-copy failed with Command '['sshpass', '-p', 'ubuntu', 'ssh-copy-id', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'ubuntu@10.102.166.37']' returned non-zero exit status 5.
2025-10-07 06:02:41,487 rpi5b8g001 INFO: DEVICE CONNECTOR: ssh-id-copy failed with Command '['sshpass', '-p', 'ubuntu', 'ssh-copy-id', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'ubuntu@10.102.166.37']' returned non-zero exit status 5.
2025-10-07 06:03:51,558 rpi5b8g001 INFO: DEVICE CONNECTOR: ssh-id-copy timed out after Command '['sshpass', '-p', 'ubuntu', 'ssh-copy-id', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'ubuntu@10.102.166.37']' timed out after 60 seconds
2025-10-07 06:04:02,626 rpi5b8g001 INFO: DEVICE CONNECTOR: END provision

```
