### PR TITLE
Remove retries for alloem script

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -186,9 +186,6 @@ class DeviceConnector(ZapperConnector):
             provision_data["username"], provision_data["password"] = (
                 self._get_credentials("jammy-oem")
             )
-            provision_data["robot_retries"] = max(
-                2, self.job_data["provision_data"].get("robot_retries", 1)
-            )
             provision_data["autoinstall_conf"] = (
                 self._get_autoinstall_conf()
             )
@@ -200,9 +197,6 @@ class DeviceConnector(ZapperConnector):
             provision_data["username"], provision_data["password"] = (
                 self._get_credentials()
             )
-            provision_data["robot_retries"] = self.job_data[
-                "provision_data"
-            ].get("robot_retries", 1)
             provision_data["autoinstall_conf"] = (
                 self._get_autoinstall_conf()
             )
@@ -218,6 +212,7 @@ class DeviceConnector(ZapperConnector):
             "wait_until_ssh",
             "live_image",
             "ubuntu_sso_email",
+            "robot_retries",
         ]
         provision_data.update(
             {

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -161,52 +161,52 @@ class DeviceConnector(ZapperConnector):
         """Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.
         """
-        provisioning_data = {}
+        provision_data = {}
         if "preset" in self.job_data["provision_data"]:
             has_autoinstall = False
             for key, value in self.job_data["provision_data"].items():
                 if key.startswith("autoinstall"):
                     has_autoinstall = True
                 else:
-                    provisioning_data[key] = value
+                    provision_data[key] = value
 
-            provisioning_data["username"], provisioning_data["password"] = (
+            provision_data["username"], provision_data["password"] = (
                 self._get_credentials("preset")
             )
 
             if has_autoinstall:
-                provisioning_data["autoinstall_conf"] = (
+                provision_data["autoinstall_conf"] = (
                     self._get_autoinstall_conf()
                 )
 
         elif "alloem_url" in self.job_data["provision_data"]:
-            provisioning_data["url"] = self.job_data["provision_data"][
+            provision_data["url"] = self.job_data["provision_data"][
                 "alloem_url"
             ]
-            provisioning_data["username"], provisioning_data["password"] = (
+            provision_data["username"], provision_data["password"] = (
                 self._get_credentials("jammy-oem")
             )
-            provisioning_data["robot_retries"] = max(
+            provision_data["robot_retries"] = max(
                 2, self.job_data["provision_data"].get("robot_retries", 1)
             )
-            provisioning_data["autoinstall_conf"] = (
+            provision_data["autoinstall_conf"] = (
                 self._get_autoinstall_conf()
             )
-            provisioning_data["robot_tasks"] = self.job_data["provision_data"][
+            provision_data["robot_tasks"] = self.job_data["provision_data"][
                 "robot_tasks"
             ]
         else:
-            provisioning_data["url"] = self.job_data["provision_data"]["url"]
-            provisioning_data["username"], provisioning_data["password"] = (
+            provision_data["url"] = self.job_data["provision_data"]["url"]
+            provision_data["username"], provision_data["password"] = (
                 self._get_credentials()
             )
-            provisioning_data["robot_retries"] = self.job_data[
+            provision_data["robot_retries"] = self.job_data[
                 "provision_data"
             ].get("robot_retries", 1)
-            provisioning_data["autoinstall_conf"] = (
+            provision_data["autoinstall_conf"] = (
                 self._get_autoinstall_conf()
             )
-            provisioning_data["robot_tasks"] = self.job_data["provision_data"][
+            provision_data["robot_tasks"] = self.job_data["provision_data"][
                 "robot_tasks"
             ]
 
@@ -219,7 +219,7 @@ class DeviceConnector(ZapperConnector):
             "live_image",
             "ubuntu_sso_email",
         ]
-        provisioning_data.update(
+        provision_data.update(
             {
                 opt: self.job_data["provision_data"][opt]
                 for opt in optionals
@@ -227,7 +227,7 @@ class DeviceConnector(ZapperConnector):
             }
         )
 
-        return ((), provisioning_data)
+        return ((), provision_data)
 
     def _post_run_actions(self, args):
         super()._post_run_actions(args)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -186,9 +186,7 @@ class DeviceConnector(ZapperConnector):
             provision_data["username"], provision_data["password"] = (
                 self._get_credentials("jammy-oem")
             )
-            provision_data["autoinstall_conf"] = (
-                self._get_autoinstall_conf()
-            )
+            provision_data["autoinstall_conf"] = self._get_autoinstall_conf()
             provision_data["robot_tasks"] = self.job_data["provision_data"][
                 "robot_tasks"
             ]
@@ -197,9 +195,7 @@ class DeviceConnector(ZapperConnector):
             provision_data["username"], provision_data["password"] = (
                 self._get_credentials()
             )
-            provision_data["autoinstall_conf"] = (
-                self._get_autoinstall_conf()
-            )
+            provision_data["autoinstall_conf"] = self._get_autoinstall_conf()
             provision_data["robot_tasks"] = self.job_data["provision_data"][
                 "robot_tasks"
             ]

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -63,7 +63,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "password": "ubuntu",
             "autoinstall_conf": connector._get_autoinstall_conf.return_value,
             "robot_tasks": ["job.robot", "another.robot"],
-            "robot_retries": 1,
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
@@ -135,7 +134,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                     "another.robot",
                 ],
                 "autoinstall_storage_layout": "lvm",
-                "robot_retries": 3,
+                "robot_retries": 1,
                 "cmdline_append": "more arguments",
                 "skip_download": True,
                 "wait_until_ssh": True,
@@ -157,7 +156,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "password": "password",
             "autoinstall_conf": connector._get_autoinstall_conf.return_value,
             "robot_tasks": ["job.robot", "another.robot"],
-            "robot_retries": 3,
+            "robot_retries": 1,
             "cmdline_append": "more arguments",
             "skip_download": True,
             "wait_until_ssh": True,
@@ -201,7 +200,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "password": "u",
             "autoinstall_conf": connector._get_autoinstall_conf.return_value,
             "robot_tasks": ["job.robot", "another.robot"],
-            "robot_retries": 2,
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

We were forcing a minimum of 2 retries when running 22.04 OEM just because the alloem snippet was trying to force a reset. Since we have made the process a bit more "resilient" to work with laptop devices, we can now remove this forced retry from testflinger.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/ZAP-1408

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

The exception was not documented, and the behavior now is more general.

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->

Run on a device that has 2 retries set in their scenario
`uv run testflinger-device-connector zapper_kvm provision -c default-30464.yaml default-job-30464.json `
```
2026-02-25 17:34:56,011 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-02-25 17:34:56,011 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-02-25 17:34:56,011 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: POST http://10.102.228.186:8000/api/v1/system/poweroff
2026-02-25 17:35:06,017 hp-pro-sff-400-g9-desktop-pc-c30464 WARNING: DEVICE CONNECTOR: The REST API is not available on 10.102.228.186, falling back to default pre-provision hook
2026-02-25 17:35:06,017 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Waiting for a running SSH server on control host 10.102.228.186
2026-02-25 17:35:06,284 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Waiting for a running RPyC server on control host 10.102.228.186
2026-02-25 17:35:42,645 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: BEGIN provision
2026-02-25 17:35:42,645 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Provisioning device
^[[A2026-02-25 17:35:45,483 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Overriding selected preset at `username` with value `ubuntu`.
2026-02-25 17:35:46,386 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Overriding selected preset at `password` with value `u`.
2026-02-25 17:35:47,288 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Overriding selected preset at `preset` with value `desktop-jammy-oem`.
2026-02-25 17:35:48,505 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Arguments for KVM provisioning: {'preset': 'desktop-jammy-oem', 'username': 'ubuntu', 'password': 'ubuntu', 'agent_name': 'hp-pro-sff-400-g9-desktop-pc-c30464', 'cid': '202207-30464', 'device_ip': '10.102.148.186', 'reboot_script': ['snmpset -c private -v2c 10.102.193.129 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.8 i 0', 'sleep 30', 'snmpset -c private -v2c 10.102.193.129 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.8 i 1'], 'url': 'https://tel-image-cache.canonical.com/oem-share/somerville/Platforms/jellyfish-edge-alloem-init/dell-bto-jammy-jellyfish-edge-alloem-init-X176-20241217-20.iso', 'robot_retries': 2, 'robot_tasks': ['hp/pro/common/secure_boot/disable.robot', 'hp/bios/boot_from_usb.robot', 'hp/oem/jammy/oem_usb.robot', 'hp/boot/wait_reboot.robot'], 'job_queue': '202207-30464'}...
```
 `'robot_retries': 2`


Run on a device that has 1 retry set in its scenario:
`uv run testflinger-device-connector zapper_kvm provision -c default-31232.yaml default-job-31232.json `
```
2026-02-25 17:56:08,442 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-02-25 17:56:08,442 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-02-25 17:56:08,442 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: POST http://10.102.234.215:8000/api/v1/system/poweroff
2026-02-25 17:56:09,410 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Running control host reboot script
2026-02-25 17:56:09,410 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Executing: snmpset -c private -v 2c 10.102.132.120 1.3.6.1.2.1.105.1.1.1.3.0.14 i 2
2026-02-25 17:56:15,422 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 ERROR: DEVICE CONNECTOR: Command failed: snmpset -c private -v 2c 10.102.132.120 1.3.6.1.2.1.105.1.1.1.3.0.14 i 2 (exit code: 1)
2026-02-25 17:56:15,422 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 ERROR: DEVICE CONNECTOR: stderr: Timeout: No Response from 10.102.132.120

2026-02-25 17:56:15,422 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Executing: sleep 5
2026-02-25 17:56:20,424 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Executing: snmpset -c private -v 2c 10.102.132.120 1.3.6.1.2.1.105.1.1.1.3.0.14 i 1
2026-02-25 17:56:26,436 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 ERROR: DEVICE CONNECTOR: Command failed: snmpset -c private -v 2c 10.102.132.120 1.3.6.1.2.1.105.1.1.1.3.0.14 i 1 (exit code: 1)
2026-02-25 17:56:26,436 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 ERROR: DEVICE CONNECTOR: stderr: Timeout: No Response from 10.102.132.120

2026-02-25 17:56:26,436 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Waiting for a running RPyC server on control host 10.102.234.215
2026-02-25 17:56:26,739 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Waiting for a running RPyC server on control host 10.102.234.215
2026-02-25 17:56:27,040 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: BEGIN provision
2026-02-25 17:56:27,041 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Provisioning device
2026-02-25 17:56:29,858 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Overriding selected preset at `reboot_script` with value `['zapper hid press_and_release Control_L Alt_L Delete', 'zapper hid press_and_release Escape', 'zapper hid press_and_release Alt_L Print b']`.
2026-02-25 17:56:30,762 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Overriding selected preset at `username` with value `ubuntu`.
2026-02-25 17:56:31,671 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Overriding selected preset at `password` with value `u`.
2026-02-25 17:56:32,572 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Overriding selected preset at `preset` with value `desktop-jammy`.
2026-02-25 17:56:33,781 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 INFO: DEVICE CONNECTOR: Arguments for KVM provisioning: {'preset': 'desktop-jammy', 'username': 'ubuntu', 'password': 'ubuntu', 'agent_name': 'hp-elitebook-840-14-inch-g10-notebook-pc-c31232', 'cid': '202302-31232', 'device_ip': '10.102.154.215', 'reboot_script': ['snmpset -c private -v2c 10.102.194.154 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.7 i 0', 'sleep 30', 'snmpset -c private -v2c 10.102.194.154 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.7 i 1'], 'url': 'https://tel-image-cache.canonical.com/oem-share/somerville/Platforms/jellyfish-edge-alloem-init/dell-bto-jammy-jellyfish-edge-alloem-init-X180-20250411-28.iso', 'robot_retries': 1, 'robot_tasks': ['common/camera_kvm/__init__.robot', 'hp/bios/boot_from_usb.robot', 'hp/oem/jammy/oem_usb.robot', 'common/oem/jammy/wait_reboot.robot'], 'job_queue': '202302-31232'}
2026-02-25 17:56:34,687 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 WARNING: DEVICE CONNECTOR: Provided argument `preset` is deprecated or incorrect, check the documentation.
2026-02-25 17:56:35,589 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 WARNING: DEVICE CONNECTOR: Provided argument `agent_name` is deprecated or incorrect, check the documentation.
2026-02-25 17:56:36,491 hp-elitebook-840-14-inch-g10-notebook-pc-c31232 WARNING: DEVICE CONNECTOR: Provided argument `cid` is deprecated or incorrect, check
```
`'robot_retries': 1`