### PR TITLE
fix(oem_autoinstall): Raise ProvisioningError instead of RecoveryError to avoid agent going offline

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -30,7 +30,6 @@ import yaml
 
 from testflinger_device_connectors.devices import (
     ProvisioningError,
-    RecoveryError,
 )
 
 logger = logging.getLogger(__name__)
@@ -227,7 +226,7 @@ class OemAutoinstall:
             try:
                 subprocess.check_call(cmd.split(), timeout=120)
             except subprocess.SubprocessError as exc:
-                raise ProvisioningError("Error running reboot script!") from exc
+                raise ProvisioningError("Error running reboot script") from exc
 
     def check_device_booted(self):
         """Check to see if the device is booted and reachable with ssh."""

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/oem_autoinstall.py
@@ -54,17 +54,8 @@ class OemAutoinstall:
         try:
             self.copy_ssh_id()
         except subprocess.CalledProcessError:
-            try:
-                self.hardreset()
-                self.check_device_booted()
-            except RecoveryError as exc:
-                logger.error("Hardreset failed: %s", exc)
-                # Raising RecoveryError directly exists with error 46 and
-                # sets agent to Offline. This makes subsequent jobs fail.
-                # With ProvisioningError, we still exit but Agent stays online
-                raise ProvisioningError(
-                    "Recovery failed during provisioning stage"
-                ) from exc
+            self.hardreset()
+            self.check_device_booted()
 
         provision_data = self.job_data.get("provision_data", {})
         image_url = provision_data.get("url")
@@ -224,7 +215,7 @@ class OemAutoinstall:
     def hardreset(self):
         """Reboot the device.
 
-        :raises RecoveryError:
+        :raises ProvisioningError:
             If the command times out or anything else fails.
 
         .. note::
@@ -236,7 +227,7 @@ class OemAutoinstall:
             try:
                 subprocess.check_call(cmd.split(), timeout=120)
             except subprocess.SubprocessError as exc:
-                raise RecoveryError("Error running reboot script!") from exc
+                raise ProvisioningError("Error running reboot script!") from exc
 
     def check_device_booted(self):
         """Check to see if the device is booted and reachable with ssh."""

--- a/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/tests/test_oem_autoinstall.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oem_autoinstall/tests/test_oem_autoinstall.py
@@ -1,0 +1,200 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the OemAutoinstall class."""
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import yaml
+
+from testflinger_device_connectors.devices import ProvisioningError
+from testflinger_device_connectors.devices.oem_autoinstall.oem_autoinstall import (  # noqa: E501
+    OemAutoinstall,
+)
+
+
+class TestOemAutoinstall(unittest.TestCase):
+    """Test cases for OemAutoinstall device connector."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.config_data = {
+            "device_ip": "192.168.1.100",
+            "agent_name": "test-agent",
+            "reboot_script": ["snmpset -v1 -c private 1.2.3.4 1.3.6.1 i 1"],
+        }
+        self.job_data = {
+            "job_id": "test-job-123",
+            "provision_data": {
+                "url": "http://example.com/test-image.iso",
+            },
+            "test_data": {
+                "test_username": "ubuntu",
+                "test_password": "insecure",
+            },
+        }
+
+        # Create temporary files for config and job data
+        self.config_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        )
+        yaml.dump(self.config_data, self.config_file)
+        self.config_file.close()
+
+        self.job_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        )
+        json.dump(self.job_data, self.job_file)
+        self.job_file.close()
+
+        yield
+
+        # Teardown
+        Path(self.config_file.name).unlink(missing_ok=True)
+        Path(self.job_file.name).unlink(missing_ok=True)
+
+    def test_init(self):
+        """Test OemAutoinstall initialization."""
+        device = OemAutoinstall(self.config_file.name, self.job_file.name)
+
+        self.assertEqual(device.config["device_ip"], "192.168.1.100")
+        self.assertEqual(device.config["agent_name"], "test-agent")
+        self.assertEqual(
+            device.job_data["provision_data"]["url"],
+            "http://example.com/test-image.iso",
+        )
+
+    def test_get_test_data_or_default(self):
+        """Test get_test_data_or_default retrieves values correctly."""
+        device = OemAutoinstall(self.config_file.name, self.job_file.name)
+
+        # Test retrieving existing value
+        username = device.get_test_data_or_default("test_username", "default")
+        self.assertEqual(username, "ubuntu")
+
+        # Test retrieving non-existent value (returns default)
+        missing = device.get_test_data_or_default("missing_key", "default")
+        self.assertEqual(missing, "default")
+
+    def test_get_test_data_or_default_no_test_data(self):
+        """Test get_test_data_or_default when test_data is missing."""
+        job_data_no_test = {"job_id": "test", "provision_data": {}}
+        job_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        )
+        json.dump(job_data_no_test, job_file)
+        job_file.close()
+
+        device = OemAutoinstall(self.config_file.name, job_file.name)
+        value = device.get_test_data_or_default("test_username", "fallback")
+
+        self.assertEqual(value, "fallback")
+        Path(job_file.name).unlink()
+
+    @patch("subprocess.check_call")
+    def test_hardreset_success(self, mock_check_call):
+        """Test hardreset executes reboot script successfully."""
+        device = OemAutoinstall(self.config_file.name, self.job_file.name)
+
+        device.hardreset()
+
+        mock_check_call.assert_called_once()
+        args = mock_check_call.call_args[0][0]
+        self.assertIn("snmpset", args)
+
+    @patch("subprocess.check_call")
+    def test_hardreset_failure_raises_provisioning_error(
+        self, mock_check_call
+    ):
+        """Test hardreset raises ProvisioningError on failure."""
+        device = OemAutoinstall(self.config_file.name, self.job_file.name)
+        mock_check_call.side_effect = subprocess.TimeoutExpired("cmd", 120)
+
+        with self.assertRaises(ProvisioningError) as ctx:
+            device.hardreset()
+
+        self.assertIn("reboot script", str(ctx.exception))
+
+    @patch("time.sleep")
+    @patch("subprocess.check_output")
+    def test_check_device_booted_success(self, mock_check_output, mock_sleep):
+        """Test check_device_booted succeeds when device comes online."""
+        device = OemAutoinstall(self.config_file.name, self.job_file.name)
+        mock_check_output.return_value = b"success"
+
+        result = device.check_device_booted()
+
+        self.assertTrue(result)
+        mock_check_output.assert_called()
+
+    @patch("subprocess.run")
+    def test_run_deploy_script_success(self, mock_run):
+        """Test run_deploy_script executes successfully."""
+        device = OemAutoinstall(self.config_file.name, self.job_file.name)
+        mock_run.return_value = Mock(returncode=0)
+
+        device.run_deploy_script("http://example.com/image.iso")
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        self.assertIn("http://example.com/image.iso", args)
+        self.assertIn("192.168.1.100", args)
+
+    @patch("subprocess.run")
+    def test_run_deploy_script_failure(self, mock_run):
+        """Test run_deploy_script raises ProvisioningError on failure."""
+        device = OemAutoinstall(self.config_file.name, self.job_file.name)
+        mock_run.return_value = Mock(returncode=1)
+
+        with self.assertRaises(ProvisioningError) as ctx:
+            device.run_deploy_script("http://example.com/image.iso")
+
+        self.assertIn("Deploy script failed", str(ctx.exception))
+
+    @patch("subprocess.check_call")
+    @patch("subprocess.check_output")
+    def test_provision_hardreset_on_ssh_failure(
+        self, mock_check_output, mock_check_call
+    ):
+        """Test provision calls hardreset when copy_ssh_id fails."""
+        device = OemAutoinstall(self.config_file.name, self.job_file.name)
+
+        # First call (copy_ssh_id) fails, subsequent calls succeed
+        mock_check_output.side_effect = [
+            subprocess.CalledProcessError(1, "cmd"),
+            b"success",  # After hardreset
+        ]
+
+        # Mock hardreset success
+        mock_check_call.return_value = None
+
+        # Mock other methods to prevent actual execution
+        with patch.object(device, "run_deploy_script"):
+            with patch.object(device, "check_device_booted"):
+                with patch.object(device, "copy_to_deploy_path"):
+                    device.provision()
+
+        # Verify hardreset was called
+        mock_check_call.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
Problem:
When DUT is not ssh-able, `oem_autoinsall` will call `reboot_script` to execute snmp commands against that DUT. When power cycler is offline, snmp commands timeout and return failure, so reboot_script returns failure, then `oem_autoinsall` raises `RecoveryError` with code 46, which causes TF agent to turn itself offline.

Next time submit to this agent will fail due to agent being offline. This requires manual intervention to set agent back online.
I think this behavior started after we introduced the offline state for agents.

Fix:
This change will raise another exception type, but still fail the provisioning. So user still gets the error and expected to recover the dut

<!--
Describe your changes here:

-->

## Resolved issues
Closes: https://warthogs.atlassian.net/browse/OEX86-927
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
na
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
na
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
1. Run agent locally and reproduce the problem by setting wrong snmp ip
2. Observer TF agent offline
3. Submit job and confirm failed
4. Set agent back online
5. (apply the fix). Submit job and confirm agent still online after snmp failed
6. Submit job again
Log output is in Resolved Issue.
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
