### PR TITLE
change: don't log docker error when removing container

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
@@ -9,10 +9,10 @@ CONFIG_DIR="{{ config_dir }}"
 VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
 if [ -d "$VIRTUAL_ENV_PATH" ]; then
-    echo Cleaning up container if it exists... && docker rm -f $agent_id 2> /dev/null || /bin/true
+    echo Cleaning up container if it exists... && docker rm -f $agent_id || /bin/true
     PYTHONUNBUFFERED=1 $VIRTUAL_ENV_PATH/bin/testflinger-device-connector $PROVISION_TYPE cleanup -c $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json
 else
-    echo Cleaning up container if it exists... && docker rm -f $AGENT 2> /dev/null || /bin/true
+    echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
     . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE cleanup -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
 fi
 

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-cleanup
@@ -9,10 +9,10 @@ CONFIG_DIR="{{ config_dir }}"
 VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
 if [ -d "$VIRTUAL_ENV_PATH" ]; then
-    echo Cleaning up container if it exists... && docker rm -f $agent_id || /bin/true
+    echo Cleaning up container if it exists... && docker rm -f $agent_id 2> /dev/null || /bin/true
     PYTHONUNBUFFERED=1 $VIRTUAL_ENV_PATH/bin/testflinger-device-connector $PROVISION_TYPE cleanup -c $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json
 else
-    echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+    echo Cleaning up container if it exists... && docker rm -f $AGENT 2> /dev/null || /bin/true
     . /srv/testflinger-agent/$AGENT/env/bin/activate && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE cleanup -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json
 fi
 

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-setup
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-setup
@@ -5,8 +5,8 @@ PROVISION_TYPE="$provision_type"
 VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
 if [ -d "$VIRTUAL_ENV_PATH" ]; then
-    echo Cleaning up container if it exists... && docker rm -f $agent_id || /bin/true
+    echo Cleaning up container if it exists... && docker rm -f $agent_id 2> /dev/null || /bin/true
 else
-    echo Cleaning up container if it exists... && docker rm -f $AGENT || /bin/true
+    echo Cleaning up container if it exists... && docker rm -f $AGENT 2> /dev/null || /bin/true
 fi
 


### PR DESCRIPTION
## Description

```
***************************************************************************
* Starting testflinger setup phase on hp-pro-sff-400-g9-desktop-pc-c30464 *
***************************************************************************
Cleaning up container if it exists...
Error response from daemon: No such container: hp-pro-sff-400-g9-desktop-pc-c30464
```

Normally, there's no leftover from previous runs, but we try anyway to cleanup the container in case it still exists. The message usually displayed is misleading for a normal user: it makes them think there has been an issue while this is actually the expected situation.

I know I might be redirecting too much, at the same time I didn't want to complicate these scripts too much.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

No

## Tests

I can't actually test this, can I?
