### PR TITLE
fix(docs): require unshallow clone on Readthedocs for sitemap

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,7 @@ build:
     python: "3.11"
   jobs:
     post_checkout:
+      - git fetch --unshallow || true
       # Cancel building pull requests when there aren't changed in the docs directory or Readthedocs config YAML file.
       # If there are no changes (git diff exits with 0) we force the command to return with 183.
       # This is a special exit code on Read the Docs that will cancel the build immediately.


### PR DESCRIPTION

## Description

The documentation sitemap builds require reading git history to generate the last-update timestamp. The default shallow clone used by Readthedocs caused build errors. This PR fixes the doc build failures by adding `unshallow` fetch.

Error message:
```
getting Git timestamps for dependencies... [100%] reuse

/home/docs/checkouts/readthedocs.org/user_builds/canonical-testflinger/checkouts/doc-preview/docs/explanation/authentication.rst: WARNING: Git clone too shallow [git.too_shallow]
/home/docs/checkouts/readthedocs.org/user_builds/canonical-testflinger/checkouts/doc-preview/docs/explanation/extended-reservation.rst: WARNING: Git clone too shallow [git.too_shallow]
/home/docs/checkouts/readthedocs.org/user_builds/canonical-testflinger/checkouts/doc-preview/docs/explanation/index.rst: WARNING: Git clone too shallow [git.too_shallow]
```

## Resolved issues

N/A

## Documentation

N/A

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
N/A

## Tests

PR check for Readthedocs build