### PR TITLE
fix(cli): use correct endpoint url for serial logs

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -277,6 +277,7 @@ class TestflingerCli:
             "--phase",
             "-p",
             type=str,
+            choices=[phase.value for phase in TestPhase],
             help="Return logs from a specific phase",
         )
         parser.add_argument(

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -386,28 +386,17 @@ class Client:
         phase: TestPhase,
         start_fragment: int,
         start_timestamp: str,
-    ):
+    ) -> dict:
         """Get the latest output/serial output for a specified test job.
 
-        :param job_id:
-            ID for the test job
-        :param log_type
-            Enum representing normal output or serial output
-        :param phase
-            Phase to retrieve logs for
-        :param start_fragment
-            First log fragment to start from
-        :param start_timestamp
-            Timestamp to start retrieving logs from
-        :return:
-            JSON containing combined log fragments
-            and latest retrieved fragment number.
+        :param job_id: ID for the test job
+        :param log_type: Enum representing normal output or serial output
+        :param phase: Phase to retrieve logs for
+        :param start_fragment: First log fragment to start from
+        :param start_timestamp: Timestamp to start retrieving logs from
+        :return: Combined log fragments and latest fragment number.
         """
-        match log_type:
-            case LogType.STANDARD_OUTPUT:
-                endpoint = f"/v1/result/{job_id}/log/output"
-            case LogType.SERIAL_OUTPUT:
-                endpoint = f"/v1/result/{job_id}/log/serial_output"
+        endpoint = f"/v1/result/{job_id}/log/{log_type.value}"
         params = {"start_fragment": start_fragment}
         if start_timestamp is not None:
             params["start_timestamp"] = start_timestamp.isoformat()

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -910,7 +910,7 @@ def test_poll_serial_oneshot(capsys, requests_mock):
         }
     }
     requests_mock.get(
-        URL + f"/v1/result/{job_id}/log/serial_output?start_fragment=0",
+        URL + f"/v1/result/{job_id}/log/serial?start_fragment=0",
         json=mock_response,
     )
 
@@ -1010,7 +1010,7 @@ def test_poll_serial(capsys, requests_mock):
         }
     }
     requests_mock.get(
-        URL + f"/v1/result/{job_id}/log/serial_output?start_fragment=0",
+        URL + f"/v1/result/{job_id}/log/serial?start_fragment=0",
         json=mock_response,
     )
     sys.argv = ["", "poll-serial", "--oneshot", job_id]

--- a/cli/tests/test_client.py
+++ b/cli/tests/test_client.py
@@ -165,7 +165,7 @@ def test_get_logs_serial_output(requests_mock):
     }
 
     requests_mock.get(
-        f"http://testflinger/v1/result/{job_id}/log/serial_output?start_fragment=0",
+        f"http://testflinger/v1/result/{job_id}/log/serial?start_fragment=0",
         json=mock_response,
     )
 
@@ -265,7 +265,7 @@ def test_get_logs_with_all_parameters(requests_mock):
     }
 
     requests_mock.get(
-        f"http://testflinger/v1/result/{job_id}/log/serial_output?start_fragment={start_fragment}&start_timestamp={encoded_timestamp}",
+        f"http://testflinger/v1/result/{job_id}/log/serial?start_fragment={start_fragment}&start_timestamp={encoded_timestamp}",
         json=mock_response,
     )
 


### PR DESCRIPTION
## Description
This PR address the incorrect URL used for retrieving serial logs. Server endpoint is defined as a enum which is either `serial` or `output` and so CLI was failing while attempting to get logs from `.../log/serial_output`

Additionally, I added a `choices` so the phase is one of the valid enums.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
[CERRTF-825](https://warthogs.atlassian.net/browse/CERTTF-825)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
All unit tests were modified to match the correct endpoint. 

Additionally, this was tested locally and attempting to fetch a real job:
```
uv run testflinger-cli poll-serial 134a182c-d56f-4eaa-ad61-6a00598da22c --phase provision --oneshot 
,
ser2net port telnet(rfc2217),tcp,3000 device serialdev, /dev/ttyACM3, 115200n81,local [115200N81,CLOCAL,HANGUP_WHEN_DONE] (Debian GNU/Linux)
...
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
