### PR TITLE
fix: muxpi busy loop using wrong command

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -473,7 +473,6 @@ class DefaultDevice:
                     capture_output=True,
                     text=True,
                 )
-                logger.info("Command completed successfully: %s", cmd)
             except subprocess.CalledProcessError as e:
                 logger.error(
                     "Command failed: %s (exit code: %d)", cmd, e.returncode
@@ -507,6 +506,12 @@ class DefaultDevice:
         self.__reboot_control_host()
 
         timeout = 300
+        logger.info(
+            "Waiting for control host %s to come back online "
+            "(timeout: %d seconds)",
+            control_host,
+            timeout,
+        )
         try:
             self.wait_online(
                 self.__check_ssh_server_on_host, control_host, timeout

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -218,7 +218,7 @@ class MuxPi:
         :raises ConnectionError in case the server is not reachable.
         """
         try:
-            self._run_control("zapper --help")
+            self._run_control("zapper typecmux get")
             logger.debug("The host %s has an available RPyC server", host)
         except ProvisioningError as e:
             raise ConnectionError from e

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -121,7 +121,7 @@ class TestMuxPiRpycCheck:
         # Access the private method
         muxpi._MuxPi__check_rpyc_server_on_host("test-host")
 
-        mock_run_control.assert_called_once_with("zapper --help")
+        mock_run_control.assert_called_once_with("zapper typecmux get")
 
     def test_check_rpyc_server_on_host_raises_connection_error(self, mocker):
         """Test connection check raises ConnectionError on failure."""


### PR DESCRIPTION
## Description

A small amendment to https://github.com/canonical/testflinger/pull/837, which was using a non-rpyc command in a busy loop.

## Resolved issues

An example of control host being down, rebooted, but then provisioning fails because rpyc is *actually* not ready: https://testflinger.canonical.com/jobs/6d1528e2-271d-4365-8ebe-e540683dff49

## Documentation

N/A

## Web service API changes

Agent host only

## Tests

```
2026-01-23 15:21:51,669 rpi4b1g001 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-01-23 15:21:51,669 rpi4b1g001 INFO: DEVICE CONNECTOR: Waiting for a running SSH server on control host 10.102.241.177
2026-01-23 15:21:54,673 rpi4b1g001 INFO: DEVICE CONNECTOR: Running control host reboot script
2026-01-23 15:21:54,673 rpi4b1g001 INFO: DEVICE CONNECTOR: Executing: ssh JumpHostL1 ssh agent5 'snmpset -c private -v 2c XXX 1.3.6.1.2.1.105.1.1.1.3.0.2 i 2'
2026-01-23 15:22:01,271 rpi4b1g001 INFO: DEVICE CONNECTOR: Executing: sleep 5
2026-01-23 15:22:06,276 rpi4b1g001 INFO: DEVICE CONNECTOR: Executing: ssh JumpHostL1 ssh agent5 'snmpset -c private -v 2c XXX1.3.6.1.2.1.105.1.1.1.3.0.2 i 1'
2026-01-23 15:22:13,355 rpi4b1g001 INFO: DEVICE CONNECTOR: Waiting for control host XXX to come back online (timeout: 300 seconds)
2026-01-23 15:22:13,355 rpi4b1g001 INFO: DEVICE CONNECTOR: 0
2026-01-23 15:22:18,364 rpi4b1g001 INFO: DEVICE CONNECTOR: 1
2026-01-23 15:22:23,371 rpi4b1g001 INFO: DEVICE CONNECTOR: 2
2026-01-23 15:22:28,380 rpi4b1g001 INFO: DEVICE CONNECTOR: 3
2026-01-23 15:22:33,389 rpi4b1g001 INFO: DEVICE CONNECTOR: 4
2026-01-23 15:22:38,399 rpi4b1g001 INFO: DEVICE CONNECTOR: 5
2026-01-23 15:22:43,407 rpi4b1g001 INFO: DEVICE CONNECTOR: 6
2026-01-23 15:22:48,414 rpi4b1g001 INFO: DEVICE CONNECTOR: 7
2026-01-23 15:22:53,423 rpi4b1g001 INFO: DEVICE CONNECTOR: 8
2026-01-23 15:22:56,060 rpi4b1g001 INFO: DEVICE CONNECTOR: BEGIN provision
2026-01-23 15:22:56,060 rpi4b1g001 INFO: DEVICE CONNECTOR: Provisioning device
2026-01-23 15:22:56,061 rpi4b1g001 INFO: DEVICE CONNECTOR: Waiting for a running RPyC server on control host 10.102.241.177
2026-01-23 15:22:56,061 rpi4b1g001 INFO: DEVICE CONNECTOR: 0
2026-01-23 15:23:11,137 rpi4b1g001 INFO: DEVICE CONNECTOR: 1
2026-01-23 15:23:21,098 rpi4b1g001 INFO: DEVICE CONNECTOR: 2
2026-01-23 15:23:29,239 rpi4b1g001 INFO: DEVICE CONNECTOR: control host server is available.
```
