### PR TITLE
breaking(agent): Add authentication for getting jobs

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/charmcraft.yaml
+++ b/agent/charms/testflinger-agent-host-charm/charmcraft.yaml
@@ -84,7 +84,15 @@ config:
       default: "https://testflinger.canonical.com"
       description: |
         The hostname of the Testflinger server to connect to. 
-        This should include the protocol (http:// or https://),
+        This should include the protocol (http:// or https://)
+    credentials-secret:
+      type: secret
+      description: |
+        The Juju secret URI containing the credentials for 
+        authenticating with Testflinger server.
+        The secret should contain the following key-value pairs:
+          - client-id: The client ID for authentication
+          - secret-key: The client secret for authentication
 
 parts:
   charm:

--- a/agent/charms/testflinger-agent-host-charm/charmcraft.yaml
+++ b/agent/charms/testflinger-agent-host-charm/charmcraft.yaml
@@ -46,6 +46,9 @@ actions:
         type: string
         description: The name of the branch or tag to pull Testflinger agent code from
 
+assumes:
+  - juju >= 3.0.0
+
 config:
   options:
     config-repo:
@@ -76,6 +79,12 @@ config:
         UserKnownHostsFile /dev/null
         LogLevel QUIET
         ConnectTimeout 30
+    testflinger-server:
+      type: string
+      default: "https://testflinger.canonical.com"
+      description: |
+        The hostname of the Testflinger server to connect to. 
+        This should include the protocol (http:// or https://),
 
 parts:
   charm:

--- a/agent/charms/testflinger-agent-host-charm/requirements.txt
+++ b/agent/charms/testflinger-agent-host-charm/requirements.txt
@@ -1,9 +1,10 @@
 pip>=26.0
 setuptools>=75.0
 urllib3>=2.6.3
-ops >= 1.4.0
+ops >= 3.5.0
 GitPython==3.1.46
 Jinja2==3.1.6
 maturin==1.8.6
 charmlibs-passwd==1.0.0
 charmlibs-apt==1.0.0
+requests>=2.32.4

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -255,7 +255,7 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
 
     def _on_secret_changed(self, event: ops.SecretChangedEvent):
         """Handle secret changed event."""
-        if event.secret.label == "testflinger-credentials":
+        if event.secret.id == self.config.get("credentials-secret"):
             logger.info("Credentials secret changed, re-authenticating")
             self._authenticate_with_server()
 
@@ -273,6 +273,27 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         self.unit.status = ops.model.BlockedStatus(message)
         return False
 
+    def _valid_secret(self) -> dict | None:
+        """Check if the secret contains the necessary fields."""
+        secret_uri = self.config.get("credentials-secret")
+        if not secret_uri:
+            logger.error("credentials-secret config not set")
+            return
+
+        try:
+            secret = self.model.get_secret(id=secret_uri)
+            content = secret.get_content(refresh=True)
+            if "client-id" not in content or "secret-key" not in content:
+                logger.error("Secret missing required fields")
+                return
+        except (ops.SecretNotFoundError, ops.ModelError):
+            logger.error(
+                "Credentials secret not found or inaccessible for the charm"
+            )
+            return
+
+        return content
+
     def _authenticate_with_server(self) -> bool:
         """Authenticate with the server if token is missing or expiring.
 
@@ -282,16 +303,8 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         if not token_update_needed():
             return True
 
-        try:
-            secret = self.model.get_secret(label="testflinger-credentials")
-            content = secret.get_content()
-        except ops.SecretNotFoundError:
-            logger.error("Credentials secret not found")
-            return self._block("Missing testflinger-credentials secret")
-
-        if "client_id" not in content or "secret_key" not in content:
-            logger.error("Secret missing required fields")
-            return self._block("Secret missing client_id or secret_key")
+        if not (content := self._valid_secret()):
+            return self._block("Invalid credentials secret")
 
         server = self.config.get("testflinger-server")
         if not server or not server.startswith("http"):
@@ -300,8 +313,8 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         logger.info("Authenticating with Testflinger server")
         if not authenticate(
             server=server,
-            client_id=content["client_id"],
-            secret_key=content["secret_key"],
+            client_id=content["client-id"],
+            secret_key=content["secret-key"],
         ):
             return self._block("Authentication with Testflinger server failed")
 
@@ -320,6 +333,7 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
             return
         copy_ssh_keys(self.config)
         self.update_tf_cmd_scripts()
+        self._authenticate_with_server()
         self.write_supervisor_service_files()
         supervisord.supervisor_update()
         supervisord.restart_agents()

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import ops
 import supervisord
+import testflinger_client
 import testflinger_source
 from charmlibs import apt, passwd
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
@@ -24,7 +25,6 @@ from defaults import (
 )
 from git import GitCommandError, Repo
 from jinja2 import Template
-import testflinger_client
 
 logger = logging.getLogger(__name__)
 

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -333,10 +333,11 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
             return
         copy_ssh_keys(self.config)
         self.update_tf_cmd_scripts()
-        self._authenticate_with_server()
         self.write_supervisor_service_files()
         supervisord.supervisor_update()
         supervisord.restart_agents()
+        if not self._authenticate_with_server():
+            return
         self.unit.status = ops.model.ActiveStatus()
 
     def install_apt_packages(self, packages: list):

--- a/agent/charms/testflinger-agent-host-charm/src/common.py
+++ b/agent/charms/testflinger-agent-host-charm/src/common.py
@@ -38,20 +38,15 @@ def copy_ssh_keys(config: dict) -> None:
     try:
         ssh_config = config.get("ssh-config", "")
         config_file = Path(SSH_CONFIG)
-        write_file(config_file, ssh_config)
-        os.chown(config_file, 1000, 1000)
-        os.chmod(config_file, 0o640)
+        write_file(config_file, ssh_config, chmod=0o640)
 
         priv_key = config.get("ssh-private-key", "")
         priv_key_file = Path(SSH_PRIVATE_KEY)
-        write_file(priv_key_file, b64decode(priv_key).decode())
-        os.chown(priv_key_file, 1000, 1000)
-        os.chmod(priv_key_file, 0o600)
+        write_file(priv_key_file, b64decode(priv_key).decode(), chmod=0o600)
 
         pub_key = config.get("ssh-public-key", "")
         pub_key_file = Path(SSH_PUBLIC_KEY)
         write_file(pub_key_file, b64decode(pub_key).decode())
-        os.chown(pub_key_file, 1000, 1000)
     except (TypeError, UnicodeDecodeError):
         logger.error(
             "Failed to decode ssh keys - ensure they are base64 encoded"
@@ -59,9 +54,19 @@ def copy_ssh_keys(config: dict) -> None:
         raise
 
 
-def write_file(location: Path, contents: str) -> None:
+def write_file(location: Path, contents: str, chmod: int = 0o644) -> None:
+    """Write contents to a file at location with specified permissions.
+
+    This also sets the owner to user/group 1000:1000 (ubuntu:ubuntu).
+
+    :param location: Path to the file to write.
+    :param contents: Contents to write to the file.
+    :param chmod: File permission to set on the file.
+    """
     with open(location, "w", encoding="utf-8", errors="ignore") as out:
         out.write(contents)
+    os.chown(location, 1000, 1000)
+    os.chmod(location, chmod)
 
 
 def update_charm_scripts(config: dict) -> None:

--- a/agent/charms/testflinger-agent-host-charm/src/defaults.py
+++ b/agent/charms/testflinger-agent-host-charm/src/defaults.py
@@ -6,4 +6,4 @@ DEFAULT_TESTFLINGER_REPO = "https://github.com/canonical/testflinger.git"
 DEFAULT_BRANCH = "main"
 LOCAL_TESTFLINGER_PATH = "/srv/testflinger"
 VIRTUAL_ENV_PATH = "/srv/testflinger-venv"
-DEFAULT_TOKEN_PATH = "/var/lib/testflinger-agent/refresh_token" #noqa S105
+DEFAULT_TOKEN_PATH = "/var/lib/testflinger-agent/refresh_token"  # noqa S105

--- a/agent/charms/testflinger-agent-host-charm/src/defaults.py
+++ b/agent/charms/testflinger-agent-host-charm/src/defaults.py
@@ -6,3 +6,4 @@ DEFAULT_TESTFLINGER_REPO = "https://github.com/canonical/testflinger.git"
 DEFAULT_BRANCH = "main"
 LOCAL_TESTFLINGER_PATH = "/srv/testflinger"
 VIRTUAL_ENV_PATH = "/srv/testflinger-venv"
+DEFAULT_TOKEN_PATH = "/var/lib/testflinger-agent/refresh_token" #noqa S105

--- a/agent/charms/testflinger-agent-host-charm/src/testflinger_client.py
+++ b/agent/charms/testflinger-agent-host-charm/src/testflinger_client.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Canonical
+# See LICENSE file for licensing details.
+import base64
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+from pathlib import Path
+
+import requests
+from common import write_file
+from defaults import DEFAULT_TOKEN_PATH
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 15
+REFRESH_TOKEN_LIFETIME_DAYS = 30
+
+
+def post_request(
+    uri: str, headers: dict, timeout: int = DEFAULT_TIMEOUT
+) -> dict:
+    """Send a POST request to the specified URI with given headers.
+
+    :param uri: The target URI for the POST request.
+    :param headers: A dictionary of headers to include in the request.
+    :return: The response object from the POST request.
+    """
+    try:
+        response = requests.post(uri, headers=headers, timeout=timeout)
+    except requests.exceptions.ConnectTimeout:
+        logger.error("Connection to Testflinger server timed out.")
+    except requests.exceptions.ConnectionError:
+        logger.error("Failed to connect to Testflinger server.")
+
+    if response and response.status_code == HTTPStatus.OK:
+        return response.json()
+
+    logger.error(
+        "Authentication failed with status code: %s", response.status_code
+    )
+    return None
+
+
+def authenticate(server: str, client_id: str, secret_key: str) -> bool:
+    """Authenticate the Testflinger client using provided credentials.
+
+    This also stores the refresh token for persistent agents login.
+
+    :param client_id: Agent Host client id.
+    :param secret_key: Agent Host client secret.
+
+    :returns: True if authentication succeeded, False otherwise.
+    """
+    uri = f"{server}/v1/oauth2/token"
+    id_key_pair = f"{client_id}:{secret_key}"
+    encoded_id_key_pair = base64.b64encode(id_key_pair.encode("utf-8")).decode(
+        "utf-8"
+    )
+    headers = {"Authorization": f"Basic {encoded_id_key_pair}"}
+    token_request = post_request(uri, headers)
+
+    if token_request:
+        now = datetime.now(timezone.utc)
+        expires_at = now + timedelta(days=REFRESH_TOKEN_LIFETIME_DAYS)
+        token_data = {
+            "refresh_token": token_request.get("refresh_token"),
+            "obtained_at": now.isoformat(),
+            "expires_at": expires_at.isoformat(),
+        }
+        token_path = Path(DEFAULT_TOKEN_PATH)
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        write_file(token_path, json.dumps(token_data))
+        return True
+    return False
+
+
+def get_token_data() -> dict | None:
+    """Read and parse the stored token data.
+
+    :returns: Token data dict or None if file doesn't exist or is invalid.
+    """
+    token_path = Path(DEFAULT_TOKEN_PATH)
+    if not token_path.exists():
+        return None
+    try:
+        return json.loads(token_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.error("Failed to read token file: %s", exc)
+        return None
+
+
+def token_update_needed(days_threshold: int = 7) -> bool:
+    """Check if the refresh token is expiring within the threshold.
+
+    By default, refresh tokens expire after 30 days on server side.
+
+    :param days_threshold: Number of days before expiration to trigger refresh.
+    :returns: True if token is missing, invalid, or expiring soon.
+    """
+    token_data = get_token_data()
+    if not token_data:
+        return True
+
+    try:
+        expires_at = datetime.fromisoformat(token_data["expires_at"])
+        threshold = datetime.now(timezone.utc) + timedelta(days=days_threshold)
+        return expires_at <= threshold
+    except (KeyError, ValueError) as exc:
+        logger.error("Invalid token data: %s", exc)
+        return True

--- a/agent/charms/testflinger-agent-host-charm/src/testflinger_client.py
+++ b/agent/charms/testflinger-agent-host-charm/src/testflinger_client.py
@@ -37,6 +37,7 @@ def post_request(
         return None
 
     if response.status_code == HTTPStatus.OK:
+        logger.info("Successfully authenticated with Testflinger server.")
         return response.json()
 
     logger.error(

--- a/agent/charms/testflinger-agent-host-charm/tests/integration/conftest.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 import jubilant
@@ -16,15 +16,12 @@ logger = logging.getLogger(__name__)
 def create_mock_token(juju: jubilant.Juju, app_name: str):
     """Create a mock token file so authentication is skipped.
 
-    This creates a valid token file with an expiration date 30 days in the
-    future.
+    This creates a valid token file with a recent obtained_at timestamp.
     """
-    now = datetime.now(timezone.utc)
-    expires_at = now + timedelta(days=30)
     token_data = json.dumps(
         {
             "refresh_token": "mock-token",
-            "expires_at": expires_at.isoformat(),
+            "obtained_at": datetime.now(timezone.utc).isoformat(),
         }
     )
     token_dir = str(Path(DEFAULT_TOKEN_PATH).parent)

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/conftest.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/conftest.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Canonical
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+from collections.abc import Callable
+
+import pytest
+from charm import TestflingerAgentHostCharm
+from ops import testing
+
+
+@pytest.fixture
+def ctx() -> testing.Context:
+    """Fixture to create a testing context for the charm."""
+    return testing.Context(TestflingerAgentHostCharm)
+
+
+@pytest.fixture
+def secret() -> testing.Secret:
+    """Fixture to create a testing secret with valid credentials."""
+    return testing.Secret(
+        tracked_content={"client-id": "test-id", "secret-key": "test-key"},
+    )
+
+
+@pytest.fixture
+def state_in() -> Callable[..., testing.State]:
+    """Create a testing state with configurable config and secrets."""
+
+    def _state_in(
+        *, config: dict | None = None, secrets: list | None = None
+    ) -> testing.State:
+        default_config = {
+            "config-repo": "some-repo",
+            "config-dir": "agent-configs",
+        }
+        if config:
+            default_config.update(config)
+        return testing.State(config=default_config, secrets=secrets or [])
+
+    return _state_in

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -70,3 +70,148 @@ def test_update_tf_cmd_scripts_on_config_changed(
     ctx.run(ctx.on.config_changed(), state=state_in)
 
     mock_update_scripts.assert_called_once()
+
+
+def test_blocked_on_no_valid_server(ctx):
+    """Test blocked status when server is not set."""
+    secret = testing.Secret(
+        tracked_content={"client_id": "test-id", "secret_key": "test-key"},
+        label="testflinger-credentials",
+    )
+    state_in = testing.State(
+        config={
+            "config-repo": "some-repo",
+            "config-dir": "agent-configs",
+            "testflinger-server": "localhost:5000",
+        },
+        secrets=[secret],
+    )
+    state_out = ctx.run(ctx.on.start(), state=state_in)
+    assert state_out.unit_status == testing.BlockedStatus(
+        "Testflinger server config not set or invalid"
+    )
+
+
+def test_blocked_on_no_secret(ctx):
+    """Test blocked status when secret is not set."""
+    state_in = testing.State(
+        config={"config-repo": "some-repo", "config-dir": "agent-configs"}
+    )
+
+    state_out = ctx.run(ctx.on.start(), state=state_in)
+    assert state_out.unit_status == testing.BlockedStatus(
+        "Missing testflinger-credentials secret"
+    )
+
+
+def test_blocked_on_secret_missing_fields(ctx):
+    """Test blocked status when secret is missing required fields."""
+    secret = testing.Secret(
+        tracked_content={"client_id": "test-id"},
+        label="testflinger-credentials",
+    )
+    state_in = testing.State(
+        config={
+            "config-repo": "some-repo",
+            "config-dir": "agent-configs",
+        },
+        secrets=[secret],
+    )
+
+    state_out = ctx.run(ctx.on.start(), state=state_in)
+    assert state_out.unit_status == testing.BlockedStatus(
+        "Secret missing client_id or secret_key"
+    )
+
+
+def test_blocked_on_secret_incorrect_fields(ctx):
+    """Test blocked status when secret has incorrect fields."""
+    secret = testing.Secret(
+        tracked_content={"client": "test-id", "secret": "test-secret"},
+        label="testflinger-credentials",
+    )
+    state_in = testing.State(
+        config={
+            "config-repo": "some-repo",
+            "config-dir": "agent-configs",
+        },
+        secrets=[secret],
+    )
+
+    state_out = ctx.run(ctx.on.start(), state=state_in)
+    assert state_out.unit_status == testing.BlockedStatus(
+        "Secret missing client_id or secret_key"
+    )
+
+
+@patch("charm.authenticate", return_value=False)
+def test_blocked_on_authentication_failure(mock_authenticate, ctx):
+    """Test blocked status when authentication fails."""
+    secret = testing.Secret(
+        tracked_content={"client_id": "test-id", "secret_key": "test-key"},
+        label="testflinger-credentials",
+    )
+    state_in = testing.State(
+        config={
+            "config-repo": "some-repo",
+            "config-dir": "agent-configs",
+        },
+        secrets=[secret],
+    )
+    state_out = ctx.run(ctx.on.start(), state=state_in)
+    assert state_out.unit_status == testing.BlockedStatus(
+        "Authentication with Testflinger server failed"
+    )
+
+
+@patch("charm.authenticate", return_value=True)
+def test_active_on_successful_authentication(mock_authenticate, ctx):
+    """Test active status when authentication is successful."""
+    secret = testing.Secret(
+        tracked_content={"client_id": "test-id", "secret_key": "test-key"},
+        label="testflinger-credentials",
+    )
+    state_in = testing.State(
+        config={
+            "config-repo": "some-repo",
+            "config-dir": "agent-configs",
+        },
+        secrets=[secret],
+    )
+    state_out = ctx.run(ctx.on.start(), state=state_in)
+    assert state_out.unit_status == testing.ActiveStatus()
+
+
+@patch("charm.TestflingerAgentHostCharm._authenticate_with_server")
+def test_authentication_triggered_on_secret_change(
+    mock_authenticate_with_server, ctx
+):
+    """Test that authentication is triggered when secret changes."""
+    secret = testing.Secret(
+        tracked_content={"client_id": "test-id", "secret_key": "test-key"},
+        label="testflinger-credentials",
+    )
+    state_in = testing.State(
+        config={
+            "config-repo": "some-repo",
+            "config-dir": "agent-configs",
+        },
+        secrets=[secret],
+    )
+    ctx.run(ctx.on.secret_changed(secret), state=state_in)
+    mock_authenticate_with_server.assert_called_once()
+
+
+@patch("charm.TestflingerAgentHostCharm._authenticate_with_server")
+def test_authentication_triggered_on_update_status(
+    mock_authenticate_with_server, ctx
+):
+    """Test that authentication is triggered on update_status event."""
+    state_in = testing.State(
+        config={
+            "config-repo": "some-repo",
+            "config-dir": "agent-configs",
+        },
+    )
+    ctx.run(ctx.on.update_status(), state=state_in)
+    mock_authenticate_with_server.assert_called_once()

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -49,8 +49,8 @@ def test_update_tf_cmd_scripts_on_config_changed(
     mock_update_scripts.assert_called_once()
 
 
-def test_blocked_on_no_valid_server(ctx, state_in, secret):
-    """Test blocked status when server is not set."""
+def test_blocked_on_invalid_server(ctx, state_in, secret):
+    """Test blocked status when server is not valid."""
     state = state_in(
         config={
             "testflinger-server": "localhost:5000",
@@ -108,7 +108,7 @@ def test_blocked_on_secret_incorrect_fields(ctx, state_in, caplog):
     assert "Secret missing required fields" in caplog.text
 
 
-@patch("charm.authenticate", return_value=False)
+@patch("testflinger_client.authenticate", return_value=False)
 def test_start_blocked_on_authentication_failure(
     mock_authenticate, ctx, state_in, secret
 ):
@@ -122,7 +122,7 @@ def test_start_blocked_on_authentication_failure(
     )
 
 
-@patch("charm.authenticate", return_value=True)
+@patch("testflinger_client.authenticate", return_value=True)
 def test_start_active_on_successful_authentication(
     mock_authenticate, ctx, state_in, secret
 ):
@@ -135,7 +135,7 @@ def test_start_active_on_successful_authentication(
     assert state_out.unit_status == testing.ActiveStatus()
 
 
-@patch("charm.authenticate", return_value=False)
+@patch("testflinger_client.authenticate", return_value=False)
 @patch("charm.supervisord.restart_agents")
 @patch("charm.supervisord.supervisor_update")
 @patch("charm.TestflingerAgentHostCharm.write_supervisor_service_files")

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -6,39 +6,22 @@
 
 from unittest.mock import patch
 
-import pytest
-from charm import TestflingerAgentHostCharm
 from ops import testing
 
 
-@pytest.fixture
-def ctx() -> testing.Context:
-    return testing.Context(TestflingerAgentHostCharm)
-
-
-def test_blocked_on_no_config_repo(ctx):
+def test_blocked_on_no_config_repo(ctx, state_in):
     """Test blocked status when config-repo is not set."""
-    state_in = testing.State(
-        config={
-            "config-repo": "",
-            "config-dir": "agent-configs",
-        }
-    )
-    state_out = ctx.run(ctx.on.config_changed(), state=state_in)
+    state = state_in(config={"config-repo": ""})
+    state_out = ctx.run(ctx.on.config_changed(), state=state)
     assert state_out.unit_status == testing.BlockedStatus(
         "config-repo and config-dir must be set"
     )
 
 
-def test_blocked_on_no_config_dir(ctx):
+def test_blocked_on_no_config_dir(ctx, state_in):
     """Test blocked status when config-dir is not set."""
-    state_in = testing.State(
-        config={
-            "config-repo": "some-repo",
-            "config-dir": "",
-        }
-    )
-    state_out = ctx.run(ctx.on.config_changed(), state=state_in)
+    state = state_in(config={"config-dir": ""})
+    state_out = ctx.run(ctx.on.config_changed(), state=state)
     assert state_out.unit_status == testing.BlockedStatus(
         "config-repo and config-dir must be set"
     )
@@ -58,89 +41,67 @@ def test_update_tf_cmd_scripts_on_config_changed(
     mock_copy_ssh,
     mock_update_scripts,
     ctx,
+    state_in,
 ):
     """Test update_tf_cmd_scripts is called during config_changed."""
-    state_in = testing.State(
-        config={
-            "config-repo": "some-repo",
-            "config-dir": "agent-configs",
-        }
-    )
-
-    ctx.run(ctx.on.config_changed(), state=state_in)
+    ctx.run(ctx.on.config_changed(), state=state_in())
 
     mock_update_scripts.assert_called_once()
 
 
-def test_blocked_on_no_valid_server(ctx):
+def test_blocked_on_no_valid_server(ctx, state_in, secret):
     """Test blocked status when server is not set."""
-    secret = testing.Secret(
-        tracked_content={"client_id": "test-id", "secret_key": "test-key"},
-    )
-    state_in = testing.State(
+    state = state_in(
         config={
-            "config-repo": "some-repo",
-            "config-dir": "agent-configs",
             "testflinger-server": "localhost:5000",
             "credentials-secret": secret.id,
         },
         secrets=[secret],
     )
-    state_out = ctx.run(ctx.on.start(), state=state_in)
+    state_out = ctx.run(ctx.on.start(), state=state)
     assert state_out.unit_status == testing.BlockedStatus(
         "Testflinger server config not set or invalid"
     )
 
 
-def test_blocked_on_no_secret(ctx, caplog):
+def test_blocked_on_no_secret(ctx, state_in, caplog):
     """Test blocked status when credentials-secret config is not set."""
-    state_in = testing.State(
-        config={"config-repo": "some-repo", "config-dir": "agent-configs"}
-    )
-
-    state_out = ctx.run(ctx.on.start(), state=state_in)
+    state_out = ctx.run(ctx.on.start(), state=state_in())
     assert state_out.unit_status == testing.BlockedStatus(
         "Invalid credentials secret"
     )
     assert "credentials-secret config not set" in caplog.text
 
 
-def test_blocked_on_secret_missing_fields(ctx, caplog):
+def test_blocked_on_secret_missing_fields(ctx, state_in, caplog):
     """Test blocked status when secret is missing required fields."""
     secret = testing.Secret(
-        tracked_content={"client_id": "test-id"},
+        tracked_content={"client-id": "test-id"},
     )
-    state_in = testing.State(
-        config={
-            "config-repo": "some-repo",
-            "config-dir": "agent-configs",
-            "credentials-secret": secret.id,
-        },
+    state = state_in(
+        config={"credentials-secret": secret.id},
         secrets=[secret],
     )
 
-    state_out = ctx.run(ctx.on.start(), state=state_in)
+    state_out = ctx.run(ctx.on.start(), state=state)
     assert state_out.unit_status == testing.BlockedStatus(
         "Invalid credentials secret"
     )
     assert "Secret missing required fields" in caplog.text
 
 
-def test_blocked_on_secret_incorrect_fields(ctx, caplog):
+def test_blocked_on_secret_incorrect_fields(ctx, state_in, caplog):
     """Test blocked status when secret has incorrect fields."""
+    # Correct field name are "client-id" and "secret-key"
     secret = testing.Secret(
         tracked_content={"client": "test-id", "secret": "test-secret"},
     )
-    state_in = testing.State(
-        config={
-            "config-repo": "some-repo",
-            "config-dir": "agent-configs",
-            "credentials-secret": secret.id,
-        },
+    state = state_in(
+        config={"credentials-secret": secret.id},
         secrets=[secret],
     )
 
-    state_out = ctx.run(ctx.on.start(), state=state_in)
+    state_out = ctx.run(ctx.on.start(), state=state)
     assert state_out.unit_status == testing.BlockedStatus(
         "Invalid credentials secret"
     )
@@ -148,73 +109,78 @@ def test_blocked_on_secret_incorrect_fields(ctx, caplog):
 
 
 @patch("charm.authenticate", return_value=False)
-def test_blocked_on_authentication_failure(mock_authenticate, ctx):
-    """Test blocked status when authentication fails."""
-    secret = testing.Secret(
-        tracked_content={"client_id": "test-id", "secret_key": "test-key"},
-    )
-    state_in = testing.State(
-        config={
-            "config-repo": "some-repo",
-            "config-dir": "agent-configs",
-            "credentials-secret": secret.id,
-        },
+def test_start_blocked_on_authentication_failure(
+    mock_authenticate, ctx, state_in, secret
+):
+    state = state_in(
+        config={"credentials-secret": secret.id},
         secrets=[secret],
     )
-    state_out = ctx.run(ctx.on.start(), state=state_in)
+    state_out = ctx.run(ctx.on.start(), state=state)
     assert state_out.unit_status == testing.BlockedStatus(
         "Authentication with Testflinger server failed"
     )
 
 
 @patch("charm.authenticate", return_value=True)
-def test_active_on_successful_authentication(mock_authenticate, ctx):
+def test_start_active_on_successful_authentication(
+    mock_authenticate, ctx, state_in, secret
+):
     """Test active status when authentication is successful."""
-    secret = testing.Secret(
-        tracked_content={"client_id": "test-id", "secret_key": "test-key"},
-    )
-    state_in = testing.State(
-        config={
-            "config-repo": "some-repo",
-            "config-dir": "agent-configs",
-            "credentials-secret": secret.id,
-        },
+    state = state_in(
+        config={"credentials-secret": secret.id},
         secrets=[secret],
     )
-    state_out = ctx.run(ctx.on.start(), state=state_in)
+    state_out = ctx.run(ctx.on.start(), state=state)
     assert state_out.unit_status == testing.ActiveStatus()
+
+
+@patch("charm.authenticate", return_value=False)
+@patch("charm.supervisord.restart_agents")
+@patch("charm.supervisord.supervisor_update")
+@patch("charm.TestflingerAgentHostCharm.write_supervisor_service_files")
+@patch("charm.update_charm_scripts")
+@patch("charm.copy_ssh_keys")
+@patch("charm.TestflingerAgentHostCharm.update_config_files")
+def test_config_changed_blocked_on_authentication_failure(
+    mock_update_config,
+    mock_copy_ssh,
+    mock_update_scripts,
+    mock_write_supervisor,
+    mock_supervisor_update,
+    mock_restart,
+    mock_authenticate,
+    ctx,
+    state_in,
+    secret,
+):
+    state = state_in(
+        config={"credentials-secret": secret.id},
+        secrets=[secret],
+    )
+    state_out = ctx.run(ctx.on.config_changed(), state=state)
+    assert state_out.unit_status == testing.BlockedStatus(
+        "Authentication with Testflinger server failed"
+    )
 
 
 @patch("charm.TestflingerAgentHostCharm._authenticate_with_server")
 def test_authentication_triggered_on_secret_change(
-    mock_authenticate_with_server, ctx
+    mock_authenticate_with_server, ctx, state_in, secret
 ):
     """Test that authentication is triggered when secret changes."""
-    secret = testing.Secret(
-        tracked_content={"client_id": "test-id", "secret_key": "test-key"},
-    )
-    state_in = testing.State(
-        config={
-            "config-repo": "some-repo",
-            "config-dir": "agent-configs",
-            "credentials-secret": secret.id,
-        },
+    state = state_in(
+        config={"credentials-secret": secret.id},
         secrets=[secret],
     )
-    ctx.run(ctx.on.secret_changed(secret), state=state_in)
+    ctx.run(ctx.on.secret_changed(secret), state=state)
     mock_authenticate_with_server.assert_called_once()
 
 
 @patch("charm.TestflingerAgentHostCharm._authenticate_with_server")
 def test_authentication_triggered_on_update_status(
-    mock_authenticate_with_server, ctx
+    mock_authenticate_with_server, ctx, state_in
 ):
     """Test that authentication is triggered on update_status event."""
-    state_in = testing.State(
-        config={
-            "config-repo": "some-repo",
-            "config-dir": "agent-configs",
-        },
-    )
-    ctx.run(ctx.on.update_status(), state=state_in)
+    ctx.run(ctx.on.update_status(), state=state_in())
     mock_authenticate_with_server.assert_called_once()

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_common.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_common.py
@@ -27,7 +27,10 @@ def test_copy_ssh_keys(mock_write_file, mock_chmod, mock_chown):
     common.copy_ssh_keys(config)
 
     mock_write_file.assert_any_call(
-        Path(SSH_PRIVATE_KEY), "ssh_private_key_content"
+        Path("/home/ubuntu/.ssh/config"), "ssh_config_content", chmod=0o640
+    )
+    mock_write_file.assert_any_call(
+        Path(SSH_PRIVATE_KEY), "ssh_private_key_content", chmod=0o600
     )
     mock_write_file.assert_any_call(
         Path(SSH_PUBLIC_KEY), "ssh_public_key_content"

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_client.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_client.py
@@ -14,100 +14,59 @@ from defaults import DEFAULT_TOKEN_PATH
 TEST_SERVER = "http://testflinger.local"
 
 
+@patch("testflinger_client.write_file")
+@patch("testflinger_client.Path.mkdir")
 @patch("testflinger_client.requests.post")
-def test_post_request_success(mock_post):
-    """Test successful POST request returns JSON response."""
+def test_authenticate_success(mock_post, mock_mkdir, mock_write_file):
+    """Test successful authentication returns True."""
     mock_response = MagicMock()
     mock_response.status_code = HTTPStatus.OK
-    expiration = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
     mock_response.json.return_value = {
         "access_token": "token123",
         "refresh_token": "refresh123",
-        "expires_at": expiration,
     }
     mock_post.return_value = mock_response
-
-    result = testflinger_client.post_request(
-        f"{TEST_SERVER}/v1/oauth2/token", {"Authorization": "Basic abc"}
-    )
-
-    assert result == {
-        "access_token": "token123",
-        "refresh_token": "refresh123",
-        "expires_at": expiration,
-    }
-    mock_post.assert_called_once_with(
-        f"{TEST_SERVER}/v1/oauth2/token",
-        headers={"Authorization": "Basic abc"},
-        timeout=testflinger_client.DEFAULT_TIMEOUT,
-    )
-
-
-@patch("testflinger_client.requests.post")
-def test_post_request_failure(mock_post):
-    """Test failed POST request due to unauthorized status returns None."""
-    mock_response = MagicMock()
-    mock_response.status_code = HTTPStatus.UNAUTHORIZED
-    mock_post.return_value = mock_response
-
-    result = testflinger_client.post_request(
-        f"{TEST_SERVER}/v1/oauth2/token", {"Authorization": "Basic abc"}
-    )
-
-    assert result is None
-
-
-@patch("testflinger_client.requests.post")
-def test_post_request_connection_error(mock_post):
-    """Test POST request handles connection error."""
-    mock_post.side_effect = requests.exceptions.ConnectionError()
-
-    result = testflinger_client.post_request(
-        f"{TEST_SERVER}/v1/oauth2/token", {"Authorization": "Basic abc"}
-    )
-
-    assert result is None
-
-
-@patch("testflinger_client.write_file")
-@patch("testflinger_client.Path.mkdir")
-@patch("testflinger_client.post_request")
-def test_authenticate_success(mock_post_request, mock_mkdir, mock_write_file):
-    """Test successful authentication returns True."""
-    mock_post_request.return_value = {
-        "access_token": "token123",
-        "refresh_token": "refresh123",
-        "expires_at": (
-            datetime.now(timezone.utc) + timedelta(days=30)
-        ).isoformat(),
-    }
 
     result = testflinger_client.authenticate(
-        server=f"{TEST_SERVER}",
+        server=TEST_SERVER,
         client_id="test-client",
         secret_key="test-secret",  # noqa: S106
     )
 
-    assert result is not None
+    assert result is True
     mock_write_file.assert_called_once()
 
-    # Verify token data was written to the correct path
     args, _ = mock_write_file.call_args
     assert args[0] == Path(DEFAULT_TOKEN_PATH)
 
-    # Verify the content written to the refresh token file is correct
     written_data = json.loads(args[1])
     assert written_data["refresh_token"] == "refresh123"  # noqa: S105
     assert "obtained_at" in written_data
 
 
-@patch("testflinger_client.post_request")
-def test_authenticate_failure(mock_post_request):
+@patch("testflinger_client.requests.post")
+def test_authenticate_failure(mock_post):
     """Test failed authentication returns False."""
-    mock_post_request.return_value = None
+    mock_response = MagicMock()
+    mock_response.status_code = HTTPStatus.UNAUTHORIZED
+    mock_post.return_value = mock_response
 
     result = testflinger_client.authenticate(
-        server=f"{TEST_SERVER}",
+        server=TEST_SERVER,
+        client_id="test-client",
+        secret_key="test-secret",  # noqa: S106
+    )
+
+    assert result is False
+
+
+@patch("testflinger_client.requests.post")
+def test_authenticate_connection_error(mock_post):
+    """Test authentication handles connection error."""
+    mock_post.side_effect = requests.exceptions.ConnectionError()
+
+    result = testflinger_client.authenticate(
+        server=TEST_SERVER,
         client_id="test-client",
         secret_key="test-secret",  # noqa: S106
     )
@@ -157,7 +116,7 @@ def test_token_update_needed_valid_token(mock_get_token_data):
 @patch("testflinger_client.get_token_data")
 def test_token_update_needed(mock_get_token_data):
     """Test token_update_needed when token is older than 7 days."""
-    old_date = datetime.now(timezone.utc) - timedelta(days=10)
+    old_date = datetime.now(timezone.utc) - timedelta(days=7, minutes=5)
     mock_get_token_data.return_value = {
         "refresh_token": "token123",
         "obtained_at": old_date.isoformat(),
@@ -166,3 +125,17 @@ def test_token_update_needed(mock_get_token_data):
     result = testflinger_client.token_update_needed()
 
     assert result is True
+
+
+@patch("testflinger_client.get_token_data")
+def test_token_update_not_needed(mock_get_token_data):
+    """Test token_update_needed when token is older than 7 days."""
+    old_date = datetime.now(timezone.utc) - timedelta(days=6)
+    mock_get_token_data.return_value = {
+        "refresh_token": "token123",
+        "obtained_at": old_date.isoformat(),
+    }
+
+    result = testflinger_client.token_update_needed()
+
+    assert result is False

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_client.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_client.py
@@ -88,9 +88,7 @@ def test_get_token_data_success(mock_exists, mock_read_text):
     mock_exists.return_value = True
     token_data = {
         "refresh_token": "token123",
-        "expires_at": (
-            datetime.now(timezone.utc) + timedelta(days=30)
-        ).isoformat(),
+        "obtained_at": datetime.now(timezone.utc).isoformat(),
     }
     mock_read_text.return_value = json.dumps(token_data)
 
@@ -111,12 +109,10 @@ def test_token_update_needed_no_token(mock_get_token_data):
 
 @patch("testflinger_client.get_token_data")
 def test_token_update_needed_valid_token(mock_get_token_data):
-    """Test token_update_needed returns False when token is valid."""
+    """Test token_update_needed when token was recently obtained."""
     mock_get_token_data.return_value = {
         "refresh_token": "token123",
-        "expires_at": (
-            datetime.now(timezone.utc) + timedelta(days=20)
-        ).isoformat(),
+        "obtained_at": datetime.now(timezone.utc).isoformat(),
     }
 
     result = testflinger_client.token_update_needed()
@@ -125,12 +121,12 @@ def test_token_update_needed_valid_token(mock_get_token_data):
 
 
 @patch("testflinger_client.get_token_data")
-def test_token_update_needed_expired(mock_get_token_data):
-    """Test token_update_needed returns True when token is already expired."""
-    past_expiry = datetime.now(timezone.utc) - timedelta(days=5)
+def test_token_update_needed(mock_get_token_data):
+    """Test token_update_needed when token is older than 7 days."""
+    old_date = datetime.now(timezone.utc) - timedelta(days=10)
     mock_get_token_data.return_value = {
         "refresh_token": "token123",
-        "expires_at": past_expiry.isoformat(),
+        "obtained_at": old_date.isoformat(),
     }
 
     result = testflinger_client.token_update_needed()

--- a/agent/src/testflinger_agent/__init__.py
+++ b/agent/src/testflinger_agent/__init__.py
@@ -18,6 +18,7 @@ import os
 import time
 from collections import deque
 from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
 from threading import Timer
 from urllib.parse import urljoin
 
@@ -29,7 +30,6 @@ from urllib3.exceptions import HTTPError
 from testflinger_agent import schema
 from testflinger_agent.agent import TestflingerAgent
 from testflinger_agent.client import TestflingerClient
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/agent/src/testflinger_agent/__init__.py
+++ b/agent/src/testflinger_agent/__init__.py
@@ -29,6 +29,7 @@ from urllib3.exceptions import HTTPError
 from testflinger_agent import schema
 from testflinger_agent.agent import TestflingerAgent
 from testflinger_agent.client import TestflingerClient
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +122,7 @@ def start_agent():
     args = parse_args()
     config = load_config(args.config)
     config["metrics_endpoint_port"] = args.metrics_port
+    config["token_file"] = str(args.token_file)
     configure_logging(config)
     check_interval = config.get("polling_interval")
     client = TestflingerClient(config)
@@ -213,4 +215,11 @@ def parse_args():
         type=int,
         help="Port to expose metrics endpoint on",
     )
+    parser.add_argument(
+        "--token-file",
+        default="/var/lib/testflinger-agent/refresh_token",
+        type=Path,
+        help="Path to the refresh token file used for authentication",
+    )
+
     return parser.parse_args()

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -156,9 +156,7 @@ class TestflingerClient:
                 HTTPStatus.UNAUTHORIZED,
                 HTTPStatus.FORBIDDEN,
             ):
-                logger.error(
-                    "Agent not authorized to request jobs."
-                )
+                logger.error("Agent not authorized to request jobs.")
             logger.error(exc)
         except requests.exceptions.RequestException as exc:
             logger.error(exc)

--- a/agent/src/testflinger_agent/errors.py
+++ b/agent/src/testflinger_agent/errors.py
@@ -22,3 +22,6 @@ class TFServerError(Exception):
     def __str__(self):
         """Return a string with the the error message."""
         return self.message
+
+class InvalidTokenError(Exception):
+    """Base class for errors related to authentication and authorization."""

--- a/agent/src/testflinger_agent/errors.py
+++ b/agent/src/testflinger_agent/errors.py
@@ -23,5 +23,6 @@ class TFServerError(Exception):
         """Return a string with the the error message."""
         return self.message
 
+
 class InvalidTokenError(Exception):
     """Base class for errors related to authentication and authorization."""

--- a/agent/tests/test_client.py
+++ b/agent/tests/test_client.py
@@ -40,6 +40,7 @@ class TestClient:
 
     def test_check_jobs_empty(self, client, requests_mock):
         requests_mock.get(rmock.ANY, status_code=HTTPStatus.OK)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         job_data = client.check_jobs()
         assert job_data is None
 
@@ -49,6 +50,7 @@ class TestClient:
             "job_queue": "test_queue",
         }
         requests_mock.get(rmock.ANY, json=fake_job_data)
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         job_data = client.check_jobs()
         assert job_data == fake_job_data
 
@@ -70,6 +72,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job",
             json=fake_job_data,
         )
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         job_data = client.check_jobs()
         params = requests_mock.last_request.qs.get("queue")
         assert params == ["test_queue"]
@@ -90,6 +93,7 @@ class TestClient:
             "http://127.0.0.1:8000/v1/job",
             json=fake_job_data,
         )
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
         job_data = client.check_jobs()
         params = requests_mock.last_request.qs.get("queue")
         assert params == ["queue1"]

--- a/agent/tests/test_init.py
+++ b/agent/tests/test_init.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from unittest.mock import patch
+
+import testflinger_agent
+
+
+class TestAgentArgs:
+    @patch("sys.argv", ["testflinger-agent", "-c", "test.conf"])
+    def test_default_token_file(self):
+        """Test parse_args sets the default token file path."""
+        args = testflinger_agent.parse_args()
+
+        assert args.token_file == Path(
+            "/var/lib/testflinger-agent/refresh_token"
+        )
+
+    @patch(
+        "sys.argv",
+        [
+            "testflinger-agent",
+            "-c",
+            "test.conf",
+            "--token-file",
+            "/tmp/custom_token",
+        ],
+    )
+    def test_custom_token_file(self):
+        """Test parse_args accepts a custom token file path."""
+        args = testflinger_agent.parse_args()
+
+        assert args.token_file == Path("/tmp/custom_token")

--- a/agent/tests/test_status_handler.py
+++ b/agent/tests/test_status_handler.py
@@ -148,7 +148,7 @@ class TestClient:
         assert agent.status_handler.comment == ""
 
     def test_agent_offline_not_processing_jobs(
-        self, agent, requests_mock, caplog
+        self, agent, requests_mock, caplog, tmp_path
     ):
         """Test device is offline and not processing any job."""
         # Mocking retrieval of agent status as offline
@@ -177,6 +177,7 @@ class TestClient:
             # Mocking args for starting agent
             mock_args.return_value.config = "fake.yaml"
             mock_args.return_value.metrics_port = 8000
+            mock_args.return_value.token_file = f"{tmp_path}/test_token"
 
             # Make sure we terminate after first agent status check
             with pytest.raises(Exception, match="end"):
@@ -184,7 +185,7 @@ class TestClient:
         assert "Agent test01 is offline, not processing jobs" in caplog.text
 
     def test_agent_process_job_after_offline_cleared(
-        self, agent, requests_mock, caplog
+        self, agent, requests_mock, caplog, tmp_path
     ):
         """Test agent is able to process jobs after offline is cleared."""
         # Mocking retrieval of agent status as offline
@@ -213,6 +214,7 @@ class TestClient:
             # Mocking args for starting agent
             mock_args.return_value.config = "fake.yaml"
             mock_args.return_value.metrics_port = 8000
+            mock_args.return_value.token_file = f"{tmp_path}/test_token"
 
             # Make sure we terminate after processing job.
             with pytest.raises(Exception, match="end"):


### PR DESCRIPTION
## Description
This PR adds agent authentication as drafted in the [Spec](https://docs.google.com/document/d/1q5IRYd3kurs5R3yjoMSEa4xke2g4kXgHLJ1IrZDWTXM/edit?tab=t.0)

1. Agent Charm needs to read from juju secret the Testflinger credentials
2. With the credentials in place, agent charm authenticates with the server on behalf of all agents deployed inside each unit. 
3. Upon successful authentication, the agent charm will store the `refresh_token` in a file accessible by each agent process. 
4. Each agent process will read from this file and will exchange the refresh token for an authentication token that can be used to get jobs. 

> [!IMPORTANT]
> - Charm code portion is immediately breaking after upgrade to this version, charm will block until the config is set, secret application is granted access to the secret and authentication succeeds. 
> -  Agent portion is also breaking but until the server endpoint restriction is enabled. For now, it will handle 401s and 403s and can continue running even when charm is Blocked. This means that we can update agent code without necessarily upgrading charm. 

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Related to [CERTTF-786](https://warthogs.atlassian.net/browse/CERTTF-786)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
Please refer to #924 
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added charm unit and integration tests along with unit tests for agent code. 

Additionally, tested on staging:

Procedure
----

1.  Add secret to model
```
# juju add-secret staging-credentials client-id=staging-agent-charm secret-key=<sensitive value>
secret:<secret URI>
```

2.  Grant charm accesss to secret
```
# juju grant-secret staging-credentials agent-host-tor3-staging
```

3. Charm enters in blocked status
From logs:
```
unit-agent-host-tor3-staging-0: 18:48:25 ERROR unit.agent-host-tor3-staging/0.juju-log credentials-secret config not set
```

4. Set Juju config
```
# juju config agent-host-tor3-staging credentials-secret=secret:<secret URI>
```

5. Setting testflinger staging server as well:
```
# juju config agent-host-tor3-staging testflinger-server=https://testflinger-staging.canonical.com
```

6. Validate from logs:
```
unit-agent-host-tor3-staging-0: 21:04:00 INFO unit.agent-host-tor3-staging/0.juju-log Authenticating with Testflinger server
unit-agent-host-tor3-staging-0: 21:04:01 INFO unit.agent-host-tor3-staging/0.juju-log Found 3 configured agents
unit-agent-host-tor3-staging-0: 21:04:01 INFO unit.agent-host-tor3-staging/0.juju-log Agent multi-3 keeping existing port 8001
unit-agent-host-tor3-staging-0: 21:04:01 INFO unit.agent-host-tor3-staging/0.juju-log Agent audino keeping existing port 8000
```

7. From inside juju unit:
```
# ls -lh /var/lib/testflinger-agent/refresh_token 
-rw-r--r-- 1 ubuntu ubuntu 120 Feb  9 21:04 /var/lib/testflinger-agent/refresh_token
```
```
# cat /var/lib/testflinger-agent/refresh_token
{"refresh_token": "<sensitive value>", "obtained_at": "2026-02-09T21:04:01.746013+00:00"}
```

8. Update agent code
```
# juju run agent-host-tor3-staging/0 update-testflinger branch=breaking/add-agent-authentication
```

9. Check agent status
```
# sudo supervisorctl status
audino                           RUNNING   pid 873197, uptime 0:00:34
multi-3                          RUNNING   pid 873201, uptime 0:00:33
petilil                          RUNNING   pid 873198, uptime 0:00:34
```

10. Validate agent can get jobs (endpoint restriction not enabled yet on server side)
```
[26-02-09 21:12:26]    INFO: (__init__.py:147)| Checking jobs
[26-02-09 21:12:27]    INFO: (agent.py:312)| Starting job 4ce43d89-60c5-4cb1-be6f-89acca7f04d0
[26-02-09 21:12:28]    INFO: (job.py:129)| Running setup_command: tf-setup
[26-02-09 21:12:34]    INFO: (job.py:129)| Running provision_command: tf-provision
```

11. Updated server to restrict endpoint

12. Validate agent can get jobs with endpoint restriction
```
[26-02-09 22:13:10]    INFO: (__init__.py:147)| Checking jobs
[26-02-09 22:13:11]    INFO: (agent.py:312)| Starting job a9d69701-385b-4355-89b1-50ac89621751
[26-02-09 22:13:12]    INFO: (job.py:129)| Running setup_command: tf-setup
[26-02-09 22:13:18]    INFO: (job.py:129)| Running provision_command: tf-provision
```

13. Attempt to get job with curl:
```
curl https://testflinger-staging.canonical.com/v1/job?queue=audino
{"detail": {}, "message": "Authentication is required for specified endpoint"}
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-786]: https://warthogs.atlassian.net/browse/CERTTF-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ