### PR TITLE
Fix: Update code and tests to use HTTPStatus enumerations throughout instead of magic numeric constants

### DIFF
--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -87,7 +87,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
         )
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         with patch("shutil.rmtree"):
             agent.process_jobs()
         setuplog = open(
@@ -110,7 +110,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
         )
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         with patch("shutil.rmtree"):
             agent.process_jobs()
         provisionlog = open(
@@ -135,7 +135,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(fake_job_data)}, {"text": "{}"}],
         )
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         with patch("shutil.rmtree"):
             agent.process_jobs()
         testlog = open(
@@ -169,7 +169,7 @@ class TestClient:
         }
 
         with rmock.Mocker() as mocker:
-            mocker.post(rmock.ANY, status_code=200)
+            mocker.post(rmock.ANY, status_code=HTTPStatus.OK)
             # mock response to requesting jobs
             mocker.get(f"{agent.client.server}/v1", status_code=HTTPStatus.OK)
             mocker.get(
@@ -206,6 +206,7 @@ class TestClient:
             attachment = basepath / ATTACHMENTS_DIR / archive_name
             assert attachment.exists()
 
+
     def test_attachments_insecure_no_phase(self, agent, tmp_path):
         # create file to be used as attachment
         attachment = tmp_path / "random.bin"
@@ -233,7 +234,7 @@ class TestClient:
         }
 
         with rmock.Mocker() as mocker:
-            mocker.post(rmock.ANY, status_code=200)
+            mocker.post(rmock.ANY, status_code=HTTPStatus.OK)
             # mock response to requesting jobs
             mocker.get(f"{agent.client.server}/v1", status_code=HTTPStatus.OK)
             mocker.get(
@@ -296,7 +297,7 @@ class TestClient:
         }
 
         with rmock.Mocker() as mocker:
-            mocker.post(rmock.ANY, status_code=200)
+            mocker.post(rmock.ANY, status_code=HTTPStatus.OK)
             # mock response to requesting jobs
             mocker.get(f"{agent.client.server}/v1", status_code=HTTPStatus.OK)
             mocker.get(
@@ -347,7 +348,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
         )
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         with patch("shutil.rmtree"):
             agent.process_jobs()
         testlog = open(
@@ -373,7 +374,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
         )
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         with patch("shutil.rmtree"), patch("pathlib.Path.unlink"):
             agent.process_jobs()
         outcome_file = os.path.join(
@@ -405,7 +406,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job?queue=test",
             [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
         )
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         with patch("shutil.rmtree"), patch("pathlib.Path.unlink"):
             agent.process_jobs()
         outcome_file = os.path.join(
@@ -437,7 +438,7 @@ class TestClient:
             f"http://127.0.0.1:8000/v1/agents/data/{self.config['agent_id']}",
             json={"state": AgentState.WAITING, "restricted_to": {}},
         )
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         with patch.object(
             testflinger_agent.client.TestflingerClient, "transmit_job_outcome"
         ) as mock_transmit_job_outcome:
@@ -538,7 +539,7 @@ class TestClient:
             json={"state": AgentState.WAITING, "restricted_to": {}},
         )
         status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
-        requests_mock.post(status_url, status_code=200)
+        requests_mock.post(status_url, status_code=HTTPStatus.OK)
         with patch("shutil.rmtree"):
             agent.process_jobs()
 
@@ -579,7 +580,7 @@ class TestClient:
             json={"state": AgentState.WAITING, "restricted_to": {}},
         )
         status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
-        requests_mock.post(status_url, status_code=200)
+        requests_mock.post(status_url, status_code=HTTPStatus.OK)
 
         requests_mock.get(
             "http://127.0.0.1:8000/v1/result/" + job_id,
@@ -620,7 +621,7 @@ class TestClient:
             json={"state": AgentState.WAITING, "restricted_to": {}},
         )
         status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
-        requests_mock.post(status_url, status_code=200)
+        requests_mock.post(status_url, status_code=HTTPStatus.OK)
 
         with patch("shutil.rmtree"):
             agent.process_jobs()
@@ -657,7 +658,7 @@ class TestClient:
             json={"state": AgentState.WAITING, "restricted_to": {}},
         )
         status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
-        requests_mock.post(status_url, status_code=200)
+        requests_mock.post(status_url, status_code=HTTPStatus.OK)
 
         with patch("shutil.rmtree"):
             agent.process_jobs()
@@ -747,7 +748,7 @@ class TestClient:
             json={"state": AgentState.WAITING, "restricted_to": {}},
         )
         status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
-        requests_mock.post(status_url, status_code=200)
+        requests_mock.post(status_url, status_code=HTTPStatus.OK)
 
         provision_exception_info = {
             "provision_exception_info": {
@@ -820,7 +821,7 @@ class TestClient:
             json={"state": AgentState.WAITING, "restricted_to": {}},
         )
         status_url = f"http://127.0.0.1:8000/v1/job/{job_id}/events"
-        requests_mock.post(status_url, status_code=200)
+        requests_mock.post(status_url, status_code=HTTPStatus.OK)
 
         provision_exception_info = {
             "provision_exception_info": {
@@ -973,7 +974,7 @@ class TestClient:
             f"http://127.0.0.1:8000/v1/agents/data/{self.config['agent_id']}",
             status_code=HTTPStatus.NOT_FOUND,
         )
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         with patch("shutil.rmtree"):
             agent.process_jobs()
         assert "Failed to retrieve agent data" in caplog.text

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -206,7 +206,6 @@ class TestClient:
             attachment = basepath / ATTACHMENTS_DIR / archive_name
             assert attachment.exists()
 
-
     def test_attachments_insecure_no_phase(self, agent, tmp_path):
         # create file to be used as attachment
         attachment = tmp_path / "random.bin"

--- a/agent/tests/test_client.py
+++ b/agent/tests/test_client.py
@@ -144,7 +144,8 @@ class TestClient:
         testflinger_outcome_json = tmp_path / "testflinger-outcome.json"
         testflinger_outcome_json.write_text("{}")
         requests_mock.post(
-            f"http://127.0.0.1:8000/v1/result/{job_id}", status_code=200
+            f"http://127.0.0.1:8000/v1/result/{job_id}",
+            status_code=HTTPStatus.OK,
         )
         client.transmit_job_outcome(tmp_path)
         assert requests_mock.last_request.json() == {"job_state": "complete"}
@@ -227,7 +228,7 @@ class TestClient:
         testflinger_json.write_text(json.dumps(testflinger_data))
         requests_mock.post(
             f"http://127.0.0.1:8000/v1/result/{job_id}/artifact",
-            status_code=200,
+            status_code=HTTPStatus.OK,
         )
         client.transmit_job_outcome(tmp_path)
         assert requests_mock.called

--- a/agent/tests/test_job.py
+++ b/agent/tests/test_job.py
@@ -134,7 +134,7 @@ class TestJob:
         self.config["provision_command"] = (
             "bash -c 'sleep 12 && echo complete'"
         )
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         job = _TestflingerJob(fake_job_data, client)
         job.phase = "provision"
 
@@ -162,8 +162,8 @@ class TestJob:
             outcome_file.write("{}")
 
         self.config["setup_command"] = "fake_setup_command"
-        requests_mock.post(rmock.ANY, status_code=200)
-        requests_mock.get(rmock.ANY, json={}, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
+        requests_mock.get(rmock.ANY, json={}, status_code=HTTPStatus.OK)
         job = _TestflingerJob({}, client)
         job.phase = "setup"
         # Don't raise the exception on the 3 banner lines
@@ -225,8 +225,8 @@ class TestJob:
             "job_id": job_id,
         }
 
-        post_mock = requests_mock.post(rmock.ANY, status_code=200)
-        requests_mock.get(rmock.ANY, status_code=200)
+        post_mock = requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
+        requests_mock.get(rmock.ANY, status_code=HTTPStatus.OK)
         job = _TestflingerJob(fake_job_data, client)
         job.run_test_phase("reserve", tmp_path)
 
@@ -407,8 +407,8 @@ class TestJob:
             return log.read()
 
     def test_run_test_phase_secret(self, client, tmp_path, requests_mock):
-        requests_mock.post(rmock.ANY, status_code=200)
-        requests_mock.get(rmock.ANY, json={}, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
+        requests_mock.get(rmock.ANY, json={}, status_code=HTTPStatus.OK)
 
         # create the job data
         job_data = {
@@ -455,7 +455,7 @@ class TestJob:
 
         job = _TestflingerJob(fake_job_data, client)
         self.config[f"{phase}_command"] = "/bin/true"
-        requests_mock.post(rmock.ANY, status_code=200)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         return_value, exit_event, exit_reason = job.run_test_phase(
             phase, tmp_path
         )

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -57,7 +57,7 @@ def test_cancel_503(requests_mock):
     jobid = str(uuid.uuid1())
     requests_mock.post(
         f"{URL}/v1/job/{jobid}/action",
-        status_code=503,
+        status_code=HTTPStatus.SERVICE_UNAVAILABLE,
     )
     sys.argv = ["", "cancel", jobid]
     tfcli = testflinger_cli.TestflingerCli()
@@ -71,7 +71,7 @@ def test_cancel(requests_mock):
     jobid = str(uuid.uuid1())
     requests_mock.post(
         f"{URL}/v1/job/{jobid}/action",
-        status_code=400,
+        status_code=HTTPStatus.BAD_REQUEST,
     )
     sys.argv = ["", "cancel", jobid]
     tfcli = testflinger_cli.TestflingerCli()
@@ -180,7 +180,11 @@ def test_submit_bad_data(tmp_path, requests_mock):
     testfile = tmp_path / "test.json"
     testfile.write_text(json.dumps(fake_data))
     # return 422 and "expected error"
-    requests_mock.post(f"{URL}/v1/job", status_code=422, text="expected error")
+    requests_mock.post(
+        f"{URL}/v1/job",
+        status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        text="expected error",
+    )
     requests_mock.get(
         f"{URL}/v1/queues/fake/agents",
         json=[{"name": "fake_agent", "state": "waiting"}],

--- a/cli/tests/test_cli_auth.py
+++ b/cli/tests/test_cli_auth.py
@@ -90,7 +90,9 @@ def test_submit_token_timeout_retry(tmp_path, requests_mock, monkeypatch):
     sys.argv = ["", "submit", str(job_file)]
     tfcli = testflinger_cli.TestflingerCli()
     requests_mock.post(
-        f"{URL}/v1/job", text="Token has expired", status_code=401
+        f"{URL}/v1/job",
+        text="Token has expired",
+        status_code=HTTPStatus.UNAUTHORIZED,
     )
     requests_mock.get(
         f"{URL}/v1/queues/fake/agents",

--- a/cli/tests/test_client.py
+++ b/cli/tests/test_client.py
@@ -283,7 +283,7 @@ def test_get_logs_error_handling(requests_mock):
 
     requests_mock.get(
         f"http://testflinger/v1/result/{job_id}/log/output?start_fragment=0",
-        status_code=404,
+        status_code=HTTPStatus.NOT_FOUND,
     )
 
     client = Client("http://testflinger")

--- a/server/src/testflinger/views.py
+++ b/server/src/testflinger/views.py
@@ -78,7 +78,7 @@ def agent_detail(agent_id):
         response = make_response(
             render_template("agent_not_found.html", agent_id=agent_id)
         )
-        response.status_code = 404
+        response.status_code = HTTPStatus.NOT_FOUND
         return response
 
     restricted_queues = database.get_restricted_queues()

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -857,7 +857,9 @@ def test_agents_status_put(mongo_app, requests_mock):
     job_id = job_output.json.get("job_id")
 
     webhook = "http://mywebhook.com"
-    requests_mock.put(webhook, status_code=200, text="webhook requested")
+    requests_mock.put(
+        webhook, status_code=HTTPStatus.OK, text="webhook requested"
+    )
     status_update_data = {
         "agent_id": "agent1",
         "job_queue": "myjobqueue",


### PR DESCRIPTION
## Description

Updated all code and tests to comply with the use of HTTPStatus rather than magic numbers for HTTP status codes

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

Unit tests were ran for each component: cli, agent, server.
