### PR TITLE
Add SECURITY.md consistent with Cert Org security policy CERTTF-736

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+To report a security issue, please email [security@ubuntu.com](mailto:security@ubuntu.com) with a description of the issue,
+the steps to take to reproduce the issue, affected versions, and, if known, mitigations for the issue.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information
+about what you can expect when you contact us and what we expect from you.


### PR DESCRIPTION
## Description

Add SECURITY.md to testflinger repo documenting the project security policy.  Keeping it consistent with Checkbox

## Resolved issues

Resolves CERTTF-736

## Documentation

Added documentation is just the SECURITY.md file inline with how this was handled in checkbox

## Web service API changes

None

## Tests

None
