### PR TITLE
add(oem_autoinstall): user-data to setup rdp service in provisioned dut

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
@@ -44,6 +44,11 @@ autoinstall:
           ubuntu-lock-on-suspend=false
           lock-enabled=false
           idle-activation-enabled=false
+          [org.gnome.desktop.remote-desktop.rdp]
+          enable=true
+          view-only=false
+          tls-cert='/home/ubuntu/.local/share/gnome-remote-desktop/certificates/rdp-tls.crt'
+          tls-key='/home/ubuntu/.local/share/gnome-remote-desktop/certificates/rdp-tls.key'
         path: /usr/share/glib-2.0/schemas/certification.gschema.override
       - content: |
           #!/bin/bash
@@ -79,6 +84,43 @@ autoinstall:
           set_usb_boot_first
         path: /usr/bin/set_usb_boot.sh
         permissions: '0755'
+      - content: |
+          #!/bin/bash
+
+          mkdir -p ~/.local/share/keyrings/
+          pushd ~/.local/share/keyrings/ || exit
+          rm -fr ./*
+          STAMP=$(date +%s)
+          cat > default <<ENDLINE
+          headless
+          ENDLINE
+          cat > headless.keyring <<ENDLINE
+          [keyring]
+          display-name=Default keyring
+          ctime=$STAMP
+          mtime=0
+          lock-on-idle=false
+          lock-after=false
+
+          [1]
+          item-type=0
+          display-name=GNOME Remote Desktop RDP credentials
+          secret={'username': <'ubuntu'>, 'password': <'insecure'>}
+          mtime=$STAMP
+          ctime=$STAMP
+
+          [1:attribute0]
+          name=xdg:schema
+          type=string
+          value=org.gnome.RemoteDesktop.RdpCredentials
+          ENDLINE
+          popd || exit
+          mkdir -p "$HOME"/.local/share/gnome-remote-desktop/certificates/
+          rm -fr "$HOME"/.local/share/gnome-remote-desktop/certificates/*
+          openssl genrsa -out "$HOME"/.local/share/gnome-remote-desktop/certificates/rdp-tls.key 4096
+          openssl req -subj "/O=Testflinger/CN=OEM Autoinstall" -new -x509 -days 365 -key "$HOME"/.local/share/gnome-remote-desktop/certificates/rdp-tls.key -out "$HOME"/.local/share/gnome-remote-desktop/certificates/rdp-tls.crt
+        path: /usr/local/bin/rdp-setup
+        permissions: '0755'
 
     users:
       - name: ubuntu
@@ -92,6 +134,7 @@ autoinstall:
 
     packages:
       - openssh-server
+      - gnome-remote-desktop
 
     package_upgrade: false
 
@@ -105,6 +148,8 @@ autoinstall:
       - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.desktop.session"]
       - ["sudo", "-u", "ubuntu", "-H", "gsettings", "reset-recursively", "org.gnome.desktop.screensaver"]
       - ["/usr/bin/set_usb_boot.sh"]
+      - ["sudo", "-u", "ubuntu", "-H", "/usr/local/bin/rdp-setup"]
+      - ["systemctl", "--global", "enable", "gnome-remote-desktop"]
     # Reboot after early-welcome is done
     power_state:
       mode: "reboot"


### PR DESCRIPTION
## Description
This change adds remote desktop configs in user-data steps after provisioning the dut. This feature was in oem provisioning already, but was missed when migrating user-data to this repo.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Use updated user-data to provision two machines in different labs successfully
https://testflinger.canonical.com/jobs/7ac9d5ef-e965-4dfc-8d9e-5384c7a55f6a
https://testflinger.canonical.com/jobs/30d73f4f-83a1-456e-8302-b0ae734cc567

rdp is running after provisioning
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
