### PR TITLE
Removed forced retries for alloem

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -64,18 +64,10 @@ class DeviceConnector(ZapperConnector):
             url = self.job_data["provision_data"]["alloem_url"]
             username = "ubuntu"
             password = "u"
-            retries = max(
-                2, self.job_data["provision_data"].get("robot_retries", 1)
-            )
         else:
             url = self.job_data["provision_data"]["url"]
-            username = self.job_data.get("test_data", {}).get(
-                "test_username", "ubuntu"
-            )
-            password = self.job_data.get("test_data", {}).get(
-                "test_password", "ubuntu"
-            )
-            retries = self.job_data["provision_data"].get("robot_retries", 1)
+            username = self.job_data.get("test_data", {}).get("test_username", "ubuntu")
+            password = self.job_data.get("test_data", {}).get("test_password", "ubuntu")
 
         provisioning_data = {
             "url": url,
@@ -85,10 +77,8 @@ class DeviceConnector(ZapperConnector):
             "reboot_script": self.config["reboot_script"],
             "device_ip": self.config["device_ip"],
             "robot_tasks": self.job_data["provision_data"]["robot_tasks"],
-            "robot_retries": retries,
-            "cmdline_append": self.job_data["provision_data"].get(
-                "cmdline_append", ""
-            ),
+            "robot_retries": self.job_data["provision_data"].get("robot_retries", 1),
+            "cmdline_append": self.job_data["provision_data"].get("cmdline_append", ""),
             "skip_download": self.job_data["provision_data"].get(
                 "skip_download", False
             ),
@@ -109,13 +99,9 @@ class DeviceConnector(ZapperConnector):
             self._copy_ssh_id()
         except subprocess.CalledProcessError as exc:
             logger.error("Process failed with: %s", exc.output.decode())
-            raise ProvisioningError(
-                "Failed configuring SSH on the DUT."
-            ) from exc
+            raise ProvisioningError("Failed configuring SSH on the DUT.") from exc
         except subprocess.TimeoutExpired as exc:
-            raise ProvisioningError(
-                "Timed out configuring SSH on the DUT."
-            ) from exc
+            raise ProvisioningError("Timed out configuring SSH on the DUT.") from exc
 
         self._run_oem_script(args)
 
@@ -173,9 +159,7 @@ class DeviceConnector(ZapperConnector):
     def _change_password(self, username, orig_password):
         """Change password via SSH to the one specified in the job data."""
 
-        password = self.job_data.get("test_data", {}).get(
-            "test_password", "ubuntu"
-        )
+        password = self.job_data.get("test_data", {}).get("test_password", "ubuntu")
         logger.info("Changing the original password to %s", password)
 
         cmd = [


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

We were forcing a minimum of 2 retries when running 22.04 OEM just because the alloem snippet was trying to force a reset. Since we have made the process a bit more ·resilient" to work with laptop devices, we can now remove this forced retry from testflinger.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/ZAP-1408

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

The exception was not documented, and the behavior now is more general.

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->

```
uv run testflinger-device-connector zapper_kvm provision -c default-30464.yaml default-job-30464.json 
2026-02-25 17:34:56,011 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-02-25 17:34:56,011 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-02-25 17:34:56,011 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: POST http://10.102.228.186:8000/api/v1/system/poweroff
2026-02-25 17:35:06,017 hp-pro-sff-400-g9-desktop-pc-c30464 WARNING: DEVICE CONNECTOR: The REST API is not available on 10.102.228.186, falling back to default pre-provision hook
2026-02-25 17:35:06,017 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Waiting for a running SSH server on control host 10.102.228.186
2026-02-25 17:35:06,284 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Waiting for a running RPyC server on control host 10.102.228.186
2026-02-25 17:35:42,645 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: BEGIN provision
2026-02-25 17:35:42,645 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Provisioning device
^[[A2026-02-25 17:35:45,483 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Overriding selected preset at `username` with value `ubuntu`.
2026-02-25 17:35:46,386 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Overriding selected preset at `password` with value `u`.
2026-02-25 17:35:47,288 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Overriding selected preset at `preset` with value `desktop-jammy-oem`.
2026-02-25 17:35:48,505 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Arguments for KVM provisioning: {'preset': 'desktop-jammy-oem', 'username': 'ubuntu', 'password': 'ubuntu', 'agent_name': 'hp-pro-sff-400-g9-desktop-pc-c30464', 'cid': '202207-30464', 'device_ip': '10.102.148.186', 'reboot_script': ['snmpset -c private -v2c 10.102.193.129 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.8 i 0', 'sleep 30', 'snmpset -c private -v2c 10.102.193.129 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.8 i 1'], 'url': 'https://tel-image-cache.canonical.com/oem-share/somerville/Platforms/jellyfish-edge-alloem-init/dell-bto-jammy-jellyfish-edge-alloem-init-X176-20241217-20.iso', 'robot_retries': 2, 'robot_tasks': ['hp/pro/common/secure_boot/disable.robot', 'hp/bios/boot_from_usb.robot', 'hp/oem/jammy/oem_usb.robot', 'hp/boot/wait_reboot.robot'], 'job_queue': '202207-30464'}...
```