### PR TITLE
fix(agent): read serial file as binary if any invalid character

### DIFF
--- a/agent/src/testflinger_agent/job.py
+++ b/agent/src/testflinger_agent/job.py
@@ -189,14 +189,15 @@ class TestflingerJob:
             exitcode = 100
             exit_reason = str(exc)  # noqa: F841 - ignore this until it's used
         finally:
-            # Write serial log file generated in device connector to
-            # the serial log endpoint if the file exists
-            self.serial_output_handler.write_from_file(serial_log)
+            # Update phase results first
             self._update_phase_results(
                 results_file,
                 phase,
                 exitcode,
             )
+            # Write serial log file generated in device connector to
+            # the serial log endpoint if the file exists
+            self.serial_output_handler.write_from_file(serial_log)
         if phase == "allocate":
             self.allocate_phase(rundir)
         return exitcode, exit_event, exit_reason


### PR DESCRIPTION
## Description
I've been noticing some RPI (muxpi device connector) provisioned successfully only to then proceed to the cleanup stage (skipping test and reserve phase). Since the status code (exit code) was not being sent at all to the server, my guess is that the code is breaking one step before during writing to serial endpoint.
```
testflinger-cli results 5f6dfae4-25e5-481f-8009-5f6ce4ae1223 | jq .provision_status
null
```

Note: sending all other the results and phases status codes succeeds, provisioning status code was never retrieved/send to server

Since muxpi device connector are writing serial data as [binary](https://github.com/canonical/testflinger/blob/e8f6addc42b0a757d2775198b545aeef645a3846/device-connectors/src/testflinger_device_connectors/devices/__init__.py#L124), in case there is any invalid character attempted to be read as text will raise a `UnicodeDecodeError`. 

This PR adds catching this exception and reading it properly before being sent to server.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
[CERTTF-784](https://warthogs.atlassian.net/browse/CERTTF-784)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added one unit test to validate this behavior. Tested the unit test locally with and without fix in place

Before fix:
```
...
>       (result, consumed) = self._buffer_decode(data, self.errors, final)
E       UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 8: invalid start byte

../../../../.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/codecs.py:322: UnicodeDecodeError
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-784]: https://warthogs.atlassian.net/browse/CERTTF-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ