### PR TITLE
tests: update server charm unit tests and include integration tests

### DIFF
--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -83,6 +83,8 @@ jobs:
         run: sudo snap install --classic concierge
       - name: Prepare Juju
         run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=latest/stable -p microk8s
+      - name: Enable MicroK8s ingress
+        run: sudo microk8s enable ingress
       - name: Pack charm
         run: charmcraft pack --verbose
       - name: Upload charm as an artifact

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -51,10 +51,26 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test_charm:
-    name: Run charm tests
+    name: Run charm unit tests
     defaults:
       run:
-        working-directory: agent
+        working-directory: server
+    runs-on: [self-hosted, linux, jammy, X64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
+      - name: Install uv and set up Python
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
+      - name: Run charm tests
+        run: uvx --with tox-uv tox -e charm-unit
+
+  test_charm_integration:
+    name: Run charm integration tests
+    defaults:
+      run:
+        working-directory: server/charm/
     runs-on: [self-hosted, linux, jammy, X64]
     steps:
       - name: Checkout
@@ -66,6 +82,15 @@ jobs:
       - name: Install concierge
         run: sudo snap install --classic concierge
       - name: Prepare Juju
-        run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=latest/stable -p machine
-      - name: Run charm tests
-        run: uvx --with tox-uv tox -e charm
+        run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=latest/stable -p microk8s
+      - name: Pack charm
+        run: charmcraft pack --verbose
+      - name: Upload charm as an artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: server-charm
+          path: server/charm/*.charm
+          if-no-files-found: error
+          retention-days: 2
+      - name: Run charm integration tests
+        run: uvx --with tox-uv tox -e charm-integration

--- a/server/charm/tests/integration/conftest.py
+++ b/server/charm/tests/integration/conftest.py
@@ -1,0 +1,45 @@
+"""Fixtures for charm integration tests."""
+
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+import jubilant
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def juju(request: pytest.FixtureRequest):
+    """Create temporary Juju model for running tests."""
+    with jubilant.temp_model() as juju:
+        juju.wait_timeout = 600
+        yield juju
+
+        if request.session.testsfailed:
+            logger.info("Collecting Juju logs...")
+            time.sleep(0.5)  # Wait for Juju to process logs.
+            log = juju.debug_log(limit=1000)
+            print(log, end="", file=sys.stderr)
+
+
+@pytest.fixture(scope="session")
+def charm_path():
+    """Return the path of the charm under test."""
+    if "CHARM_PATH" in os.environ:
+        charm_path = Path(os.environ["CHARM_PATH"])
+        if not charm_path.exists():
+            raise FileNotFoundError(f"Charm does not exist: {charm_path}")
+        return charm_path
+    charm_paths = list(Path(".").glob("*.charm"))
+    if not charm_paths:
+        raise FileNotFoundError("No .charm file in current directory")
+    if len(charm_paths) > 1:
+        path_list = ", ".join(str(p) for p in charm_paths)
+        raise ValueError(
+            f"More than one .charm file in current directory: {path_list}"
+        )
+    return charm_paths[0]

--- a/server/charm/tests/integration/helpers.py
+++ b/server/charm/tests/integration/helpers.py
@@ -55,16 +55,17 @@ class DNSResolverHTTPAdapter(HTTPAdapter):
             and result.scheme in ("http", "https")
             and self.ip
         ):
-            request.url = request.url.replace(  # type: ignore
+            request.url = request.url.replace(
                 f"{result.scheme}://{result.hostname}",
                 f"{result.scheme}://{self.ip}",
             )
-            self.poolmanager.connection_pool_kw["server_hostname"] = (
-                self.hostname
-            )
-            self.poolmanager.connection_pool_kw["assert_hostname"] = (
-                self.hostname
-            )
+            if result.scheme == "https":
+                self.poolmanager.connection_pool_kw["server_hostname"] = (
+                    self.hostname
+                )
+                self.poolmanager.connection_pool_kw["assert_hostname"] = (
+                    self.hostname
+                )
         elif result.hostname == self.hostname:
             self.poolmanager.connection_pool_kw.pop("server_hostname", None)
             self.poolmanager.connection_pool_kw.pop("assert_hostname", None)
@@ -78,7 +79,7 @@ def app_is_up(base_url: str, session: requests.Session | None = None) -> bool:
     :param session: Optional requests session to use.
     :return: True if the application is up, False otherwise.
     """
-    url = f"{base_url}/"
+    url = f"{base_url}/v1/"
     logger.info("Querying endpoint: %s", url)
     get = session.get if session else requests.get
     response = get(url, timeout=15, verify=False)

--- a/server/charm/tests/integration/helpers.py
+++ b/server/charm/tests/integration/helpers.py
@@ -59,6 +59,7 @@ class DNSResolverHTTPAdapter(HTTPAdapter):
                 f"{result.scheme}://{result.hostname}",
                 f"{result.scheme}://{self.ip}",
             )
+            request.headers["Host"] = self.hostname
             if result.scheme == "https":
                 self.poolmanager.connection_pool_kw["server_hostname"] = (
                     self.hostname

--- a/server/charm/tests/integration/helpers.py
+++ b/server/charm/tests/integration/helpers.py
@@ -1,0 +1,118 @@
+"""Helper functions for integration tests."""
+
+import functools
+import logging
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+import requests
+import yaml
+from requests.adapters import HTTPAdapter
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("charmcraft.yaml").read_text(encoding="utf-8"))
+APP_NAME = METADATA["name"]
+MONGODB_CHARM = "mongodb-k8s"
+
+
+class DNSResolverHTTPAdapter(HTTPAdapter):
+    """Simple DNS resolver for HTTP requests."""
+
+    def __init__(self, hostname: str, ip: str, *args, **kwargs) -> None:
+        """Initialize the dns resolver.
+
+        :param hostname: The hostname to resolve.
+        :param ip: The IP address to resolve to.
+        """
+        super().__init__(*args, **kwargs)
+        self.hostname = hostname
+        self.ip = ip
+
+    def send(
+        self,
+        request,
+        stream=False,
+        timeout=None,
+        verify=True,
+        cert=None,
+        proxies=None,
+    ) -> requests.Response:
+        """Wrap HTTPAdapter send to modify the outbound request.
+
+        :param request: The HTTP request.
+        :param stream: Whether to stream the response.
+        :param timeout: The request timeout.
+        :param verify: Whether to verify SSL certificates.
+        :param cert: Client certificate.
+        :param proxies: Proxies to use for the request.
+        :return: The HTTP response.
+        """
+        result = urlparse(request.url)
+        if (
+            result.hostname == self.hostname
+            and result.scheme in ("http", "https")
+            and self.ip
+        ):
+            request.url = request.url.replace(  # type: ignore
+                f"{result.scheme}://{result.hostname}",
+                f"{result.scheme}://{self.ip}",
+            )
+            self.poolmanager.connection_pool_kw["server_hostname"] = (
+                self.hostname
+            )
+            self.poolmanager.connection_pool_kw["assert_hostname"] = (
+                self.hostname
+            )
+        elif result.hostname == self.hostname:
+            self.poolmanager.connection_pool_kw.pop("server_hostname", None)
+            self.poolmanager.connection_pool_kw.pop("assert_hostname", None)
+        return super().send(request, stream, timeout, verify, cert, proxies)
+
+
+def app_is_up(base_url: str, session: requests.Session | None = None) -> bool:
+    """Check that the application is up.
+
+    :param base_url: The base URL of the application.
+    :param session: Optional requests session to use.
+    :return: True if the application is up, False otherwise.
+    """
+    url = f"{base_url}/"
+    logger.info("Querying endpoint: %s", url)
+    get = session.get if session else requests.get
+    response = get(url, timeout=15, verify=False)
+    return response.ok and "Testflinger Server" in response.text
+
+
+def retry(retry_num: int, retry_sleep_sec: int) -> callable:
+    """Retry function decorator.
+
+    :param retry_num: Number of retries.
+    :param retry_sleep_sec: Sleep time between retries in seconds.
+    :return: Decorated function.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            for i in range(retry_num):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exc:
+                    if i >= retry_num - 1:
+                        raise Exception(
+                            f"Exceeded {retry_num} retries"
+                        ) from exc
+                    logger.error(
+                        "func %s failure %d/%d: %s",
+                        func.__name__,
+                        i + 1,
+                        retry_num,
+                        exc,
+                    )
+                    time.sleep(retry_sleep_sec)
+
+        return wrapper
+
+    return decorator

--- a/server/charm/tests/integration/test_charm.py
+++ b/server/charm/tests/integration/test_charm.py
@@ -20,7 +20,7 @@ import jubilant
 
 from .helpers import APP_NAME, METADATA, MONGODB_CHARM, app_is_up, retry
 
-DEFAULT_HTTP_PORT = 80
+DEFAULT_HTTP_PORT = 5000
 
 
 def test_deploy(charm_path: Path, juju: jubilant.Juju):

--- a/server/charm/tests/integration/test_charm_integration.py
+++ b/server/charm/tests/integration/test_charm_integration.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for Testflinger Juju charm."""
+
+from pathlib import Path
+
+import jubilant
+import yaml
+
+METADATA = yaml.safe_load(Path("charmcraft.yaml").read_text(encoding="utf-8"))
+APP_NAME = METADATA["name"]
+MONGODB_CHARM = "mongodb-k8s"
+NGINX_INGRESS_CHARM = "nginx-ingress-integrator"
+
+
+def test_deploy(charm_path: Path, juju: jubilant.Juju):
+    """Deploy the charm under test.
+
+    Testflinger charm requires a mongodb_client relation to be established,
+    so we deploy a mongodb-k8s charm alongside it.
+    """
+    # Deploy the testflinger charm
+    resources = {
+        "testflinger-image": METADATA["resources"]["testflinger-image"][
+            "upstream-source"
+        ],
+    }
+    juju.deploy(charm_path.resolve(), app=APP_NAME, resources=resources)
+
+    # Deploy the mongodb-k8s charm
+    juju.deploy(MONGODB_CHARM, channel="6/stable", trust=True)
+
+    # Establish the mongodb_client relation
+    juju.integrate(APP_NAME, MONGODB_CHARM)
+    juju.wait(jubilant.all_active)
+
+
+def test_relate_ingress(juju: jubilant.Juju):
+    """Relate the charm under test to the nginx ingress integrator."""
+    # Deploy the nginx-ingress-integrator charm
+    juju.deploy(NGINX_INGRESS_CHARM, channel="latest/stable", trust=True)
+
+    # Establish the nginx-route relation
+    juju.integrate(APP_NAME, NGINX_INGRESS_CHARM)
+    juju.wait(jubilant.all_active)

--- a/server/charm/tests/integration/test_ingress.py
+++ b/server/charm/tests/integration/test_ingress.py
@@ -82,5 +82,5 @@ def test_ingress_is_up(juju: jubilant.Juju):
         "https://",
         DNSResolverHTTPAdapter(DEFAULT_EXTERNAL_HOSTNAME, ingress_ip),
     )
-    base_url = f"http://{DEFAULT_EXTERNAL_HOSTNAME}/"
+    base_url = f"http://{DEFAULT_EXTERNAL_HOSTNAME}"
     assert app_is_up(base_url, session=session)

--- a/server/charm/tests/integration/test_ingress.py
+++ b/server/charm/tests/integration/test_ingress.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Ingress Integration tests for Testflinger Juju charm."""
+
+from pathlib import Path
+
+import jubilant
+import requests
+
+from .helpers import (
+    APP_NAME,
+    METADATA,
+    MONGODB_CHARM,
+    DNSResolverHTTPAdapter,
+    app_is_up,
+    retry,
+)
+
+NGINX_INGRESS_CHARM = "nginx-ingress-integrator"
+DEFAULT_EXTERNAL_HOSTNAME = "testflinger.local"
+INGRESS_NAME = "ingress"
+
+
+def test_deploy(charm_path: Path, juju: jubilant.Juju):
+    """Test deploying the charm under test with ingress relation."""
+    # Deploy the testflinger charm
+    resources = {
+        "testflinger-image": METADATA["resources"]["testflinger-image"][
+            "upstream-source"
+        ],
+    }
+    juju.deploy(charm_path.resolve(), app=APP_NAME, resources=resources)
+
+    # Deploy the mongodb-k8s charm
+    juju.deploy(MONGODB_CHARM, channel="6/stable", trust=True)
+
+    # Establish the mongodb_client relation
+    juju.integrate(APP_NAME, MONGODB_CHARM)
+    juju.wait(jubilant.all_active)
+
+    # Deploy the nginx-ingress-integrator charm
+    config = {"external_hostname": DEFAULT_EXTERNAL_HOSTNAME}
+    juju.deploy(
+        NGINX_INGRESS_CHARM,
+        app=INGRESS_NAME,
+        channel="latest/stable",
+        trust=True,
+        config=config,
+    )
+
+    # Establish the nginx-route relation
+    juju.integrate(APP_NAME, INGRESS_NAME)
+    juju.wait(jubilant.all_active)
+
+
+@retry(retry_num=5, retry_sleep_sec=5)
+def test_ingress_is_up(juju: jubilant.Juju):
+    """Test that the deployed application is up and responding via ingress."""
+    ingress_ip = (
+        juju.status().apps[INGRESS_NAME].units[f"{INGRESS_NAME}/0"].address
+    )
+    session = requests.Session()
+    session.mount(
+        "http://",
+        DNSResolverHTTPAdapter(DEFAULT_EXTERNAL_HOSTNAME, ingress_ip),
+    )
+    session.mount(
+        "https://",
+        DNSResolverHTTPAdapter(DEFAULT_EXTERNAL_HOSTNAME, ingress_ip),
+    )
+    base_url = f"http://{DEFAULT_EXTERNAL_HOSTNAME}/"
+    assert app_is_up(base_url, session=session)

--- a/server/charm/tests/integration/test_ingress.py
+++ b/server/charm/tests/integration/test_ingress.py
@@ -51,13 +51,11 @@ def test_deploy(charm_path: Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
     # Deploy the nginx-ingress-integrator charm
-    config = {"external_hostname": DEFAULT_EXTERNAL_HOSTNAME}
     juju.deploy(
         NGINX_INGRESS_CHARM,
         app=INGRESS_NAME,
         channel="latest/stable",
         trust=True,
-        config=config,
     )
 
     # Establish the nginx-route relation

--- a/server/charm/tests/unit/conftest.py
+++ b/server/charm/tests/unit/conftest.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Fixtures for charm unit tests."""
+
+import pytest
+from ops import testing
+
+from charm import TestflingerCharm
+
+
+@pytest.fixture
+def ctx() -> testing.Context:
+    """Fixture for Charm context."""
+    return testing.Context(TestflingerCharm)

--- a/server/charm/tests/unit/test_charm.py
+++ b/server/charm/tests/unit/test_charm.py
@@ -15,197 +15,197 @@
 #
 """Unit tests for Testflinger Juju charm."""
 
-from pathlib import Path
 from unittest.mock import Mock, patch
 
-import ops
-import ops.testing
 import pytest
+from ops import testing
 
 from charm import TESTFLINGER_ADMIN_ID, TestflingerCharm
 
-CHARMDIR = Path(__file__).parent.parent.parent.resolve()
+TESFLINGER_CONTAINER = "testflinger"
+MONGO_DB_REMOTE_DATA = {
+    "endpoints": "mongodb:27017",
+    "username": "testflinger",
+    "password": "testflinger",
+    "database": "testflinger_db",
+    "uris": "mongodb://testflinger:testflinger@mongodb:27017/testflinger_db",
+}
 
 
-@pytest.fixture(name="harness")
-def fixture_harness():
-    """Pytest fixture for getting the harness."""
-    harness = ops.testing.Harness(TestflingerCharm)
-    return harness
+@pytest.fixture
+def ctx() -> testing.Context:
+    """Fixture for Charm context."""
+    return testing.Context(TestflingerCharm)
 
 
-def test_waiting_for_relation(harness):
-    """Test that the status is set to waiting when relation is not present."""
-    harness.begin()
+def test_missing_mongodb_relation(ctx):
+    """Test the charm is waiting a mongodb_client relation."""
+    container = testing.Container(name=TESFLINGER_CONTAINER, can_connect=False)
+    state_in = testing.State(
+        containers=[container],
+        leader=True,
+    )
+
+    # Charm raises SystemExit when no relation data is present
     with pytest.raises(SystemExit):
-        assert harness.container_pebble_ready("testflinger")
-    assert isinstance(harness.model.unit.status, ops.WaitingStatus)
+        state_out = ctx.run(ctx.on.pebble_ready(container=container), state_in)
+        assert state_out.unit_status == testing.WaitingStatus(
+            "Waiting for database relation"
+        )
 
 
-def test_good_relation_active_status(harness):
-    """Status should be active when the relation is present."""
-    harness.container_pebble_ready("testflinger")
-    harness.set_can_connect("testflinger", True)
-    harness.begin()
-    rel_id = harness.add_relation("mongodb_client", "mongodb")
-    harness.update_relation_data(
-        rel_id,
-        "mongodb",
-        {
-            "port": "27017",
-            "host": "mongodb",
-            "username": "testflinger",
-            "password": "testflinger",
-            "database": "testflinger_db",
-            "endpoints": "mongodb/0",
-        },
+def test_mongodb_relation_established(ctx):
+    """Test charm is active when the mongodb_client_relation is established."""
+    container = testing.Container(name=TESFLINGER_CONTAINER, can_connect=True)
+    relation = testing.Relation(
+        endpoint="mongodb_client",
+        remote_app_name="mongodb",
+        remote_app_data=MONGO_DB_REMOTE_DATA,
     )
-    assert isinstance(harness.model.unit.status, ops.ActiveStatus)
-
-
-def test_remove_relation_waiting_status(harness):
-    """Status should be waiting when the relation is present."""
-    harness.container_pebble_ready("testflinger")
-    harness.set_can_connect("testflinger", True)
-    harness.begin()
-    rel_id = harness.add_relation("mongodb_client", "mongodb")
-    harness.update_relation_data(
-        rel_id,
-        "mongodb",
-        {
-            "port": "27017",
-            "host": "mongodb",
-            "username": "testflinger",
-            "password": "testflinger",
-            "database": "testflinger_db",
-            "endpoints": "mongodb/0",
-        },
+    state_in = testing.State(
+        containers=[container], leader=True, relations=[relation]
     )
-    assert isinstance(harness.model.unit.status, ops.ActiveStatus)
+
+    # Validate unit is Active when relation is established
+    state_out = ctx.run(ctx.on.relation_changed(relation=relation), state_in)
+    assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_mongodb_relation_removed(ctx):
+    """Test charm status is Waiting if mongodb relation removed."""
+    container = testing.Container(name=TESFLINGER_CONTAINER, can_connect=True)
+    relation = testing.Relation(
+        endpoint="mongodb_client",
+        remote_app_name="mongodb",
+        remote_app_data=MONGO_DB_REMOTE_DATA,
+    )
+    # Test that breaking the relation sets WaitingStatus
+    state_in = testing.State(
+        containers=[container], leader=True, relations=[relation]
+    )
+
+    # Charm raises SystemExit when relation is removed
     with pytest.raises(SystemExit):
-        harness.remove_relation(rel_id)
-    assert isinstance(harness.model.unit.status, ops.WaitingStatus)
+        state_out = ctx.run(
+            ctx.on.relation_broken(relation=relation), state_in
+        )
+        assert state_out.unit_status == testing.WaitingStatus(
+            "Waiting for database relation"
+        )
 
 
-def test_container_cant_connect_waiting_status(harness):
-    """Status should be waiting container can't connect."""
-    harness.container_pebble_ready("testflinger")
-    harness.set_can_connect("testflinger", False)
-    harness.begin()
-    rel_id = harness.add_relation("mongodb_client", "mongodb")
-    harness.update_relation_data(
-        rel_id,
-        "mongodb",
-        {
-            "port": "27017",
-            "host": "mongodb",
-            "username": "testflinger",
-            "password": "testflinger",
-            "database": "testflinger_db",
-            "endpoints": "mongodb/0",
-        },
+def test_waiting_status_on_container_not_ready(ctx):
+    """Status should be waiting when container is not ready."""
+    container = testing.Container(name=TESFLINGER_CONTAINER, can_connect=False)
+    relation = testing.Relation(
+        endpoint="mongodb_client",
+        remote_app_name="mongodb",
+        remote_app_data=MONGO_DB_REMOTE_DATA,
     )
-    assert isinstance(harness.model.unit.status, ops.WaitingStatus)
-
-
-def test_incomplete_relation_maintenance_status(harness):
-    """Status should be maintenance when relation data is incomplete."""
-    harness.container_pebble_ready("testflinger")
-    harness.set_can_connect("testflinger", False)
-    harness.begin()
-    rel_id = harness.add_relation("mongodb_client", "mongodb")
-    harness.update_relation_data(
-        rel_id,
-        "mongodb",
-        {
-            "port": "27017",
-            "host": "mongodb",
-        },
+    state_in = testing.State(
+        containers=[container], leader=True, relations=[relation]
     )
-    assert isinstance(harness.model.unit.status, ops.MaintenanceStatus)
+
+    # Validate unit is Waiting when container is not ready
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+    assert state_out.unit_status == testing.WaitingStatus(
+        "Waiting for Pebble in workload container"
+    )
 
 
-@patch("charm.MongoClient")
-def test_set_admin_password(mock_mongo_client, harness):
-    """Test creating a new admin user when one doesn't exist."""
-    harness.begin()
-    harness.set_leader(True)
+def test_exit_on_empty_relation_data(ctx):
+    """Test charm exits on container ready but no relation data."""
+    container = testing.Container(name=TESFLINGER_CONTAINER, can_connect=True)
+    # Set up a relation with empty data
+    relation = testing.Relation(
+        endpoint="mongodb_client",
+        remote_app_name="mongodb",
+        remote_app_data={},
+    )
+    state_in = testing.State(
+        containers=[container], leader=True, relations=[relation]
+    )
 
-    # Mock MongoDB connection
+    # Charm raises SystemExit when relation data is missing
+    with pytest.raises(SystemExit):
+        ctx.run(ctx.on.config_changed(), state_in)
+
+
+@patch.object(TestflingerCharm, "connect_to_mongodb")
+def test_set_admin_password_creates_new_user(mock_connect, ctx):
+    """Test that the admin password action creates a new admin user."""
+    # Mock MongoDB connection and collection
     mock_db = Mock()
     mock_collection = Mock()
     mock_db.client_permissions = mock_collection
     mock_collection.count_documents.return_value = 0  # No existing user
+    mock_connect.return_value = mock_db
 
-    # Setup relation data
-    rel_id = harness.add_relation("mongodb_client", "mongodb")
-    harness.update_relation_data(
-        rel_id,
-        harness.charm.app.name,
-        {
-            "database": "testflinger_db",
-            "uris": "mongodb://testflinger:testflinger@mongo:27017/testflinger_db",
-        },
+    container = testing.Container(name=TESFLINGER_CONTAINER, can_connect=True)
+    relation = testing.Relation(
+        endpoint="mongodb_client",
+        remote_app_name="mongodb",
+        remote_app_data=MONGO_DB_REMOTE_DATA,
+    )
+    state_in = testing.State(
+        containers=[container], leader=True, relations=[relation]
     )
 
-    with patch.object(
-        harness.charm, "connect_to_mongodb", return_value=mock_db
-    ):
-        # Run the action
-        action_event = Mock()
-        action_event.params = {"password": "test123"}
-        harness.charm.on_set_admin_password(action_event)
+    # Run the set-admin-password action with password parameter
+    ctx.run(
+        ctx.on.action(
+            "set-admin-password", params={"password": "test-password"}
+        ),
+        state_in,
+    )
 
-    # Verify new user was created
+    # Verify action succeeded and new user was created
+    assert ctx.action_results == {"result": "Admin user created successfully"}
     mock_collection.insert_one.assert_called_once()
+
+    # Verify user was created in mocked collection
     insert_call = mock_collection.insert_one.call_args[0][0]
     assert insert_call["client_id"] == TESTFLINGER_ADMIN_ID
     assert insert_call["role"] == "admin"
     assert "client_secret_hash" in insert_call
 
-    action_event.set_results.assert_called_once_with(
-        {"result": "Admin user created successfully"}
-    )
 
-
-@patch("charm.MongoClient")
-def test_update_admin_password(mock_mongo_client, harness):
-    """Test updating an existing admin user's password."""
-    harness.begin()
-    harness.set_leader(True)
-
-    # Mock MongoDB connection
+@patch.object(TestflingerCharm, "connect_to_mongodb")
+def test_set_admin_password_updates_existing_user(mock_connect, ctx):
+    """Test that the admin password action updates an existing admin user."""
+    # Mock MongoDB connection and collection
     mock_db = Mock()
     mock_collection = Mock()
     mock_db.client_permissions = mock_collection
-    mock_collection.count_documents.return_value = 1  # Existing user found
+    mock_collection.count_documents.return_value = 1  # Existing found
+    mock_connect.return_value = mock_db
 
-    # Setup relation data
-    rel_id = harness.add_relation("mongodb_client", "mongodb")
-    harness.update_relation_data(
-        rel_id,
-        harness.charm.app.name,
-        {
-            "database": "testflinger_db",
-            "uris": "mongodb://testflinger:testflinger@mongo:27017/testflinger_db",
-        },
+    container = testing.Container(name=TESFLINGER_CONTAINER, can_connect=True)
+    relation = testing.Relation(
+        endpoint="mongodb_client",
+        remote_app_name="mongodb",
+        remote_app_data=MONGO_DB_REMOTE_DATA,
+    )
+    state_in = testing.State(
+        containers=[container], leader=True, relations=[relation]
     )
 
-    with patch.object(
-        harness.charm, "connect_to_mongodb", return_value=mock_db
-    ):
-        # Run the action
-        action_event = Mock()
-        action_event.params = {"password": "newpass456"}
-        harness.charm.on_set_admin_password(action_event)
+    # Run the action with password parameter
+    ctx.run(
+        ctx.on.action(
+            "set-admin-password", params={"password": "new-password"}
+        ),
+        state_in,
+    )
 
-    # Verify user was updated
+    # Verify action succeeded and user was updated
+    assert ctx.action_results == {
+        "result": "Admin password updated successfully"
+    }
     mock_collection.update_one.assert_called_once()
+
+    # Verify user was updated in mocked collection
     update_call = mock_collection.update_one.call_args
     assert update_call[0][0] == {"client_id": TESTFLINGER_ADMIN_ID}
     assert "$set" in update_call[0][1]
     assert "client_secret_hash" in update_call[0][1]["$set"]
-
-    action_event.set_results.assert_called_once_with(
-        {"result": "Admin password updated successfully"}
-    )

--- a/server/charm/tests/unit/test_charm.py
+++ b/server/charm/tests/unit/test_charm.py
@@ -32,12 +32,6 @@ MONGO_DB_REMOTE_DATA = {
 }
 
 
-@pytest.fixture
-def ctx() -> testing.Context:
-    """Fixture for Charm context."""
-    return testing.Context(TestflingerCharm)
-
-
 def test_missing_mongodb_relation(ctx):
     """Test the charm is waiting a mongodb_client relation."""
     container = testing.Container(name=TESFLINGER_CONTAINER, can_connect=False)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -36,6 +36,7 @@ client_credentials_admin = "testflinger.tools.client_credentials_admin:main"
 
 [dependency-groups]
 charm = [
+    "jubilant>=1.6.2",
     "ops[testing]",
 ]
 dev = [

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -35,7 +35,9 @@ dependencies = [
 client_credentials_admin = "testflinger.tools.client_credentials_admin:main"
 
 [dependency-groups]
-charm = ["ops>=2.2.0"]
+charm = [
+    "ops[testing]",
+]
 dev = [
     "cosl>=0.0.57",
     "djlint>=1.36.4",

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -47,15 +47,36 @@ commands =
         --cov-report=xml:coverage.xml \
         {posargs:tests}
 
-[testenv:charm]
-description = Run charm tests
+[testenv:charm-unit]
+description = Run charm unit tests
 dependency_groups =
     dev
     charm
 set_env =
     PYTHONPATH = {toxinidir}/charm/src:{toxinidir}/charm/lib
 commands =
-    pytest --cov=charm/src charm/tests/unit
+    pytest -v \
+           -s \
+           --tb native \
+           --log-cli-level=INFO \
+           {posargs} \
+           --cov=charm/src charm/tests/unit
+
+[testenv:charm-integration]
+description = Run charm integration tests
+change_dir = {toxinidir}/charm
+dependency_groups =
+    dev
+    charm
+set_env =
+    PYTHONPATH = {toxinidir}/charm/src:{toxinidir}/charm/lib
+commands =
+    pytest -v \
+           -s \
+           --tb native \
+           --log-cli-level=INFO \
+           {posargs} \
+           tests/integration
 
 [testenv:schema]
 description = Generate server OpenAPI schema

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1188,6 +1188,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/97/c1e5447c3c0d86cab16cad802e1bb58613b2396b7184797af2e4484c2014/ops-3.3.1-py3-none-any.whl", hash = "sha256:38229bb1cc6d9c2aa4dff4495f3e33af928dbd1070e8c5d8b697dfb32dcd89a8", size = 191338, upload-time = "2025-10-16T01:46:20.038Z" },
 ]
 
+[package.optional-dependencies]
+testing = [
+    { name = "ops-scenario" },
+]
+
+[[package]]
+name = "ops-scenario"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ops" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/94/cf17208427d43f9136b0fb61ca75ac937b88ac66cb0a3fe126bbffbde677/ops_scenario-8.3.1.tar.gz", hash = "sha256:553cd1ee30f161edd110e217a01505a9778baf778c039d810e0cfbd6101b855b", size = 110260, upload-time = "2025-10-16T01:46:27.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/dd/da2bcb1a164c4c9c8690c689305b15c3f988166db44add5084c4dc04ad04/ops_scenario-8.3.1-py3-none-any.whl", hash = "sha256:bf8404387cd8c22cd0b45c996ca7c12e84b6c603edc8b056e85234fc3d270941", size = 64403, upload-time = "2025-10-16T01:46:22.082Z" },
+]
+
 [[package]]
 name = "packaging"
 version = "25.0"
@@ -1941,7 +1959,7 @@ dependencies = [
 
 [package.dev-dependencies]
 charm = [
-    { name = "ops" },
+    { name = "ops", extra = ["testing"] },
 ]
 dev = [
     { name = "cosl" },
@@ -1980,7 +1998,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-charm = [{ name = "ops", specifier = ">=2.2.0" }]
+charm = [{ name = "ops", extras = ["testing"] }]
 dev = [
     { name = "cosl", specifier = ">=0.0.57" },
     { name = "djlint", specifier = ">=1.36.4" },

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1039,6 +1039,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jubilant"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/7f/4b1a751930713ee585ea0a4dcf4af30d19f4af478cf7658376ca788adbf3/jubilant-1.6.2.tar.gz", hash = "sha256:d841610fd86f7d77419da8be08e6c936412e581652f55faa23c6c19536b87a8f", size = 32016, upload-time = "2025-12-17T21:20:04.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/13/22f29f41fc6e2467f039a2d38179f59c069245090524ebc3d8aaf64d3d4b/jubilant-1.6.2-py3-none-any.whl", hash = "sha256:fa81995b64e0519fa59407beabbbc2aae097437895addcb3df54f33ab207fbfb", size = 33034, upload-time = "2025-12-17T21:20:03.265Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1959,6 +1971,7 @@ dependencies = [
 
 [package.dev-dependencies]
 charm = [
+    { name = "jubilant" },
     { name = "ops", extra = ["testing"] },
 ]
 dev = [
@@ -1998,7 +2011,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-charm = [{ name = "ops", extras = ["testing"] }]
+charm = [
+    { name = "jubilant", specifier = ">=1.6.2" },
+    { name = "ops", extras = ["testing"] },
+]
 dev = [
     { name = "cosl", specifier = ">=0.0.57" },
     { name = "djlint", specifier = ">=1.36.4" },


### PR DESCRIPTION
## Description
This PR updates server unit tests to use ops.testing instead of `Harness`. 
A 1:1 test was added to replace the old framework with the new framework. 

Additionally, integration tests were added on server side as those were missing, for now added testing deploy along with testing the ingress relation. 

Server Integration and Unit tests were split in separate jobs to make it easier to spot errors via CI

Note: For setup simplicity, I'm using single Juju controller (k8s) if we were to replicate production as close as possible, we would need to review on a cross controller testing. For now, I think its more than enough a K8s MongoDb instance instead of a Machine one. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-818](https://warthogs.atlassian.net/browse/CERTTF-818)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Harness unit tests were replaced with ops.testing
Integration tests included for server
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-818]: https://warthogs.atlassian.net/browse/CERTTF-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ