### PR TITLE
fix: update the default release from xenial to jammy in maas.py 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+artifacts
 build
 dist
 env
@@ -17,8 +18,12 @@ docs/.sphinx/.doctrees/
 *.egg*
 *.bak
 *.charm
+*.swp
 
 _build
 __pycache__
 
 *.snap
+
+# AI agent instructions (user-specific)
+.github/copilot-instructions.md

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -83,7 +83,7 @@ class Maas2:
             self.clear_tpm()
         provision_data = self.job_data.get("provision_data")
         # Default to a safe LTS if no distro is specified
-        distro = provision_data.get("distro", "xenial")
+        distro = provision_data.get("distro", "jammy")
         kernel = provision_data.get("kernel")
         user_data = provision_data.get("user_data")
         storage_data = provision_data.get("disks")


### PR DESCRIPTION
## Description

Updates the default fallback release from xenial to  jammy since xenial is no longer supported and very likely to not exist on a current maas system.


## Resolved issues
Resolves #318 
Resoves CERTTF-366


## Documentation

NA

## Web service API changes

NA

## Tests

NA
