### PR TITLE
Add `queue-status` Action

### DIFF
--- a/.github/actions/queue-status/README.md
+++ b/.github/actions/queue-status/README.md
@@ -9,11 +9,11 @@ scheduled jobs from being submitted if their associated queue(s) are busy.
 ### Simple
 
 ```yaml
-- name: Query queue-status of nvidia-gpu
+- name: Query queue-status
   id: queue-status
   uses: canonical/testflinger/.github/actions/queue-status@main
   with:
-    queue: nvidia-gpu
+    queue: <queue_name>
 ```
 
 ### As a gate for `submit`
@@ -25,7 +25,7 @@ scheduled jobs from being submitted if their associated queue(s) are busy.
   id: queue-status
   uses: canonical/testflinger/.github/actions/queue-status@main
   with:
-    queue: $${{ matrix.queue }}
+    queue: ${{ matrix.queue }}
 
 - name: Submit job
   id: submit-job

--- a/.github/actions/queue-status/action.yaml
+++ b/.github/actions/queue-status/action.yaml
@@ -63,6 +63,7 @@ runs:
         SERVER: https://${{ inputs.server }}
         QUEUE: ${{ inputs.queue }}
       run: |
+        echo "::group::Get $QUEUE queue-status"
         RESULT=$(testflinger --server "$SERVER" queue-status "$QUEUE")
         echo "$RESULT"
         
@@ -81,3 +82,4 @@ runs:
           value=$(printf '%s\n' "$RESULT" | awk -F': *' -v lbl="$label" '$1==lbl {print $2}')
           echo "${out_key}=${value}" >> "$GITHUB_OUTPUT"
         done
+        echo "::endgroup::"


### PR DESCRIPTION
## Description

This PR proposes adding an action wrapping `queue-status` similar to the existing `submit` action.

This is useful in CI that requires status tracking or scheduling, such as CI running on an automatic cadence which wishes to avoid currently-busy queues (such as in my case). Alternatively, a testflinger-enabled GitHub runner could be requested so that the user could invoke `testflinger-cli queue-status <queue>` in their CI and manually parse the output, but this is overkill for CI use cases which simply want to ask "what's going on in this queue?" before deciding whether to / in what manner to interact with the queue.

The `queue-status` action mirrors the API of `testflinger-cli queue-status <queue>` with the addition of the `--server` flag and the CLI output is parsed into individual outputs. Identical to the `submit` action, this uses the aproxy bypass step to enable the action on private runners, and the Testflinger server connectivity check step.

Perhaps more testflinger-cli commands could be wrapped in Actions? If so, some redundancies like the aproxy bypass and connectivity check may be broken out into separate Actions.

## Documentation

I've added a README for this Action, please let me know if there are other documentation sources to be updated parallel to this PR.

## Tests

The proposed `queue-status` action was tested [here](https://github.com/canonical/pe-devices-heartbeat/actions/runs/20178415625/job/57932362209).
1. Add the composite Action as a step to a workflow as documented in the README.
2. In a following step, verify the parsed outputs are equivalent to their counterparts in the original `testflinger-cli queue <queue>` CLI output.