### PR TITLE
feat(cli): Add server connectivity check before running any command

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -654,15 +654,10 @@ class TestflingerCli:
             self.client.post(f"/v1/job/{job_id}/action", {"action": "cancel"})
             self.history.update(job_id, "cancelled")
         except client.HTTPError as exc:
-            if exc.status == 400:
+            if exc.status == HTTPStatus.BAD_REQUEST:
                 sys.exit(
                     "Invalid job ID specified or the job is already "
                     "completed/cancelled."
-                )
-            if exc.status == 404:
-                sys.exit(
-                    "Received 404 error from server. Are you "
-                    "sure this is a testflinger server?"
                 )
             raise
 
@@ -849,12 +844,6 @@ class TestflingerCli:
                         "bad formatting, or did not specify a "
                         "job_queue."
                     )
-                if exc.status == HTTPStatus.NOT_FOUND:
-                    sys.exit(
-                        "Received 404 error from server. Are you "
-                        "sure this is a testflinger server?"
-                    )
-
                 if exc.status == HTTPStatus.FORBIDDEN:
                     sys.exit(
                         "Received 403 error from server with reason: "
@@ -914,16 +903,10 @@ class TestflingerCli:
                 ) from error
             except requests.HTTPError as error:
                 # we can't recover from these errors, give up without retrying
-                if error.response.status_code == 400:
+                if error.response.status_code == HTTPStatus.BAD_REQUEST:
                     raise AttachmentError(
                         f"Unable to submit attachment archive for {job_id}: "
                         f"{error.response.text}"
-                    ) from error
-                if error.response.status_code == 404:
-                    raise AttachmentError(
-                        "Received 404 error from server. Are you "
-                        "sure this is a testflinger server and "
-                        "that it supports attachments?"
                     ) from error
                 # This shouldn't happen, so let's get more information
                 sys.exit(
@@ -951,15 +934,10 @@ class TestflingerCli:
         except client.HTTPError as exc:
             if exc.status == 204:
                 sys.exit("No data found for that job id.")
-            if exc.status == 400:
+            if exc.status == HTTPStatus.BAD_REQUEST:
                 sys.exit(
                     "Invalid job id specified. Check the job id "
                     "to be sure it is correct"
-                )
-            if exc.status == 404:
-                sys.exit(
-                    "Received 404 error from server. Are you "
-                    "sure this is a testflinger server?"
                 )
             # This shouldn't happen, so let's get more information
             logger.error(
@@ -980,17 +958,12 @@ class TestflingerCli:
         try:
             results = self.client.get_results(self.args.job_id)
         except client.HTTPError as exc:
-            if exc.status == 204:
+            if exc.status == HTTPStatus.NO_CONTENT:
                 sys.exit("No results found for that job id.")
-            if exc.status == 400:
+            if exc.status == HTTPStatus.BAD_REQUEST:
                 sys.exit(
                     "Invalid job id specified. Check the job id "
                     "to be sure it is correct"
-                )
-            if exc.status == 404:
-                sys.exit(
-                    "Received 404 error from server. Are you "
-                    "sure this is a testflinger server?"
                 )
             # This shouldn't happen, so let's get more information
             logger.error(
@@ -1007,17 +980,12 @@ class TestflingerCli:
         try:
             self.client.get_artifact(self.args.job_id, self.args.filename)
         except client.HTTPError as exc:
-            if exc.status == 204:
+            if exc.status == HTTPStatus.NO_CONTENT:
                 sys.exit("No artifacts tarball found for that job id.")
-            if exc.status == 400:
+            if exc.status == HTTPStatus.BAD_REQUEST:
                 sys.exit(
                     "Invalid job id specified. Check the job id "
                     "to be sure it is correct"
-                )
-            if exc.status == 404:
-                sys.exit(
-                    "Received 404 error from server. Are you "
-                    "sure this is a testflinger server?"
                 )
             # This shouldn't happen, so let's get more information
             logger.error(
@@ -1242,20 +1210,15 @@ class TestflingerCli:
         try:
             return self.client.get_status(job_id)
         except client.HTTPError as exc:
-            if exc.status == 204:
+            if exc.status == HTTPStatus.NO_CONTENT:
                 sys.exit(
                     "No data found for that job id. Check the "
                     "job id to be sure it is correct"
                 )
-            if exc.status == 400:
+            if exc.status == HTTPStatus.BAD_REQUEST:
                 sys.exit(
                     "Invalid job id specified. Check the job id "
                     "to be sure it is correct"
-                )
-            if exc.status == 404:
-                sys.exit(
-                    "Received 404 error from server. Are you "
-                    "sure this is a testflinger server?"
                 )
         except (IOError, ValueError) as exc:
             # For other types of network errors, or JSONDecodeError if we got

--- a/cli/testflinger_cli/errors.py
+++ b/cli/testflinger_cli/errors.py
@@ -72,3 +72,7 @@ class InvalidTokenError(CredentialsError):
             f"following reason: {reason} "
             "Please reauthenticate with server."
         )
+
+
+class NetworkError(Exception):
+    """Exception thrown when unable to communicate with server."""

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -2,6 +2,7 @@
 """Shared pytest fixtures and configuration."""
 
 import uuid
+from http import HTTPStatus
 
 import jwt
 import pytest
@@ -25,6 +26,12 @@ def mock_xdg_config(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "testflinger_cli.auth.xdg_config_home", lambda: tmp_path
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_connectivity_check(requests_mock):
+    """Mock the connectivity check endpoint for all tests."""
+    requests_mock.get(f"{URL}/v1/agents/queues", status_code=HTTPStatus.OK)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
This is a spinoff PR related to #820 . It adds a simple connectivity check to make sure server is accessible before executing any command. The endpoint `/agents/queues` does not abort any request, so is a good candidate to attempt to reach the server.
In case of any network error is detected while contacting the server, a meaningful error message will be displayed before exit. 

It also removes the now unreachable "fake" health checks that uses 404 (NOT FOUND) to indicate there was any problem with the server.

> [!NOTE]
> This also removes the now unreachable FORBIDDEN from check_online_agents_available(), missing NOT_FOUND exception handling is still to be covered by #820 

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Related to #800 
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Included unit tests for this health connectivity check. 
Additionally

User not connected to VPN:
```
uv run testflinger-cli agent-status agent
Authorization error received from server.
Please make sure you are connected to the right network.
```

Server unreachable (down) :
```
uv run testflinger-cli --server http://localhost:5000 agent-status agent
Unable to communicate with server after 3 attempts.
Server may be inaccessible, please try again later.
```

Successfully reaching the server:
```
uv run testflinger-cli agent-status dratini
waiting
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
