### PR TITLE
Update urllib3 dependency version for testflinger-cli. Fixes CERTTF-739

### DIFF
--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -442,11 +442,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268, upload-time = "2024-12-22T07:47:30.032Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369, upload-time = "2024-12-22T07:47:28.074Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Update uv.lock for testflinger-cli to use newer patched version of urllib3 to mitigate https://ubuntu.com/security/CVE-2025-50181

## Resolved issues

Fixes CERTTF-739

## Documentation

NA

## Web service API changes

NA

## Tests

Test build of snap was successful
Tested a few commands:
```
bladernr@galactica:~/development/testflinger/testflinger/cli$ testflinger-cli agent-status romano
reserve
bladernr@galactica:~/development/testflinger/testflinger/cli$ testflinger-cli agent-status pikmin
waiting
bladernr@galactica:~/development/testflinger/testflinger/cli$ testflinger-cli queue-status pikmin
Agents in queue: 1
Available:       1
Busy:            0
Offline:         0
Jobs waiting:    0
Jobs running:    0
Jobs completed:  14
bladernr@galactica:~/development/testflinger/testflinger/cli$ testflinger-cli admin get client-permissions --testflinger-client-id bladernr
{"client_id": "bladernr", "max_priority": {"*": 10}, "max_reservation_time": {"cractus": 5259600, "hidon": 172800, "romano": 129600}, "role": "manager"}
bladernr@galactica:~/development/testflinger/testflinger/cli$ testflinger-cli status edabd014-e4a3-49fa-9e99-750ab78b45d0
complete
```
