### PR TITLE
breaking(server): enable restriction for /job endpoint

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 name = "testflinger"
 description = "Testflinger Server"
 readme = "README.md"
-version = "1.4.2"
+version = "1.5.0"
 authors = []
 requires-python = ">=3.10"
 dependencies = [
@@ -27,7 +27,6 @@ dependencies = [
     "testflinger-common",
     "urllib3>=2.2.1",
     "marshmallow-oneofschema==3.1.1",
-    "strenum>=0.4.15",
     "authlib>=1.6.3",
 ]
 

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -198,6 +198,8 @@ def job_builder(data: dict) -> dict:
 
 
 @v1.get("/job")
+@authenticate
+@require_role(ServerRoles.AGENT)
 @v1.output(schemas.Job)
 @v1.doc(responses=schemas.job_empty)
 def job_get():

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -17,8 +17,10 @@
 
 import os
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 
 import bcrypt
+import jwt
 import mongomock
 import pytest
 from mongomock.gridfs import enable_gridfs_integration
@@ -167,3 +169,22 @@ def sorted_roles():
         ServerRoles.MANAGER,
         ServerRoles.ADMIN,
     ]
+
+
+@pytest.fixture
+def agent_auth_header():
+    """Pytest fixture that provides an Authorization header for an agent."""
+    secret_key = "my_secret_key"  # noqa: S105
+    os.environ["JWT_SIGNING_KEY"] = secret_key
+    expiration_time = datetime.now(timezone.utc) + timedelta(seconds=30)
+    token_payload = {
+        "exp": expiration_time,
+        "iat": datetime.now(timezone.utc),
+        "sub": "access_token",
+        "permissions": {
+            "client_id": "agent-id",
+            "role": ServerRoles.AGENT,
+        },
+    }
+    token = jwt.encode(token_payload, secret_key, algorithm="HS256")
+    return {"Authorization": f"Bearer {token}"}

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -113,7 +113,7 @@ def test_add_job_valid_reserve_data(mongo_app):
     assert 200 == output.status_code
 
 
-def test_add_job_noprovision_provision_data(mongo_app):
+def test_add_job_noprovision_provision_data(mongo_app, agent_auth_header):
     """Test that a job with noprovision provision_data works."""
     app, _ = mongo_app
     # Test with blank provision_data
@@ -125,21 +125,27 @@ def test_add_job_noprovision_provision_data(mongo_app):
         "/v1/agents/data/agent1",
         json={"state": "waiting", "queues": ["test"], "location": "here"},
     )
-    recovered_data = app.get("/v1/job?queue=test").json
+    recovered_data = app.get(
+        "/v1/job?queue=test", headers=agent_auth_header
+    ).json
     assert recovered_data["provision_data"] is None
     # Test with provision_data skip=True
     provision_data = {"skip": True}
     job_data = {"job_queue": "test", "provision_data": provision_data}
     output = app.post("/v1/job", json=job_data)
     assert HTTPStatus.OK == output.status_code
-    recovered_data = app.get("/v1/job?queue=test").json
+    recovered_data = app.get(
+        "/v1/job?queue=test", headers=agent_auth_header
+    ).json
     assert recovered_data["provision_data"] == provision_data
     # Test with provision_data skip=False
     provision_data = {"skip": False}
     job_data = {"job_queue": "test", "provision_data": provision_data}
     output = app.post("/v1/job", json=job_data)
     assert HTTPStatus.OK == output.status_code
-    recovered_data = app.get("/v1/job?queue=test").json
+    recovered_data = app.get(
+        "/v1/job?queue=test", headers=agent_auth_header
+    ).json
     assert recovered_data["provision_data"] == provision_data
 
 
@@ -417,7 +423,7 @@ def test_add_job_zapper_kvm_generic_provision_data(mongo_app):
     assert HTTPStatus.OK == output.status_code
 
 
-def test_add_job_good(mongo_app):
+def test_add_job_good(mongo_app, agent_auth_header):
     """Test that adding a new job works."""
     job_data = {"job_queue": "test", "tags": ["foo", "bar"]}
     # Place a job on the queue
@@ -431,14 +437,14 @@ def test_add_job_good(mongo_app):
         json={"state": "waiting", "queues": ["test"], "location": "here"},
     )
     # Now get the job and confirm it matches
-    output = app.get("/v1/job?queue=test")
+    output = app.get("/v1/job?queue=test", headers=agent_auth_header)
     # Ensure everything we submitted is in the job_data we got back
     expected_data = set(job_data)
     actual_data = set(output.json)
     assert expected_data.issubset(actual_data)
 
 
-def test_add_job_good_with_attachments(mongo_app, tmp_path):
+def test_add_job_good_with_attachments(mongo_app, tmp_path, agent_auth_header):
     """Test that adding a new job with attachments works."""
     job_data = {
         "job_queue": "test",
@@ -457,7 +463,7 @@ def test_add_job_good_with_attachments(mongo_app, tmp_path):
     )
 
     # confirm that the job cannot be processed yet (attachments pending)
-    output = app.get("/v1/job?queue=test")
+    output = app.get("/v1/job?queue=test", headers=agent_auth_header)
     assert 204 == output.status_code
 
     # create a mock attachments archive containing random data
@@ -484,7 +490,9 @@ def test_add_job_good_with_attachments(mongo_app, tmp_path):
         assert output.data == attachments.read()
 
     # ask for a job from the queue and confirm the match
-    recovered_data = app.get("/v1/job?queue=test").json
+    recovered_data = app.get(
+        "/v1/job?queue=test", headers=agent_auth_header
+    ).json
     assert recovered_data["job_id"] == job_id
     assert set(job_data).issubset(recovered_data)
 
@@ -575,7 +583,7 @@ def test_resubmit_job_state(mongo_app):
     assert "waiting" == updated_data.get("job_state")
 
 
-def test_get_nonexistant_job(mongo_app):
+def test_get_nonexistant_job(mongo_app, agent_auth_header):
     """Test for 204 when getting from a nonexistent queue."""
     app, _ = mongo_app
     # Note: agents must register before they can be issued work:
@@ -583,14 +591,14 @@ def test_get_nonexistant_job(mongo_app):
         "/v1/agents/data/agent1",
         json={"state": "waiting", "queues": ["test"], "location": "here"},
     )
-    output = app.get("/v1/job?queue=BAD_QUEUE_NAME")
+    output = app.get("/v1/job?queue=BAD_QUEUE_NAME", headers=agent_auth_header)
     assert 204 == output.status_code
 
 
-def test_get_job_no_queue(mongo_app):
+def test_get_job_no_queue(mongo_app, agent_auth_header):
     """Test for error when getting a job without the ID."""
     app, _ = mongo_app
-    output = app.get("/v1/job")
+    output = app.get("/v1/job", headers=agent_auth_header)
     assert 400 == output.status_code
 
 
@@ -648,7 +656,7 @@ def test_job_get_id_with_data(mongo_app):
         assert output.json[key] == value
 
 
-def test_job_position(mongo_app):
+def test_job_position(mongo_app, agent_auth_header):
     """Ensure initial job state is set to 'waiting'."""
     app, _ = mongo_app
     job_data = {"job_queue": "test"}
@@ -668,7 +676,7 @@ def test_job_position(mongo_app):
     )
 
     # Request a job from the queue to remove one
-    output = app.get("/v1/job?queue=test")
+    output = app.get("/v1/job?queue=test", headers=agent_auth_header)
     # The job we get should be the first one that was added
     assert output.json.get("job_id") == job_id[0]
     # The position of the remaining jobs should decrement
@@ -1140,7 +1148,9 @@ def test_get_jobs_on_queue(mongo_app):
 
 
 @pytest.mark.parametrize("timeout", [1800, "1800", "30m", "1800s"])
-def test_reserve_data_with_human_readable_timeout(mongo_app, timeout):
+def test_reserve_data_with_human_readable_timeout(
+    mongo_app, timeout, agent_auth_header
+):
     """Test that a job with valid human readable timeout field works."""
     job_data = {
         "job_queue": "test",
@@ -1154,7 +1164,9 @@ def test_reserve_data_with_human_readable_timeout(mongo_app, timeout):
         "/v1/agents/data/agent1",
         json={"state": "waiting", "queues": ["test"], "location": "here"},
     )
-    submitted_job = app.get("/v1/job?queue=test").json
+    submitted_job = app.get(
+        "/v1/job?queue=test", headers=agent_auth_header
+    ).json
     assert submitted_job["reserve_data"]["timeout"] == 1800
 
 
@@ -1271,7 +1283,7 @@ def test_job_post_exclude_agents_all_excluded(mongo_app):
     assert "no agents" in msg or "agent" in str(output.json).lower()
 
 
-def test_pop_job_respects_exclude_agents(mongo_app):
+def test_pop_job_respects_exclude_agents(mongo_app, agent_auth_header):
     """Test that pop_job filters excluded agents correctly."""
     app, mongo = mongo_app
 
@@ -1294,7 +1306,7 @@ def test_pop_job_respects_exclude_agents(mongo_app):
         "/v1/agents/data/agent1",
         json={"state": "waiting", "queues": ["test"], "location": "here"},
     )
-    output = app.get("/v1/job?queue=test")
+    output = app.get("/v1/job?queue=test", headers=agent_auth_header)
     assert output.status_code == HTTPStatus.NO_CONTENT
 
     # Register as agent2 - should get the job
@@ -1302,12 +1314,12 @@ def test_pop_job_respects_exclude_agents(mongo_app):
         "/v1/agents/data/agent2",
         json={"state": "waiting", "queues": ["test"], "location": "here"},
     )
-    output = app.get("/v1/job?queue=test")
+    output = app.get("/v1/job?queue=test", headers=agent_auth_header)
     assert output.status_code == HTTPStatus.OK
     assert output.json["job_id"] == job_id
 
 
-def test_get_job_without_agent_id_fails(mongo_app):
+def test_get_job_without_agent_id_fails(mongo_app, agent_auth_header):
     """Test that getting a job without agent_id cookie fails."""
     app, mongo = mongo_app
 
@@ -1316,7 +1328,40 @@ def test_get_job_without_agent_id_fails(mongo_app):
     app.post("/v1/job", json=job_data)
 
     # Try to get job without agent_id (test client won't have cookie)
-    # Make a raw request without any cookies
+    # Make a raw request without any cookies but with agent auth
     with app.application.test_client() as raw_client:
-        output = raw_client.get("/v1/job?queue=test")
+        output = raw_client.get(
+            "/v1/job?queue=test", headers=agent_auth_header
+        )
         assert output.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_job_get_without_agent_cookie_fails(mongo_app):
+    """Test that getting a job without agent authentication is rejected."""
+    app, _ = mongo_app
+
+    # Create a job
+    job_data = {"job_queue": "test"}
+    app.post("/v1/job", json=job_data)
+
+    # Register agent (sets agent_name cookie)
+    app.post(
+        "/v1/agents/data/agent1",
+        json={"state": "waiting", "queues": ["test"], "location": "here"},
+    )
+
+    # Try to get job without JWT auth - should be rejected
+    output = app.get("/v1/job?queue=test")
+    assert output.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_job_get_no_auth_headers(mongo_app):
+    """Test that getting a job without authentication headers is rejected."""
+    app, _ = mongo_app
+
+    # Create a job
+    job_data = {"job_queue": "test"}
+    app.post("/v1/job", json=job_data)
+
+    output = app.get("/v1/job?queue=test")
+    assert output.status_code == HTTPStatus.UNAUTHORIZED

--- a/server/tests/test_v1_authorization.py
+++ b/server/tests/test_v1_authorization.py
@@ -191,7 +191,7 @@ def test_missing_fields_in_token(mongo_app_with_permissions):
     assert "Invalid Token" in job_response.text
 
 
-def test_job_get_with_priority(mongo_app_with_permissions):
+def test_job_get_with_priority(mongo_app_with_permissions, agent_auth_header):
     """Tests job get returns job with highest job priority."""
     app, _, client_id, client_key, _ = mongo_app_with_permissions
     token = get_access_token(app, client_id, client_key)
@@ -218,7 +218,9 @@ def test_job_get_with_priority(mongo_app_with_permissions):
 
     returned_job_ids = []
     for _ in range(len(jobs)):
-        job_get_response = app.get("/v1/job?queue=myqueue2")
+        job_get_response = app.get(
+            "/v1/job?queue=myqueue2", headers=agent_auth_header
+        )
         job_id = job_get_response.json.get("job_id")
         returned_job_ids.append(job_id)
 
@@ -227,7 +229,9 @@ def test_job_get_with_priority(mongo_app_with_permissions):
     assert returned_job_ids[2] == job_ids[0]
 
 
-def test_job_get_with_priority_multiple_queues(mongo_app_with_permissions):
+def test_job_get_with_priority_multiple_queues(
+    mongo_app_with_permissions, agent_auth_header
+):
     """
     Tests job get returns job with highest job priority when jobs are
     submitted across different queues.
@@ -262,7 +266,8 @@ def test_job_get_with_priority_multiple_queues(mongo_app_with_permissions):
     returned_job_ids = []
     for _ in range(len(jobs)):
         job_get_response = app.get(
-            "/v1/job?queue=myqueue&queue=myqueue2&queue=myqueue3"
+            "/v1/job?queue=myqueue&queue=myqueue2&queue=myqueue3",
+            headers=agent_auth_header,
         )
         job_id = job_get_response.json.get("job_id")
         returned_job_ids.append(job_id)

--- a/server/tests/test_v1_secrets.py
+++ b/server/tests/test_v1_secrets.py
@@ -521,7 +521,7 @@ def test_job_submit_with_invalid_secrets(app_with_store, secrets):
     assert "Validation error" in response.get_json()["message"]
 
 
-def test_job_get_with_secrets(app_with_store):
+def test_job_get_with_secrets(app_with_store, agent_auth_header):
     """Test retrieving a job with secrets from the queue."""
     # GIVEN: an app with a secrets store and a job with secrets submitted
     client_id = "client_1"
@@ -554,7 +554,9 @@ def test_job_get_with_secrets(app_with_store):
     )
 
     # WHEN: a job is retrieved from the queue
-    response = app_with_store.get("/v1/job?queue=test")
+    response = app_with_store.get(
+        "/v1/job?queue=test", headers=agent_auth_header
+    )
 
     # THEN: the job is returned with resolved secrets
     assert response.status_code == HTTPStatus.OK
@@ -568,7 +570,7 @@ def test_job_get_with_secrets(app_with_store):
     mock_secrets_store.read.assert_any_call(client_id, "tokens/api_key")
 
 
-def test_job_get_with_inaccessible_secrets(app_with_store):
+def test_job_get_with_inaccessible_secrets(app_with_store, agent_auth_header):
     """Test retrieving a job when some secrets are inaccessible."""
     # GIVEN: an app with a secrets store and a job with secrets submitted
     client_id = "client_1"
@@ -607,7 +609,9 @@ def test_job_get_with_inaccessible_secrets(app_with_store):
     )
 
     # WHEN: a job is retrieved from the queue
-    response = app_with_store.get("/v1/job?queue=test")
+    response = app_with_store.get(
+        "/v1/job?queue=test", headers=agent_auth_header
+    )
 
     # THEN: the job is returned with mixed secret values
     assert response.status_code == HTTPStatus.OK
@@ -617,7 +621,7 @@ def test_job_get_with_inaccessible_secrets(app_with_store):
     assert job["test_data"]["secrets"]["INVALID_SECRET"] == ""
 
 
-def test_job_get_without_secrets(app_with_store):
+def test_job_get_without_secrets(app_with_store, agent_auth_header):
     """Test retrieving a job that doesn't have secrets."""
     # GIVEN: an app with a secrets store and a job without secrets submitted
     client_id = "client_1"
@@ -638,7 +642,9 @@ def test_job_get_without_secrets(app_with_store):
     )
 
     # WHEN: a job is retrieved from the queue
-    response = app_with_store.get("/v1/job?queue=test")
+    response = app_with_store.get(
+        "/v1/job?queue=test", headers=agent_auth_header
+    )
 
     # THEN: the job is returned without secrets field
     assert response.status_code == HTTPStatus.OK
@@ -648,7 +654,7 @@ def test_job_get_without_secrets(app_with_store):
         assert "secrets" not in job["test_data"]
 
 
-def test_job_get_with_secrets_no_store(testapp):
+def test_job_get_with_secrets_no_store(testapp, agent_auth_header):
     """Test retrieving a job with secrets without a secrets store."""
     # GIVEN: an app without a secrets store
     app_client = testapp.test_client()
@@ -678,7 +684,7 @@ def test_job_get_with_secrets_no_store(testapp):
     )
 
     # WHEN: a job is retrieved from the queue
-    response = app_client.get("/v1/job?queue=test")
+    response = app_client.get("/v1/job?queue=test", headers=agent_auth_header)
 
     # THEN: the job is returned with empty secret values
     assert response.status_code == HTTPStatus.OK
@@ -687,7 +693,7 @@ def test_job_get_with_secrets_no_store(testapp):
     assert job["test_data"]["secrets"]["SECRET_KEY"] == ""
 
 
-def test_job_get_with_missing_client_id(app_with_store):
+def test_job_get_with_missing_client_id(app_with_store, agent_auth_header):
     """Test retrieving a job with secrets but missing client_id."""
     # GIVEN: an app with a secrets store
     mock_secrets_store = app_with_store.application.secrets_store
@@ -715,7 +721,9 @@ def test_job_get_with_missing_client_id(app_with_store):
     )
 
     # WHEN: a job is retrieved from the queue
-    response = app_with_store.get("/v1/job?queue=test")
+    response = app_with_store.get(
+        "/v1/job?queue=test", headers=agent_auth_header
+    )
 
     # THEN: the job is returned with empty secret values
     assert response.status_code == HTTPStatus.OK

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2008,7 +2008,7 @@ wheels = [
 
 [[package]]
 name = "testflinger"
-version = "1.4.2"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "apiflask" },
@@ -2027,7 +2027,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sentry-sdk" },
-    { name = "strenum" },
     { name = "testflinger-common" },
     { name = "urllib3" },
 ]
@@ -2068,7 +2067,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "sentry-sdk", specifier = ">=2.0.1" },
-    { name = "strenum", specifier = ">=0.4.15" },
     { name = "testflinger-common", editable = "../common" },
     { name = "urllib3", specifier = ">=2.2.1" },
 ]


### PR DESCRIPTION
## Description
This is the last bit to fully enable agent authentication (required by Testflinger Secrets implementation)

Simple PR that requires authentication for `/v1/job` with the role agent using the current decorator approach. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-834](https://warthogs.atlassian.net/browse/CERTTF-834)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
NA, once applicable and deployed, will create the Secrets documentation
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
`/v1/job` now requires authentication, existing decorators handle the error response
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
All current unit tests were modified to match this new behavior. Needed to include a fixture as `/v1/job` now requires a valid header where the role is specified. 

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-834]: https://warthogs.atlassian.net/browse/CERTTF-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ