### PR TITLE
Chore: mock HTTP request to HPE Repo

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/fw_devices/HPE/tests/test_HPE.py
+++ b/device-connectors/src/testflinger_device_connectors/fw_devices/HPE/tests/test_HPE.py
@@ -85,8 +85,12 @@ class TestHPEDevice(unittest.TestCase):
             mock1.return_value = None
             mock2.return_value = None
             device = HPEDevice("", "", "127.0.0.1", "", "")
-        with patch(f"{HPEDevice_path}.run_cmd") as mock1:
+        with (
+            patch(f"{HPEDevice_path}.run_cmd") as mock1,
+            patch(f"{HPEDevice_path}._get_hpe_fw_repo") as mock2,
+        ):
             mock1.side_effect = self.mock_run_cmd
+            mock2.side_effect = None
             device.get_fw_info()
 
         for member in json.loads(HPE_data.RAWGET_FIRMWARE_INVENTORY)[


### PR DESCRIPTION
## Description
Mock `_get_hpe_fw_repo()` to prevent real HTTP requests in the unit test `test_get_fw_info()`. The mocked function has nothing to do with fetching firmware status from the DUT, but it's used for gathering a list of available firmware from the HPE repo. Any runtime downloading error would be caught and reported [here](https://github.com/canonical/testflinger/blob/main/device-connectors/src/testflinger_device_connectors/fw_devices/HPE/HPE.py#L162). 


## Resolved issues
[MM threads](https://chat.canonical.com/canonical/pl/taytiber5fgg3fabyyre5e638o)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Tested locally and confirmed that no HTTP request was made.