### PR TITLE
fix: missing typing-extension dependency

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1117,6 +1117,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rpyc" },
+    { name = "typing-extensions" },
     { name = "validators" },
 ]
 
@@ -1125,6 +1126,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "rpyc", specifier = "<6" },
+    { name = "typing-extensions", specifier = "~=4.15.0" },
     { name = "validators", specifier = ">=0.34.0" },
 ]
 

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "requests>=2.32.3",
     "rpyc<6",
+    "typing-extensions~=4.15.0",
     "validators>=0.34.0",
 ]
 

--- a/device-connectors/uv.lock
+++ b/device-connectors/uv.lock
@@ -472,6 +472,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rpyc" },
+    { name = "typing-extensions" },
     { name = "validators" },
 ]
 
@@ -488,6 +489,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "rpyc", specifier = "<6" },
+    { name = "typing-extensions", specifier = "~=4.15.0" },
     { name = "validators", specifier = ">=0.34.0" },
 ]
 


### PR DESCRIPTION
## Description

As per title, dunno why we didn't catch it on CI.

## Resolved issues

```
  Traceback (most recent call last):
    File "/usr/local/bin/testflinger-device-connector", line 10, in <module>
      sys.exit(main())
    File "/usr/local/lib/python3.10/dist-packages/testflinger_device_connectors/cmd.py", line 115, in main
      get_device_stage_func(args.device, args.stage, config), args.stage
    File "/usr/local/lib/python3.10/dist-packages/testflinger_device_connectors/devices/__init__.py", line 540, in get_device_stage_func
      module = import_module(f".{device}", package=__package__)
    File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
    File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 883, in exec_module
    File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
    File "/usr/local/lib/python3.10/dist-packages/testflinger_device_connectors/devices/zapper_kvm/__init__.py", line 27, in <module>
      from typing_extensions import override
  ModuleNotFoundError: No module named 'typing_extensions'
```

## Documentation

N/A

## Web service API changes

N/A

## Tests

N/A