### PR TITLE
fix: longer timeout after power cycle

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -64,7 +64,7 @@ class DeviceConnector(ZapperConnector):
                     30,
                 )
             self._reboot_control_host()
-            self.wait_ready(control_host)
+            self.wait_ready(control_host, timeout=300)
         except requests.RequestException:
             logger.warning(
                 "The REST API is not available on %s, "

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -616,7 +616,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             30,
         )
         mock_reboot.assert_called_once()
-        mock_wait_ready.assert_called_once_with("zapper-host")
+        mock_wait_ready.assert_called_once_with("zapper-host", timeout=300)
 
     @patch(
         "testflinger_device_connectors.devices.DefaultDevice"


### PR DESCRIPTION
## Description

The default timeout was defined based on the assumption the control host was already online - just waiting for the API server. In this particular case though, we need to wait for the whole boot process + service startup. 5 minutes should be enough.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

N/A
