### PR TITLE
fix(cli): modify incorrect return type

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -57,9 +57,6 @@ from testflinger_cli.errors import (
     UnknownStatusError,
 )
 
-# Maximum backoff time in seconds for retrying network operations
-MAX_BACKOFF_TIME = 60
-
 logger = logging.getLogger(__name__)
 
 # Make it easier to run from a checkout
@@ -1094,7 +1091,6 @@ class TestflingerCli:
             print("This job is waiting on a node to become available.")
         cur_fragment = start_fragment
         consecutive_empty_polls = 0
-        retry_count = 0
         while True:
             try:
                 job_state_data = self.get_job_state(job_id)
@@ -1104,9 +1100,6 @@ class TestflingerCli:
                 last_fragment_number, log_data = self._get_combined_log_output(
                     job_id, log_type, phase, cur_fragment, start_timestamp
                 )
-
-                # Reset retry count as there was a successful poll
-                retry_count = 0
 
                 # Print logs before any check
                 if last_fragment_number >= 0 and log_data:
@@ -1157,11 +1150,6 @@ class TestflingerCli:
                 # Ignore/retry or debug any connection errors or timeouts
                 if self.args.debug:
                     logger.exception("Error polling for job output")
-
-                # In case network errors, delay next status check
-                backoff_delay = min(2**retry_count, MAX_BACKOFF_TIME)
-                time.sleep(backoff_delay)
-                retry_count += 1
             except KeyboardInterrupt:
                 choice = input(
                     f"\nCancel job {job_id} before exiting "

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -1282,7 +1282,7 @@ class TestflingerCli:
             # For other types of network errors, or JSONDecodeError if we got
             # a bad return from get_status()
             logger.debug("Unable to retrieve job state: %s", exc)
-        return "unknown"
+        return {"job_state": "unknown"}
 
     def login(self):
         """Authenticate using refresh_token or provided credentials."""

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -51,7 +51,6 @@ def test_status(capsys, requests_mock):
     std = capsys.readouterr()
     assert std.out == "completed\n"
 
-
 def test_cancel_503(requests_mock):
     """Cancel should fail loudly if cancel action returns 503."""
     jobid = str(uuid.uuid1())
@@ -1405,3 +1404,64 @@ def test_live_polling_by_phase(capsys, requests_mock, monkeypatch):
     # Verify logs were printed
     assert "Running tests..." in captured.out
     assert "Tests passed!" in captured.out
+
+def test_get_job_state_network_error(requests_mock):
+    """Test get_job_state returns dict on network errors."""
+    jobid = str(uuid.uuid1())
+    requests_mock.get(
+        f"{URL}/v1/result/{jobid}", exc=requests.exceptions.ConnectionError
+    )
+    sys.argv = ["", "status", jobid]
+    tfcli = testflinger_cli.TestflingerCli()
+    result = tfcli.get_job_state(jobid)
+
+    # Ensure the return type is dict
+    assert isinstance(result, dict)
+    assert result == {"job_state": "unknown"}
+
+
+def test_poll_exponential_backoff_on_network_errors(
+    capsys, requests_mock, monkeypatch
+):
+    """Test that polling uses exponential backoff on network errors."""
+    job_id = str(uuid.uuid1())
+
+    # Mock time.sleep to track backoff delays
+    sleep_calls = []
+    monkeypatch.setattr(
+        time, "sleep", lambda duration: sleep_calls.append(duration)
+    )
+
+    # Mock job status to eventually complete
+    requests_mock.get(
+        f"{URL}/v1/result/{job_id}",
+        [{"json": {"job_state": "test"}}] * 10
+        + [{"json": {"job_state": "complete"}}],
+    )
+
+    # Mock log output to fail 5 times then succeed
+    requests_mock.get(
+        f"{URL}/v1/result/{job_id}/log/output?start_fragment=0",
+        [{"exc": requests.exceptions.ConnectionError}] * 5
+        + [
+            {
+                "json": {
+                    "output": {
+                        "test": {"last_fragment_number": 1, "log_data": ""}
+                    }
+                }
+            }
+        ],
+    )
+
+    sys.argv = ["", "poll", job_id]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.do_poll(job_id)
+
+    # Verify exponential backoff pattern
+    assert len(sleep_calls) >= 5
+    assert sleep_calls[0] == 1  # 2^0 = 1
+    assert sleep_calls[1] == 2  # 2^1 = 2
+    assert sleep_calls[2] == 4  # 2^2 = 4
+    assert sleep_calls[3] == 8  # 2^3 = 8
+    assert sleep_calls[4] == 16  # 2^4 = 16

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1432,14 +1432,12 @@ def test_poll_exponential_backoff_on_network_errors(
         time, "sleep", lambda duration: sleep_calls.append(duration)
     )
 
-    # Mock job status to eventually complete
+    # Mock both endpoints to fail 5 times then succeed
     requests_mock.get(
         f"{URL}/v1/result/{job_id}",
-        [{"json": {"job_state": "test"}}] * 10
+        [{"exc": requests.exceptions.ConnectionError}] * 5
         + [{"json": {"job_state": "complete"}}],
     )
-
-    # Mock log output to fail 5 times then succeed
     requests_mock.get(
         f"{URL}/v1/result/{job_id}/log/output?start_fragment=0",
         [{"exc": requests.exceptions.ConnectionError}] * 5

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1458,8 +1458,8 @@ def test_poll_exponential_backoff_on_network_errors(
 
     # Verify exponential backoff pattern
     assert len(sleep_calls) >= 5
-    assert sleep_calls[0] == 1  # 2^0 = 1
-    assert sleep_calls[1] == 2  # 2^1 = 2
-    assert sleep_calls[2] == 4  # 2^2 = 4
-    assert sleep_calls[3] == 8  # 2^3 = 8
-    assert sleep_calls[4] == 16  # 2^4 = 16
+    assert sleep_calls[0] == 2  # 2^1 = 2
+    assert sleep_calls[1] == 4  # 2^2 = 4
+    assert sleep_calls[2] == 8  # 2^3 = 8
+    assert sleep_calls[3] == 16  # 2^4 = 16
+    assert sleep_calls[4] == 32  # 2^5 = 32


### PR DESCRIPTION
## Description
PR #851 modified the return type of get_job_state() from string to a dict, however, for networking error, this were still returning a str "unknown"

Modify code to include correct return type and to have a exponential delay check in case network errors. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves #868 
Resolves [CERTTF-792](https://warthogs.atlassian.net/browse/CERTTF-792)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added couple of unit test to add coverage to this behavior. 

Also tested locally, this error can be easily replicated by turning off internet when doing poll:

Procedure
1. Submit job
2. Turn off internet access:
3. Attempt to poll:
```
testflinger-cli --server https://testflinger-staging.canonical.com poll 6abd4eb8-b640-415c-b399-f4cc199db7c5
Traceback (most recent call last):
  File "/snap/testflinger-cli/234/bin/testflinger-cli", line 12, in <module>
    sys.exit(cli())
  File "/snap/testflinger-cli/234/lib/python3.10/site-packages/testflinger_cli/__init__.py", line 77, in cli
    tfcli.run()
  File "/snap/testflinger-cli/234/lib/python3.10/site-packages/testflinger_cli/__init__.py", line 131, in run
    self.args.func()
  File "/snap/testflinger-cli/234/lib/python3.10/site-packages/testflinger_cli/__init__.py", line 1066, in poll_output
    self.poll(LogType.STANDARD_OUTPUT)
  File "/snap/testflinger-cli/234/lib/python3.10/site-packages/testflinger_cli/__init__.py", line 1062, in poll
    self.do_poll(job_id, log_type)
  File "/snap/testflinger-cli/234/lib/python3.10/site-packages/testflinger_cli/__init__.py", line 1087, in do_poll
    job_state = job_state_data["job_state"]
TypeError: string indices must be integers
```

With fix:
uv run testflinger-cli --server https://testflinger-staging.canonical.com poll 6abd4eb8-b640-415c-b399-f4cc199db7c5
```
WARNING: 2026-01-09 09:06:30 client.py:99 -- Error communicating with the server for the past 3 requests, but will continue to retry. Last error: HTTPSConnectionPool(host='testflinger-staging.canonical.com', port=443): Max retries exceeded with url: /v1/result/6abd4eb8-b640-415c-b399-f4cc199db7c5/log/output?start_fragment=0 (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7282f476d960>: Failed to resolve 'testflinger-staging.canonical.com' ([Errno -3] Temporary failure in name resolution)"))
WARNING: 2026-01-09 09:06:32 client.py:99 -- Error communicating with the server for the past 6 requests, but will continue to retry. Last error: HTTPSConnectionPool(host='testflinger-staging.canonical.com', port=443): Max retries exceeded with url: /v1/result/6abd4eb8-b640-415c-b399-f4cc199db7c5 (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7282f476de10>: Failed to resolve 'testflinger-staging.canonical.com' ([Errno -3] Temporary failure in name resolution)"))
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-792]: https://warthogs.atlassian.net/browse/CERTTF-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ