### PR TITLE
update readme for cli to demonstrate typical use of --poll argument

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -32,8 +32,7 @@ testflinger-cli poll d14d2e31-f239-41b6-9a74-32f538e71cde
 ```
 
 > [!TIP] 
-> If you are expecting to poll the job, you may wish to specify this from
-the beginning when submitting the job with the `--poll` flag:
+> If you are expecting to poll the job, you may wish to specify this from the beginning when submitting the job with the `--poll` flag:
 >
 > ```shell
 > testflinger-cli submit --poll job.yaml


### PR DESCRIPTION
## Description

Minor change to the README.md to provide an example of using --poll right from the start as is likely the most often uses use-case.

## Resolved issues

Added an example, see above.

## Documentation

Documentation change only.

## Web service API changes

Documentation change only.

## Tests

N/A
