### PR TITLE
feat(agent): add a agent pid management module

### DIFF
--- a/agent/src/testflinger_agent/__init__.py
+++ b/agent/src/testflinger_agent/__init__.py
@@ -27,7 +27,7 @@ import yaml
 from requests.adapters import HTTPAdapter, Retry
 from urllib3.exceptions import HTTPError
 
-from testflinger_agent import schema
+from testflinger_agent import agent_pid, schema
 from testflinger_agent.agent import TestflingerAgent
 from testflinger_agent.client import TestflingerClient
 
@@ -124,6 +124,11 @@ def start_agent():
     config["metrics_endpoint_port"] = args.metrics_port
     config["token_file"] = str(args.token_file)
     configure_logging(config)
+
+    pid_file = Path(config["logging_basedir"]) / f"{config['agent_id']}.pid"
+    agent_pid.terminate_stale(pid_file, str(args.config))
+    agent_pid.write(pid_file)
+
     check_interval = config.get("polling_interval")
     client = TestflingerClient(config)
     agent = TestflingerAgent(client)

--- a/agent/src/testflinger_agent/agent_pid.py
+++ b/agent/src/testflinger_agent/agent_pid.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""PID management module for the Testflinger agent."""
+
+import atexit
+import logging
+import os
+import signal
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def write(pid_file: Path) -> None:
+    """Write the current process PID to the specified file.
+
+    :param pid_file: Path to the PID file to write.
+    """
+    try:
+        pid_file.write_text(str(os.getpid()))
+    except OSError as err:
+        logger.error("Failed to write PID file %s: %s", pid_file, err)
+        raise
+
+    atexit.register(_cleanup, pid_file)
+
+
+def _safe_unlink(pid_file: Path) -> None:
+    """Remove the PID file, logging any error without raising.
+
+    :param pid_file: Path to the PID file to remove.
+    """
+    try:
+        pid_file.unlink(missing_ok=True)
+    except OSError as err:
+        logger.error("Failed to remove PID file %s: %s", pid_file, err)
+
+
+def _cleanup(pid_file: Path) -> None:
+    """Remove the PID file on process exit.
+
+    :param pid_file: Path to the PID file to remove.
+    """
+    try:
+        if pid_file.exists() and pid_file.read_text().strip() == str(
+            os.getpid()
+        ):
+            _safe_unlink(pid_file)
+    except OSError as err:
+        logger.error("Failed to check PID file %s: %s", pid_file, err)
+        return
+
+
+def terminate_stale(pid_file: Path, config_path: str) -> None:
+    """Terminate a stale agent process if one exists for this agent.
+
+    :param pid_file: Path to the PID file.
+    :param config_path: Path to agent config path
+    """
+    if not pid_file.exists():
+        return
+
+    # Verify the process is alive and confirms it matches this agent config
+    try:
+        stale_pid = int(pid_file.read_text().strip())
+        cmdline = (
+            Path(f"/proc/{stale_pid}/cmdline")
+            .read_bytes()
+            .decode(errors="replace")
+            .replace("\0", " ")
+            .strip()
+        )
+    except (OSError, ValueError):
+        # If PID file is malformed, remove the PID file in agent config_path
+        _safe_unlink(pid_file)
+        return
+
+    # If stale PID was recycled for an unrelated process, remove only PID file
+    if "testflinger-agent" not in cmdline or config_path not in cmdline:
+        logger.warning(
+            "PID %d does not match this agent — not terminating it",
+            stale_pid,
+        )
+        _safe_unlink(pid_file)
+        return
+
+    logger.warning("Terminating orphaned agent process (PID %d)", stale_pid)
+    try:
+        os.kill(stale_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        # Process is already terminated, ignore
+        pass

--- a/agent/src/testflinger_agent/cmd.py
+++ b/agent/src/testflinger_agent/cmd.py
@@ -16,6 +16,9 @@
 import logging
 import sys
 
+import voluptuous
+import yaml
+
 from testflinger_agent import start_agent
 
 logger = logging.getLogger(__name__)
@@ -28,5 +31,16 @@ def main():
     except KeyboardInterrupt:
         logger.info("Caught interrupt, exiting!")
         sys.exit(0)
+    except (
+        OSError,
+        yaml.YAMLError,
+        voluptuous.MultipleInvalid,
+    ):
+        # OSError: Config missing or metrics port already in use
+        # YAMLError: Config file is not valid YAML
+        # MultipleInvalid: Config file does not match schema
+        logger.exception("Failed to start agent due to configuration error")
+        sys.exit(1)
+    # TODO: Remove broad exception once all exceptions are handled explicitly
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception(exc)

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Fixtures for Testflinger agent tests."""
+
+import pytest
+
+from testflinger_agent.schema import validate
+
+
+@pytest.fixture
+def config(tmp_path):
+    """Fixture of a valid agent configuration."""
+    for subdir in ("run", "logs", "results"):
+        (tmp_path / subdir).mkdir()
+    return validate(
+        {
+            "agent_id": "test01",
+            "identifier": "12345-123456",
+            "polling_interval": 2,
+            "server_address": "127.0.0.1:8000",
+            "job_queues": ["test"],
+            "location": "nowhere",
+            "provision_type": "noprovision",
+            "execution_basedir": str(tmp_path / "run"),
+            "logging_basedir": str(tmp_path / "logs"),
+            "results_basedir": str(tmp_path / "results"),
+            "advertised_queues": {"test_queue": "test_queue"},
+            "advertised_images": {
+                "test_queue": {"test_image": "url: http://foo"}
+            },
+        }
+    )

--- a/agent/tests/test_agent_pid.py
+++ b/agent/tests/test_agent_pid.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import os
+import signal
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from testflinger_agent import agent_pid
+
+
+@pytest.fixture
+def pid_file(config):
+    """Fixture for a PID file path."""
+    return Path(config["logging_basedir"]) / f"{config['agent_id']}.pid"
+
+
+def test_agent_write_pid(pid_file):
+    """Test that agent PID file is written with the current PID on startup."""
+    agent_pid.write(pid_file)
+    assert pid_file.read_text() == str(os.getpid())
+
+
+@patch("pathlib.Path.write_text", side_effect=OSError("Disk full"))
+def test_agent_write_os_error(mock_write_text, pid_file, caplog):
+    """Test that agent PID file write handles OSError."""
+    with pytest.raises(OSError, match="Disk full"):
+        agent_pid.write(pid_file)
+    assert "Failed to write PID file" in caplog.text
+
+
+def test_agent_cleanup_pid_file(pid_file):
+    """Test that PID file is removed on cleanup."""
+    agent_pid.write(pid_file)
+
+    agent_pid._cleanup(pid_file)
+    assert not pid_file.exists()
+
+
+def test_agent_not_cleanup_foreign_pid(pid_file):
+    """Test that PID file belonging to another PID is not removed."""
+    pid_file.write_text("99999999")
+
+    agent_pid._cleanup(pid_file)
+    assert pid_file.exists()
+
+
+@patch("pathlib.Path.unlink", side_effect=OSError("Permission denied"))
+def test_agent_cleanup_os_error(mock_unlink, pid_file, caplog):
+    """Test that agent PID file cleanup logs OSError without raising."""
+    agent_pid.write(pid_file)
+
+    # Only log the error as this doesn't re-raise
+    agent_pid._cleanup(pid_file)
+    assert "Failed to remove PID file" in caplog.text
+
+
+@patch("pathlib.Path.read_text", side_effect=OSError("Permission denied"))
+def test_agent_cleanup_read_os_error(mock_read_text, pid_file, caplog):
+    """Test that OSError when reading PID file during cleanup is logged."""
+    pid_file.write_text(str(os.getpid()))
+
+    # Only log the error as this doesn't re-raise
+    agent_pid._cleanup(pid_file)
+    assert "Failed to check PID file" in caplog.text
+
+
+@patch("pathlib.Path.unlink")
+def test_agent_terminate_stale_no_pid_file(mock_unlink, pid_file):
+    """Test terminate_stale early return if no PID file exists."""
+    agent_pid.terminate_stale(pid_file, "dummy_config_path")
+    assert not pid_file.exists()
+    mock_unlink.assert_not_called()
+
+
+@patch("os.kill")
+def test_agent_terminate_stale_clean_old_pid_file(mock_kill, pid_file):
+    """Test stale PID file without any matching process is cleaned up."""
+    pid_file.write_text("99999999")
+    agent_pid.terminate_stale(pid_file, "testflinger-agent.conf")
+    assert not pid_file.exists()
+    mock_kill.assert_not_called()
+
+
+@patch("os.kill")
+def test_agent_terminate_stale_malformed_pid(mock_kill, pid_file):
+    """Test that malformed PID file is cleaned up."""
+    pid_file.write_text("not_a_pid")
+    agent_pid.terminate_stale(pid_file, "testflinger-agent.conf")
+    assert not pid_file.exists()
+    mock_kill.assert_not_called()
+
+
+@patch(
+    "pathlib.Path.read_bytes",
+    return_value=b"some-other-program\x00--flag",
+)
+@patch("os.kill")
+def test_agent_terminate_stale_mismatched_cmdline(
+    mock_killed, mock_read_bytes, pid_file, caplog
+):
+    """Test that PID file is cleaned up when cmdline doesn't match."""
+    pid_file.write_text(str(os.getpid()))
+    agent_pid.terminate_stale(pid_file, "testflinger-agent.conf")
+    assert not pid_file.exists()
+    assert "does not match this agent" in caplog.text
+    mock_killed.assert_not_called()
+
+
+@patch("os.kill")
+@patch(
+    "pathlib.Path.read_bytes",
+    return_value=b"testflinger-agent\x00--config\x00testflinger-agent.conf",
+)
+def test_agent_terminate_stale_kills_orphan(
+    mock_read_bytes, mock_kill, pid_file
+):
+    """Test that a matching orphan process is SIGKILLed."""
+    pid_file.write_text(str(os.getpid()))
+    agent_pid.terminate_stale(pid_file, "testflinger-agent.conf")
+    mock_kill.assert_called_once_with(os.getpid(), signal.SIGKILL)
+
+
+@patch("os.kill", side_effect=ProcessLookupError)
+@patch(
+    "pathlib.Path.read_bytes",
+    return_value=b"testflinger-agent\x00--config\x00testflinger-agent.conf",
+)
+def test_agent_terminate_stale_process_already_dead(
+    mock_read_bytes, mock_kill, pid_file
+):
+    """Test that ProcessLookupError after SIGKILL is silently ignored."""
+    pid_file.write_text(str(os.getpid()))
+    # must not raise
+    agent_pid.terminate_stale(pid_file, "testflinger-agent.conf")
+    mock_kill.assert_called_once()

--- a/agent/tests/test_cmd.py
+++ b/agent/tests/test_cmd.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+from unittest.mock import patch
+
+import pytest
+import voluptuous
+import yaml
+
+from testflinger_agent import cmd
+
+
+@patch("sys.exit")
+@patch("testflinger_agent.cmd.start_agent")
+def test_agent_start_valid_config(mock_start_agent, mock_exit):
+    """Test entrypoint does not call exit on valid configuration."""
+    cmd.main()
+    mock_exit.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        OSError("Address already in use"),
+        yaml.YAMLError("Invalid YAML"),
+        voluptuous.MultipleInvalid("Invalid config"),
+    ],
+)
+@patch("sys.exit")
+@patch("testflinger_agent.cmd.start_agent")
+def test_agent_start_exceptions_on_invalid_config(
+    mock_start_agent, mock_exit, exception
+):
+    """Test entrypoint exits with code 1 on known configuration errors."""
+    mock_start_agent.side_effect = exception
+    cmd.main()
+    mock_exit.assert_called_once_with(1)
+
+
+@patch("testflinger_agent.cmd.start_agent", side_effect=KeyboardInterrupt)
+@patch("sys.exit")
+def test_agent_start_keyboard_interrupt(mock_exit, mock_start_agent):
+    """Test entrypoint handles KeyboardInterrupt gracefully."""
+    cmd.main()
+    mock_exit.assert_called_once_with(0)
+
+
+@patch(
+    "testflinger_agent.cmd.start_agent",
+    side_effect=Exception("Unexpected error"),
+)
+@patch("sys.exit")
+def test_agent_start_unspecified_exception(mock_exit, mock_start_agent):
+    """Test entrypoint does not call explicit exit for unknown exceptions."""
+    cmd.main()
+    mock_exit.assert_not_called()


### PR DESCRIPTION
## Description
This PR is meant to add more resiliency to agents spawned by Supervisor. 

In a scenario where Supervisor crash or is OOM Killed, it can become unaware of the old process, leaving agents orphaned and requiring manual intervention, long term fix is to increase charm unit memory per deployment but the proposed module should ensure only one PID exist per agent. 
Agent now creates a PID file on start, if for some reason supervisor tries to restart the agent and the old process became orphaned, the agent will now get the old PID and terminate the old process on startup
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves #939 
Resolves [CERTTF-843](https://warthogs.atlassian.net/browse/CERTTF-843)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests that should cover all of the module scenarios. 
Quick test on staging just to verify the PID was getting rewritten properly:

```
sudo supervisorctl status audino
audino                           RUNNING   pid 1522718, uptime 0:33:25

cat testflinger/audino/logs/audino.pid 
1522718
```

After agent restart: 
```
sudo supervisorctl status audino
audino                           RUNNING   pid 1527087, uptime 0:51:53

cat testflinger/audino/logs/audino.pid 
1527087
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-843]: https://warthogs.atlassian.net/browse/CERTTF-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ