### PR TITLE
Reboot control host before provisioning

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -460,6 +460,7 @@ class DefaultDevice:
 
         with contextlib.suppress(FileNotFoundError):
             ping(control_host)
+            logger.debug("The control host is already up and running.")
             return
 
         control_host_reboot_script: list[str] = [

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -431,7 +431,9 @@ class DefaultDevice:
                 capture_output=True,
                 text=True,
             )
-            logger.debug("The host %s has an available SSH server", host)
+            logger.debug(
+                "The control host %s has an available SSH server", host
+            )
         except subprocess.CalledProcessError as e:
             raise ConnectionError from e
 
@@ -495,7 +497,7 @@ class DefaultDevice:
             return
 
         logger.info(
-            "Waiting for a running SSH server on host %s", control_host
+            "Waiting for a running SSH server on control host %s", control_host
         )
         with contextlib.suppress(ConnectionError):
             self.__check_ssh_server_on_host(control_host)
@@ -511,7 +513,7 @@ class DefaultDevice:
             )
         except TimeoutError:
             msg = (
-                "Host %s is not available "
+                "Control host %s is not available "
                 "or the SSH server is not running after %d seconds"
             )
             logger.error(msg, control_host, timeout)

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -426,7 +426,7 @@ class DefaultDevice:
         timeout = 3
         try:
             subprocess.run(
-                ["nc", "-z", "-w", str(timeout), host, "22"],
+                ["/usr/bin/nc", "-z", "-w", str(timeout), host, "22"],
                 check=True,
                 capture_output=True,
                 text=True,

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -435,7 +435,7 @@ class DefaultDevice:
         except subprocess.CalledProcessError as e:
             raise ConnectionError from e
 
-    def __wait_back_alive(self, host: str, timeout: int) -> None:
+    def __wait_back_online(self, host: str, timeout: int) -> None:
         """Poll the host SSH server until it's available."""
         logger.info("Waiting for a running SSH server on host %s", host)
 
@@ -508,7 +508,7 @@ class DefaultDevice:
         self.__reboot_control_host()
 
         # Wait for control host to be reachable via ping
-        self.__wait_back_alive(control_host, 300)
+        self.__wait_back_online(control_host, 300)
 
     def provision(self, args):
         """Run pre-provision hook."""

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -417,8 +417,7 @@ class DefaultDevice:
         )
         time.sleep(int(timeout))
 
-    @staticmethod
-    def __ping(host: str) -> None:
+    def __ping(self, host: str) -> None:
         try:
             subprocess.run(
                 ["/usr/bin/ping", "-c", "1", "-W", "2", host],
@@ -430,13 +429,12 @@ class DefaultDevice:
         except subprocess.CalledProcessError as e:
             raise FileNotFoundError from e
 
-    @staticmethod
-    def __wait_back_alive(host: str, timeout: int) -> None:
+    def __wait_back_alive(self, host: str, timeout: int) -> None:
         logger.info("Waiting for control host %s to respond to ping", host)
         start_time = time.time()
         while time.time() - start_time < timeout:
             try:
-                __ping(host)
+                self.__ping(host)
                 break
             except FileNotFoundError:
                 # Ping failed, continue waiting
@@ -487,7 +485,6 @@ class DefaultDevice:
 
     def pre_provision_hook(self):
         """Execute control host reboot script before provisioning."""
-
         control_host: str = str(self.config.get("control_host", ""))
         if not control_host:
             logger.debug("No control host configured for this agent.")

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -435,14 +435,15 @@ class DefaultDevice:
         except subprocess.CalledProcessError as e:
             raise ConnectionError from e
 
-    def __wait_back_online(self, host: str, timeout: int) -> None:
+    @staticmethod
+    def wait_online(check: Callable, host: str, timeout: int) -> None:
         """Poll the host SSH server until it's available."""
         logger.info("Waiting for a running SSH server on host %s", host)
 
         start_time = time.time()
         while time.time() - start_time < timeout:
             try:
-                self.__check_ssh_server_on_host(host)
+                check(host)
                 break
             except ConnectionError:
                 time.sleep(2)
@@ -508,7 +509,7 @@ class DefaultDevice:
         self.__reboot_control_host()
 
         # Wait for control host to be reachable via ping
-        self.__wait_back_online(control_host, 300)
+        self.wait_online(self.__check_ssh_server_on_host, control_host, 300)
 
     def provision(self, args):
         """Run pre-provision hook."""

--- a/device-connectors/src/testflinger_device_connectors/devices/cm3/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/cm3/__init__.py
@@ -34,6 +34,9 @@ class DeviceConnector(DefaultDevice):
         """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
+
+        super().provision(args)
+
         device = CM3(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
@@ -34,6 +34,8 @@ class DeviceConnector(DefaultDevice):
 
     def provision(self, args):
         """Provision device when the command is invoked."""
+        super().provision(args)
+
         device = DellOemScript(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/dragonboard/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/dragonboard/__init__.py
@@ -36,6 +36,9 @@ class DeviceConnector(DefaultDevice):
         """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
+
+        super().provision(args)
+
         device = Dragonboard(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Booting Master Image")

--- a/device-connectors/src/testflinger_device_connectors/devices/fake_connector/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/fake_connector/__init__.py
@@ -32,6 +32,8 @@ class DeviceConnector(DefaultDevice):
 
     def provision(self, args):
         """Begin dummy provision."""
+        super().provision(args)
+
         with open(args.job_data) as json_file:
             job_data = json.load(json_file)
         provision_data = job_data.get("provision_data", {})

--- a/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/hp_oemscript/__init__.py
@@ -34,6 +34,8 @@ class DeviceConnector(DefaultDevice):
 
     def provision(self, args):
         """Provision device when the command is invoked."""
+        super().provision(args)
+
         device = HPOemScript(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
@@ -35,6 +35,8 @@ class DeviceConnector(DefaultDevice):
 
     def provision(self, args):
         """Provision device when the command is invoked."""
+        super().provision(args)
+
         device = LenovoOemScript(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/__init__.py
@@ -35,6 +35,9 @@ class DeviceConnector(DefaultDevice):
         """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
+
+        super().provision(args)
+
         device = Maas2(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/multi/__init__.py
@@ -47,6 +47,8 @@ class DeviceConnector(DefaultDevice):
 
     def provision(self, args):
         """Provision device when the command is invoked.."""
+        super().provision(args)
+
         self.init_device(args)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
@@ -34,6 +34,9 @@ class DeviceConnector(DefaultDevice):
         """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
+
+        super().provision(args)
+
         device = MuxPi(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -231,7 +231,8 @@ class MuxPi:
         else:
             _, control_host = self.get_credentials()
             logger.info(
-                "Waiting for a running RPyC server on host %s", control_host
+                "Waiting for a running RPyC server on control host %s",
+                control_host,
             )
             try:
                 DefaultDevice.wait_online(

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -227,12 +227,20 @@ class MuxPi:
         # If this is not a zapper, reboot before provisioning
         if "zapper" not in self.config.get("control_switch_local_cmd", ""):
             self.reboot_sdwire()
+            time.sleep(5)
         else:
             _, control_host = self.get_credentials()
-            DefaultDevice.wait_online(
-                self.__check_rpyc_server_on_host, control_host, 60
+            logger.info(
+                "Waiting for a running RPyC server on host %s", control_host
             )
-        time.sleep(5)
+            try:
+                DefaultDevice.wait_online(
+                    self.__check_rpyc_server_on_host, control_host, 60
+                )
+            except TimeoutError as e:
+                raise ProvisioningError(
+                    "Cannot reach out the service over RPyC"
+                ) from e
 
         # determine where to get the provisioning image from
         source = self.job_data["provision_data"].get("url")

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -30,6 +30,7 @@ import requests
 import yaml
 
 from testflinger_device_connectors.devices import (
+    DefaultDevice,
     ProvisioningError,
     RecoveryError,
 )
@@ -210,10 +211,27 @@ class MuxPi:
                     f"but got {media!r}"
                 )
 
+    def __check_rpyc_server_on_host(self, host: str) -> None:
+        """
+        Check if the host has an active RPyC server running.
+
+        :raises ConnectionError in case the server is not reachable.
+        """
+        try:
+            self._run_control("zapper --help")
+            logger.debug("The host %s has an available RPyC server", host)
+        except ProvisioningError as e:
+            raise ConnectionError from e
+
     def provision(self):
         # If this is not a zapper, reboot before provisioning
         if "zapper" not in self.config.get("control_switch_local_cmd", ""):
             self.reboot_sdwire()
+        else:
+            _, control_host = self.get_credentials()
+            DefaultDevice.wait_online(
+                self.__check_rpyc_server_on_host, control_host, 60
+            )
         time.sleep(5)
 
         # determine where to get the provisioning image from

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -18,7 +18,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from testflinger_device_connectors.devices import ProvisioningError
+from testflinger_device_connectors.devices import (
+    DefaultDevice,
+    ProvisioningError,
+)
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
 
 
@@ -104,3 +107,98 @@ def test_check_test_image_booted_fails(mocker):
     )
     with pytest.raises(ProvisioningError, match="Failed to boot test image!"):
         muxpi.check_test_image_booted()
+
+
+class TestMuxPiRpycCheck:
+    """Tests for MuxPi RPyC server check."""
+
+    def test_check_rpyc_server_on_host_success(self, mocker):
+        """Test connection check succeeds when zapper is available."""
+        muxpi = MuxPi()
+        muxpi.config = {"control_host": "test-host", "control_user": "ubuntu"}
+        mock_run_control = mocker.patch.object(muxpi, "_run_control")
+
+        # Access the private method
+        muxpi._MuxPi__check_rpyc_server_on_host("test-host")
+
+        mock_run_control.assert_called_once_with("zapper --help")
+
+    def test_check_rpyc_server_on_host_raises_connection_error(self, mocker):
+        """Test connection check raises ConnectionError on failure."""
+        muxpi = MuxPi()
+        muxpi.config = {"control_host": "test-host", "control_user": "ubuntu"}
+        mocker.patch.object(
+            muxpi, "_run_control", side_effect=ProvisioningError("failed")
+        )
+
+        with pytest.raises(ConnectionError):
+            muxpi._MuxPi__check_rpyc_server_on_host("test-host")
+
+
+class TestMuxPiProvisionWithZapper:
+    """Tests for MuxPi provision method with zapper configuration."""
+
+    def test_provision_with_zapper_waits_for_rpyc(self, mocker):
+        """Test provision waits for RPyC server when using zapper."""
+        muxpi = MuxPi()
+        muxpi.config = {
+            "control_switch_local_cmd": "zapper sdwire set TS",
+            "control_host": "zapper-host",
+            "control_user": "ubuntu",
+            "device_ip": "1.2.3.4",
+            "test_device": "/dev/sda",
+        }
+        muxpi.job_data = {
+            "provision_data": {
+                "url": "http://example.com/image.img",
+                "create_user": False,
+            }
+        }
+
+        mocker.patch("time.sleep")
+        mock_wait_online = mocker.patch.object(DefaultDevice, "wait_online")
+        # Mock the rest of provision to avoid running actual provisioning
+        mocker.patch.object(muxpi, "flash_test_image")
+        mocker.patch.object(muxpi, "hardreset")
+        mocker.patch.object(muxpi, "check_test_image_booted")
+        mocker.patch.object(muxpi, "_run_control")
+        mocker.patch.object(muxpi, "run_post_provision_script")
+
+        muxpi.provision()
+
+        mock_wait_online.assert_called_once()
+        call_args = mock_wait_online.call_args
+        assert call_args[0][1] == "zapper-host"
+        assert call_args[0][2] == 60
+
+    def test_provision_without_zapper_reboots_sdwire(self, mocker):
+        """Test provision reboots sdwire when not using zapper."""
+        muxpi = MuxPi()
+        muxpi.config = {
+            "control_switch_local_cmd": "stm -ts",
+            "control_host": "control-host",
+            "control_user": "ubuntu",
+            "device_ip": "1.2.3.4",
+            "test_device": "/dev/sda",
+        }
+        muxpi.job_data = {
+            "provision_data": {
+                "url": "http://example.com/image.img",
+                "create_user": False,
+            }
+        }
+
+        mocker.patch("time.sleep")
+        mock_reboot_sdwire = mocker.patch.object(muxpi, "reboot_sdwire")
+        mock_wait_online = mocker.patch.object(DefaultDevice, "wait_online")
+        # Mock the rest of provision
+        mocker.patch.object(muxpi, "flash_test_image")
+        mocker.patch.object(muxpi, "hardreset")
+        mocker.patch.object(muxpi, "check_test_image_booted")
+        mocker.patch.object(muxpi, "_run_control")
+        mocker.patch.object(muxpi, "run_post_provision_script")
+
+        muxpi.provision()
+
+        mock_reboot_sdwire.assert_called_once()
+        mock_wait_online.assert_not_called()

--- a/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/netboot/__init__.py
@@ -38,6 +38,9 @@ class DeviceConnector(DefaultDevice):
         """Provision device when the command is invoked."""
         with open(args.config) as configfile:
             config = yaml.safe_load(configfile)
+
+        super().provision(args)
+
         device = Netboot(args.config)
         image = testflinger_device_connectors.get_image(args.job_data)
         if not image:

--- a/device-connectors/src/testflinger_device_connectors/devices/noprovision/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/noprovision/__init__.py
@@ -29,6 +29,8 @@ logger = logging.getLogger(__name__)
 
 class DeviceConnector(DefaultDevice):
     def provision(self, args):
+        super().provision(args)
+
         device = Noprovision(args.config)
         test_username = testflinger_device_connectors.get_test_username(
             args.job_data

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/__init__.py
@@ -40,6 +40,8 @@ class DeviceConnector(DefaultDevice):
 
     def provision(self, args):
         """Provision device when the command is invoked."""
+        super().provision(args)
+
         with open(args.job_data, encoding="utf-8") as job_json:
             self.job_data = json.load(job_json)
         provision_data = self.job_data.get("provision_data", {})

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/tests/test_zapper_oem.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/tests/test_zapper_oem.py
@@ -141,6 +141,20 @@ class ZapperOemTests(unittest.TestCase):
             device._validate_configuration()
         self.assertIn("zapper_iso_type is required", str(context.exception))
 
+    def test_validate_configuration_missing_device_ip(self):
+        """Test _validate_configuration with missing device_ip."""
+        # Config with control_host but missing device_ip
+        device = self._create_device(config={"control_host": "zapper-host"})
+        device.job_data = {
+            "provision_data": {
+                "zapper_iso_url": "http://example.com/image.iso",
+                "zapper_iso_type": "bootstrap",
+            }
+        }
+        with self.assertRaises(ProvisioningError) as context:
+            device._validate_configuration()
+        self.assertIn("device_ip is missing", str(context.exception))
+
     def test_validate_configuration_invalid_iso_type(self):
         """Test _validate_configuration with invalid ISO type."""
         device = self._create_device()

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/tests/test_zapper_oem.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/tests/test_zapper_oem.py
@@ -30,6 +30,7 @@ class ZapperOemTests(unittest.TestCase):
         if config is None:
             config = {
                 "device_ip": "192.168.1.100",
+                "control_host": "zapper-host",
                 "reboot_script": "snmp 1.2.3.4.5.6.7",
             }
         return ZapperOem(config)
@@ -139,19 +140,6 @@ class ZapperOemTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError) as context:
             device._validate_configuration()
         self.assertIn("zapper_iso_type is required", str(context.exception))
-
-    def test_validate_configuration_missing_device_ip(self):
-        """Test _validate_configuration with missing device_ip."""
-        device = self._create_device(config={})  # Empty config
-        device.job_data = {
-            "provision_data": {
-                "zapper_iso_url": "http://example.com/image.iso",
-                "zapper_iso_type": "bootstrap",
-            }
-        }
-        with self.assertRaises(ProvisioningError) as context:
-            device._validate_configuration()
-        self.assertIn("device_ip is missing", str(context.exception))
 
     def test_validate_configuration_invalid_iso_type(self):
         """Test _validate_configuration with invalid ISO type."""

--- a/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemrecovery/__init__.py
@@ -31,6 +31,8 @@ class DeviceConnector(DefaultDevice):
 
     def provision(self, args):
         """Provision device when the command is invoked."""
+        super().provision(args)
+
         device = OemRecovery(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/__init__.py
@@ -29,6 +29,8 @@ class DeviceConnector(DefaultDevice):
 
     def provision(self, args):
         """Provision device when the command is invoked."""
+        super().provision(args)
+
         device = OemScript(args.config, args.job_data)
         logger.info("BEGIN provision")
         logger.info("Provisioning device")

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -47,6 +47,8 @@ class ZapperConnector(ABC, DefaultDevice):
 
     def provision(self, args):
         """Provision device when the command is invoked."""
+        super().provision(args)
+
         with open(args.config, encoding="utf-8") as configfile:
             self.config = yaml.safe_load(configfile)
         with open(args.job_data, encoding="utf-8") as job_json:

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -76,7 +76,8 @@ class ZapperConnector(ABC, DefaultDevice):
 
         control_host = self.config["control_host"]
         logger.info(
-            "Waiting for a running RPyC server on host %s", control_host
+            "Waiting for a running RPyC server on control host %s",
+            control_host,
         )
         try:
             self.wait_online(

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -12,7 +12,7 @@ class ZapperIoTTests(unittest.TestCase):
         """Test the function creates a proper provision_data
         dictionary when valid data are provided.
         """
-        device = DeviceConnector({})
+        device = DeviceConnector({"control_host": "zapper-host"})
         device.job_data = {
             "provision_data": {
                 "preset": "TestPreset",
@@ -36,7 +36,7 @@ class ZapperIoTTests(unittest.TestCase):
 
     def test_validate_configuration_ubuntu_sso_email(self):
         """Test the function username will be ubuntu_sso_email if provided."""
-        device = DeviceConnector({})
+        device = DeviceConnector({"control_host": "zapper-host"})
         device.job_data = {
             "provision_data": {
                 "ubuntu_sso_email": "test@example.com",
@@ -62,7 +62,7 @@ class ZapperIoTTests(unittest.TestCase):
         """Test the function validates a custom test plan
         when provided.
         """
-        device = DeviceConnector({})
+        device = DeviceConnector({"control_host": "zapper-host"})
         device.job_data = {
             "provision_data": {
                 "provision_plan": {
@@ -111,12 +111,14 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(expected, kwargs)
 
-    def test_validate_configuration_ubuntu_sso_email_provision_plan(self):
+    def test_validate_configuration_ubuntu_sso_email_provision_plan(
+        self
+    ):
         """Test the function validates a custom test plan
         when provided and an ubuntu_sso_email is provided.
         The username should be overridden with the ubuntu_sso_email.
         """
-        device = DeviceConnector({})
+        device = DeviceConnector({"control_host": "zapper-host"})
         device.job_data = {
             "provision_data": {
                 "ubuntu_sso_email": "test@example.com",
@@ -165,13 +167,14 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertDictEqual(expected, kwargs)
 
     def test_validate_configuration_ubuntu_sso_email_missing_provision_plan(
-        self,
+        self
     ):
         """Test the function raises an exception if ubuntu_sso_email is not
         provided and the initial login method is console-conf.
         """
         fake_config = {
             "device_ip": "1.1.1.1",
+            "control_host": "zapper-host",
             "reboot_script": ["cmd1", "cmd2"],
         }
         device = DeviceConnector(fake_config)
@@ -202,6 +205,7 @@ class ZapperIoTTests(unittest.TestCase):
         """
         fake_config = {
             "device_ip": "1.1.1.1",
+            "control_host": "zapper-host",
             "reboot_script": ["cmd1", "cmd2"],
         }
         device = DeviceConnector(fake_config)
@@ -214,12 +218,15 @@ class ZapperIoTTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
 
-    def test_validate_configuration_invalid_provision_plan_key_error(self):
+    def test_validate_configuration_invalid_provision_plan_key_error(
+        self
+    ):
         """Test the function raises an exception if the
         provided custom testplan is not valid.
         """
         fake_config = {
             "device_ip": "1.1.1.1",
+            "control_host": "zapper-host",
             "reboot_script": ["cmd1", "cmd2"],
         }
         device = DeviceConnector(fake_config)
@@ -230,12 +237,15 @@ class ZapperIoTTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
 
-    def test_validate_configuration_invalid_provision_plan_value_error(self):
+    def test_validate_configuration_invalid_provision_plan_value_error(
+        self
+    ):
         """Test the function raises an exception if the
         provided custom testplan is not valid.
         """
         fake_config = {
             "device_ip": "1.1.1.1",
+            "control_host": "zapper-host",
             "reboot_script": ["cmd1", "cmd2"],
         }
         device = DeviceConnector(fake_config)
@@ -261,7 +271,7 @@ class ZapperIoTTests(unittest.TestCase):
         """Test the function copy the ssh id if there is no provision plan
         and without ubuntu_sso_email.
         """
-        fake_config = {"device_ip": "1.1.1.1"}
+        fake_config = {"device_ip": "1.1.1.1", "control_host": "zapper-host"}
         device = DeviceConnector(fake_config)
         device.job_data = {"provision_data": {}}
         device._post_run_actions(args=None)
@@ -274,7 +284,7 @@ class ZapperIoTTests(unittest.TestCase):
         """Test the function does not copy the ssh id if there is
         buntu_sso_email.
         """
-        fake_config = {"device_ip": "1.1.1.1"}
+        fake_config = {"device_ip": "1.1.1.1", "control_host": "zapper-host"}
         device = DeviceConnector(fake_config)
         device.job_data = {
             "provision_data": {
@@ -291,7 +301,7 @@ class ZapperIoTTests(unittest.TestCase):
         """Test the function copies the ssh id if the
         initial login method is Not console-conf.
         """
-        fake_config = {"device_ip": "1.1.1.1"}
+        fake_config = {"device_ip": "1.1.1.1", "control_host": "zapper-host"}
         device = DeviceConnector(fake_config)
         device.job_data = {
             "provision_data": {

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -111,9 +111,7 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(expected, kwargs)
 
-    def test_validate_configuration_ubuntu_sso_email_provision_plan(
-        self
-    ):
+    def test_validate_configuration_ubuntu_sso_email_provision_plan(self):
         """Test the function validates a custom test plan
         when provided and an ubuntu_sso_email is provided.
         The username should be overridden with the ubuntu_sso_email.
@@ -167,7 +165,7 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertDictEqual(expected, kwargs)
 
     def test_validate_configuration_ubuntu_sso_email_missing_provision_plan(
-        self
+        self,
     ):
         """Test the function raises an exception if ubuntu_sso_email is not
         provided and the initial login method is console-conf.
@@ -218,9 +216,7 @@ class ZapperIoTTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
 
-    def test_validate_configuration_invalid_provision_plan_key_error(
-        self
-    ):
+    def test_validate_configuration_invalid_provision_plan_key_error(self):
         """Test the function raises an exception if the
         provided custom testplan is not valid.
         """
@@ -237,9 +233,7 @@ class ZapperIoTTests(unittest.TestCase):
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
 
-    def test_validate_configuration_invalid_provision_plan_value_error(
-        self
-    ):
+    def test_validate_configuration_invalid_provision_plan_value_error(self):
         """Test the function raises an exception if the
         provided custom testplan is not valid.
         """

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -90,9 +90,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
-    def test_validate_configuration_preset_with_overriding_items(
-        self
-    ):
+    def test_validate_configuration_preset_with_overriding_items(self):
         """Test whether the validate_configuration function returns
         the expected data merging the relevant bits from conf and job
         data when passing only the required arguments.

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -29,7 +29,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
     """Unit tests for ZapperConnector KVM class."""
 
     def test_get_credentials(self) -> None:
-        connector = DeviceConnector({})
+        connector = DeviceConnector({"control_host": "zapper-host"})
         connector.job_data = {}
         assert connector._get_credentials("jammy-oem") == ("ubuntu", "u")
         assert connector._get_credentials("preset") == ("ubuntu", "ubuntu")
@@ -40,7 +40,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         the expected data merging the relevant bits from conf and job
         data when passing only the required arguments.
         """
-        connector = DeviceConnector({})
+        connector = DeviceConnector({"control_host": "zapper-host"})
         connector.job_data = {
             "job_queue": "queue",
             "provision_data": {
@@ -71,7 +71,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         the expected data merging the relevant bits from conf and job
         data when passing only the required arguments.
         """
-        connector = DeviceConnector({})
+        connector = DeviceConnector({"control_host": "zapper-host"})
         connector.job_data = {
             "job_queue": "queue",
             "provision_data": {
@@ -90,12 +90,14 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
-    def test_validate_configuration_preset_with_overriding_items(self):
+    def test_validate_configuration_preset_with_overriding_items(
+        self
+    ):
         """Test whether the validate_configuration function returns
         the expected data merging the relevant bits from conf and job
         data when passing only the required arguments.
         """
-        connector = DeviceConnector({})
+        connector = DeviceConnector({"control_host": "zapper-host"})
         connector.job_data = {
             "job_queue": "queue",
             "provision_data": {
@@ -123,7 +125,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         the expected data merging the relevant bits from conf and job
         data when passing all the optional arguments.
         """
-        connector = DeviceConnector({})
+        connector = DeviceConnector({"control_host": "zapper-host"})
         connector.job_data = {
             "job_queue": "queue",
             "provision_data": {
@@ -172,7 +174,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         password are hardcoded and the Zapper shall try the procedures
         at least twice because it can fail on purpose.
         """
-        connector = DeviceConnector({})
+        connector = DeviceConnector({"control_host": "zapper-host"})
         connector.job_data = {
             "job_queue": "queue",
             "provision_data": {
@@ -310,7 +312,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         """Test the autoinstall configuration includes oem_autoinstall
         user-data file + 'direct' storage layout when 'oem:true'.
         """
-        fake_config = {"device_ip": "localhost"}
+        fake_config = {"device_ip": "localhost", "control_host": "zapper-host"}
         connector = DeviceConnector(fake_config)
         connector.job_data = {
             "job_queue": "queue",
@@ -483,7 +485,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         """Test the function runs a command over SSH to change the
         original password to the one specified in test_data.
         """
-        fake_config = {"device_ip": "localhost"}
+        fake_config = {"device_ip": "localhost", "control_host": "zapper-host"}
         connector = DeviceConnector(fake_config)
         connector.job_data = {"test_data": {"test_password": "new_password"}}
 
@@ -509,7 +511,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         """Test the function updates the password and run the OEM script
         when `alloem_url` is in scope.
         """
-        fake_config = {"device_ip": "localhost"}
+        fake_config = {"device_ip": "localhost", "control_host": "zapper-host"}
         connector = DeviceConnector(fake_config)
         connector.job_data = {
             "provision_data": {"alloem_url": "file://image.iso"}
@@ -528,7 +530,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         """Test the function raises the ProvisioningError
         exception in case one of the SSH commands fail.
         """
-        fake_config = {"device_ip": "localhost"}
+        fake_config = {"device_ip": "localhost", "control_host": "zapper-host"}
         connector = DeviceConnector(fake_config)
         connector.job_data = {
             "provision_data": {"alloem_url": "file://image.iso"}
@@ -558,7 +560,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         """Test the function raises the ProvisioningError
         exception in case one of the SSH commands times out.
         """
-        fake_config = {"device_ip": "localhost"}
+        fake_config = {"device_ip": "localhost", "control_host": "zapper-host"}
         connector = DeviceConnector(fake_config)
         connector.job_data = {
             "provision_data": {"alloem_url": "file://image.iso"}
@@ -586,7 +588,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         ssh_path = mock_path.return_value.expanduser.return_value
         ssh_path.read_text.return_value = "mykey"
 
-        fake_config = {"device_ip": "localhost"}
+        fake_config = {"device_ip": "localhost", "control_host": "zapper-host"}
         connector = DeviceConnector(fake_config)
         key = connector._read_ssh_key()
         self.assertEqual(key, "mykey")


### PR DESCRIPTION
## Description

1. Any type of control host might affect provisioning
2. Any type of control host might affect testing
3. If the control host is not reachable, (1) or (2) can fail for a reason completed unrelated to the DUT

This PR propose a programmatic way to reboot the control host *just before provisioning* in case it's not reachable.

This is still opt-in (you need to call the super() method), but I think it's safe to call it everywhere for now, since it doesn't raise any error. We could also wrap it in `try/except Exception` if it makes sense.

Also, connectors relying on a specific control host, now also wait for the service of interest to be available.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

No!

## Tests

Test with functional control host machine:
```
2026-01-15 11:27:22,323 rpi5b8g001 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-01-15 11:27:22,323 rpi5b8g001 INFO: DEVICE CONNECTOR: Waiting for a running SSH server on control host 10.102.246.37
2026-01-15 11:27:22,682 rpi5b8g001 INFO: DEVICE CONNECTOR: BEGIN provision
2026-01-15 11:27:22,682 rpi5b8g001 INFO: DEVICE CONNECTOR: Provisioning device
2026-01-15 11:27:22,684 rpi5b8g001 INFO: DEVICE CONNECTOR: Waiting for a running RPyC server on control host xxx
2026-01-15 11:27:41,658 rpi5b8g001 WARNING: DEVICE CONNECTOR: Device /dev/sda might not be mounted
...
```

Test with not reachable control host (Cannot run *snmp* commands remotely, from source) :
```
2026-01-15 11:33:03,775 rpi5b8g001 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-01-15 11:33:03,775 rpi5b8g001 INFO: DEVICE CONNECTOR: Waiting for a running SSH server on control host 10.102.246.37
2026-01-15 11:33:06,780 rpi5b8g001 INFO: DEVICE CONNECTOR: Running control host reboot script
2026-01-15 11:33:06,780 rpi5b8g001 INFO: DEVICE CONNECTOR: Executing: snmpset -c private -v 2c XXX 1.3.6.1.2.1.105.1.1.1.3.0.2 i 2
2026-01-15 11:33:06,781 rpi5b8g001 ERROR: DEVICE CONNECTOR: Command failed: snmpset -c private -v 2c XXX 1.3.6.1.2.1.105.1.1.1.3.0.2 i 2 (exit code: 127)
2026-01-15 11:33:06,781 rpi5b8g001 ERROR: DEVICE CONNECTOR: stderr: /bin/sh: 1: snmpset: not found

2026-01-15 11:33:06,781 rpi5b8g001 INFO: DEVICE CONNECTOR: Executing: sleep 5
2026-01-15 11:33:11,784 rpi5b8g001 INFO: DEVICE CONNECTOR: Command completed successfully: sleep 5
2026-01-15 11:33:11,784 rpi5b8g001 INFO: DEVICE CONNECTOR: Executing: snmpset -c private -v 2c XXX 1.3.6.1.2.1.105.1.1.1.3.0.2 i 1
2026-01-15 11:33:11,785 rpi5b8g001 ERROR: DEVICE CONNECTOR: Command failed: snmpset -c private -v 2c XXX 1.3.6.1.2.1.105.1.1.1.3.0.2 i 1 (exit code: 127)
2026-01-15 11:33:11,785 rpi5b8g001 ERROR: DEVICE CONNECTOR: stderr: /bin/sh: 1: snmpset: not found

2026-01-15 11:38:12,230 rpi5b8g001 ERROR: DEVICE CONNECTOR: Control host XXX is not available or the SSH server is not running after 300 seconds
2026-01-15 11:38:12,235 rpi5b8g001 INFO: DEVICE CONNECTOR: BEGIN provision
2026-01-15 11:38:12,235 rpi5b8g001 INFO: DEVICE CONNECTOR: Provisioning device
2026-01-15 11:38:12,236 rpi5b8g001 INFO: DEVICE CONNECTOR: Waiting for a running RPyC server on control host XXX
2026-01-15 11:38:15,688 rpi5b8g001 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server. Retrying in the background...
2026-01-15 11:39:14,480 rpi5b8g001 ERROR: DEVICE CONNECTOR: Cannot reach out the service over RPyC
```

^ as you can see here, we attempted reboot but failed. Provisioning will continue, because the specific device connector is responsible for checking what it actually needs.
