### PR TITLE
Change: power cycle the control host when using certain connectors

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -450,7 +450,7 @@ class DefaultDevice:
         else:
             raise TimeoutError
 
-    def __reboot_control_host(self) -> None:
+    def _reboot_control_host(self) -> None:
         control_host_reboot_script: list[str] = [
             str(cmd)
             for cmd in self.config.get("control_host_reboot_script", [])
@@ -503,7 +503,7 @@ class DefaultDevice:
             logger.debug("The control host is reachable over SSH.")
             return
 
-        self.__reboot_control_host()
+        self._reboot_control_host()
 
         timeout = 300
         logger.info(

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -22,7 +22,9 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
+import requests
 import yaml
+from typing_extensions import override
 
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.dell_oemscript import DellOemScript
@@ -40,6 +42,35 @@ class DeviceConnector(ZapperConnector):
     """Tool for provisioning baremetal with a given image."""
 
     PROVISION_METHOD = "ProvisioningKVM"
+
+    @override
+    def pre_provision_hook(self):
+        """Power off the DUT via the Zapper REST API before provisioning.
+
+        If the REST API is not available, fall back to the default
+        pre-provision hook (SSH-based control host check).
+        """
+        control_host = self.config.get("control_host", "")
+        if not control_host:
+            return super().pre_provision_hook()
+
+        try:
+            self._api_post("/api/v1/system/poweroff", timeout=10)
+            with contextlib.suppress(TimeoutError):
+                ZapperConnector.wait_online(
+                    ZapperConnector._check_rpyc_server_on_host,
+                    control_host,
+                    30,
+                )
+            self._reboot_control_host()
+            self.wait_ready(control_host)
+        except requests.RequestException:
+            logger.warning(
+                "Zapper REST API is not available on %s, "
+                "falling back to default pre-provision hook",
+                control_host,
+            )
+            super().pre_provision_hook()
 
     def _validate_base_user_data(self, encoded_user_data: str):
         """Assert `base_user_data` argument is a valid base64 encoded YAML."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -55,6 +55,7 @@ class DeviceConnector(ZapperConnector):
             return super().pre_provision_hook()
 
         try:
+            logger.info("Attempt to power cycle the control host.")
             self._api_post("/api/v1/system/poweroff", timeout=10)
             with contextlib.suppress(TimeoutError):
                 ZapperConnector.wait_online(
@@ -66,7 +67,7 @@ class DeviceConnector(ZapperConnector):
             self.wait_ready(control_host)
         except requests.RequestException:
             logger.warning(
-                "Zapper REST API is not available on %s, "
+                "The REST API is not available on %s, "
                 "falling back to default pre-provision hook",
                 control_host,
             )

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -114,7 +114,7 @@ class TestCheckSshServerOnHost:
 
 
 class TestRebootControlHost:
-    """Tests for DefaultDevice.__reboot_control_host method."""
+    """Tests for DefaultDevice._reboot_control_host method."""
 
     def test_reboot_control_host_no_script(self, mocker):
         """Test reboot returns early when no script is configured."""
@@ -122,7 +122,7 @@ class TestRebootControlHost:
         mock_subprocess = mocker.patch("subprocess.run")
         device = DefaultDevice({"device_ip": "1.1.1.1"})
 
-        device._DefaultDevice__reboot_control_host()
+        device._reboot_control_host()
 
         mock_subprocess.assert_not_called()
 
@@ -137,7 +137,7 @@ class TestRebootControlHost:
             }
         )
 
-        device._DefaultDevice__reboot_control_host()
+        device._reboot_control_host()
 
         assert mock_subprocess.call_count == 2
 
@@ -156,7 +156,7 @@ class TestRebootControlHost:
         )
 
         # Should not raise
-        device._DefaultDevice__reboot_control_host()
+        device._reboot_control_host()
 
     def test_reboot_control_host_timeout_expired(self, mocker):
         """Test reboot handles TimeoutExpired gracefully."""
@@ -171,7 +171,7 @@ class TestRebootControlHost:
         )
 
         # Should not raise
-        device._DefaultDevice__reboot_control_host()
+        device._reboot_control_host()
 
     def test_reboot_control_host_unexpected_error(self, mocker):
         """Test reboot handles unexpected exceptions gracefully."""
@@ -185,7 +185,7 @@ class TestRebootControlHost:
         )
 
         # Should not raise
-        device._DefaultDevice__reboot_control_host()
+        device._reboot_control_host()
 
 
 class TestPreProvisionHook:


### PR DESCRIPTION
## Description

When using `zapper_kvm` it's appropriate the power cycle the control host first.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

None

## Tests

Control host not updated
```
$ uv run testflinger-device-connector zapper_kvm provision -c ./local-rpi.yaml local-rpi.json
2026-02-09 14:54:47,687 rpi4b1g001 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-02-09 14:54:47,687 rpi4b1g001 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-02-09 14:54:47,687 rpi4b1g001 INFO: DEVICE CONNECTOR: POST http://192.168.68.59:8000/api/v1/system/poweroff
2026-02-09 14:54:47,696 rpi4b1g001 WARNING: DEVICE CONNECTOR: The REST API is not available on 192.168.68.59, falling back to default pre-provision hook
2026-02-09 14:54:47,696 rpi4b1g001 INFO: DEVICE CONNECTOR: Waiting for a running SSH server on control host 192.168.68.59
2026-02-09 14:54:47,701 rpi4b1g001 INFO: DEVICE CONNECTOR: Waiting for a running RPyC server on control host 192.168.68.59
```

Control host updated
```
$ uv run testflinger-device-connector zapper_kvm provision -c ./local-rpi.yaml local-rpi.json
2026-02-09 14:55:19,242 rpi4b1g001 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-02-09 14:55:19,242 rpi4b1g001 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-02-09 14:55:19,242 rpi4b1g001 INFO: DEVICE CONNECTOR: POST http://192.168.68.59:8000/api/v1/system/poweroff
2026-02-09 14:55:53,398 rpi4b1g001 INFO: DEVICE CONNECTOR: Running control host reboot script
2026-02-09 14:55:53,398 rpi4b1g001 INFO: DEVICE CONNECTOR: Executing: <reboot-cmd-1>
2026-02-09 14:55:53,400 rpi4b1g001 INFO: DEVICE CONNECTOR: Executing: <reboot-cmd-2>
2026-02-09 14:56:23,405 rpi4b1g001 INFO: DEVICE CONNECTOR: Waiting for a running RPyC server on control host 192.168.68.59
```
