### PR TITLE
fix(agent): remove writing to old endpoint to address BSON limit

### DIFF
--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -346,52 +346,23 @@ class TestflingerClient:
         job_id: str,
         log_input: LogEndpointInput,
         log_type: LogType,
-    ):
+    ) -> bool:
         """Post log data to the testflinger server for this job.
 
         :param job_id: id for the job
         :param log_input: Dataclass with all of the keys for the log endpoint
         :param log_type: Enum of different log types the server accepts
+        :returns: True if log was posted successfully, False otherwise
         """
         endpoint = urljoin(self.server, f"/v1/result/{job_id}/log/{log_type}")
-
-        # Define request success flags
-        request = None
-
-        # TODO: Remove legacy endpoint support in future versions
-        # Define legacy_request success flag
-        legacy_request = None
-
-        # Enum is "serial", for compatibility, define "serial_output" instead
-        suffix = (
-            "serial_output"
-            if log_type == LogType.SERIAL_OUTPUT
-            else log_type.value
-        )
-        legacy_endpoint = urljoin(self.server, f"/v1/result/{job_id}/{suffix}")
-        # Prioritize writing to legacy endpoint
-        try:
-            legacy_request = self.session.post(
-                legacy_endpoint,
-                data=log_input.log_data.encode("utf-8"),
-                timeout=60,
-            )
-        except requests.exceptions.RequestException as exc:
-            logger.error(exc)
-            logger.info("Fallback to new log endpoint")
-
-        # Write logs to new endpoint
         try:
             request = self.session.post(
                 endpoint, json=asdict(log_input), timeout=60
             )
         except requests.exceptions.RequestException as exc:
             logger.error(exc)
-
-        # Return True if either request was successful
-        return any(
-            req is not None and req.ok for req in (legacy_request, request)
-        )
+            return False
+        return request.ok
 
     def post_advertised_queues(self):
         """Post the list of advertised queues to testflinger server."""

--- a/agent/tests/test_client.py
+++ b/agent/tests/test_client.py
@@ -14,13 +14,16 @@
 
 import json
 import uuid
+from datetime import datetime, timezone
 from http import HTTPStatus
 from unittest.mock import patch
 
 import pytest
 import requests_mock as rmock
 from requests.exceptions import RequestException
+from testflinger_common.enums import LogType
 
+from testflinger_agent.client import LogEndpointInput
 from testflinger_agent.client import TestflingerClient as _TestflingerClient
 from testflinger_agent.errors import InvalidTokenError, TFServerError
 
@@ -716,3 +719,58 @@ class TestClient:
             and "/v1/agents/data/test_agent" in request.url
         ]
         assert len(agent_data_calls) == 0
+
+    @pytest.mark.parametrize(
+        "log_type", [LogType.STANDARD_OUTPUT, LogType.SERIAL_OUTPUT]
+    )
+    def test_post_log_success(self, client, requests_mock, log_type):
+        job_id = str(uuid.uuid4())
+        requests_mock.post(
+            f"http://127.0.0.1:8000/v1/result/{job_id}/log/{log_type}",
+            status_code=HTTPStatus.OK,
+        )
+        log_input = LogEndpointInput(
+            fragment_number=0,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            phase="test",
+            log_data="output_log_data",
+        )
+        assert client.post_log(job_id, log_input, log_type) is True
+
+    @pytest.mark.parametrize(
+        "log_type", [LogType.STANDARD_OUTPUT, LogType.SERIAL_OUTPUT]
+    )
+    def test_post_log_failure_server_error(
+        self, client, requests_mock, log_type
+    ):
+        job_id = str(uuid.uuid4())
+        requests_mock.post(
+            f"http://127.0.0.1:8000/v1/result/{job_id}/log/{log_type}",
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
+        log_input = LogEndpointInput(
+            fragment_number=0,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            phase="test",
+            log_data="output_log_data",
+        )
+        assert client.post_log(job_id, log_input, log_type) is False
+
+    @pytest.mark.parametrize(
+        "log_type", [LogType.STANDARD_OUTPUT, LogType.SERIAL_OUTPUT]
+    )
+    def test_post_log_failure_request_exception(
+        self, client, requests_mock, log_type
+    ):
+        job_id = str(uuid.uuid4())
+        requests_mock.post(
+            f"http://127.0.0.1:8000/v1/result/{job_id}/log/{log_type}",
+            exc=RequestException("connection error"),
+        )
+        log_input = LogEndpointInput(
+            fragment_number=0,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            phase="test",
+            log_data="output_log_data",
+        )
+        assert client.post_log(job_id, log_input, log_type) is False


### PR DESCRIPTION
## Description
This PR removes writing to the old endpoint as its no longer needed, besides its creating problem with agents attempting to write to the old endpoint as its hitting the 16 MB BSON limit (single document for all chunks). See following jobs for massive serial logs:
`curl https://testflinger.canonical.com/v1/result/4c07d47c-cebc-4b30-a6ce-bf7fcd38eaaf/log/serial`

New endpoint does not have this problem because each chunk has its own document so it won't hit this limit. 

Error seen:
```
[26-03-03 15:17:38]    INFO: (client.py:381)| Fallback to new log endpoint
[26-03-03 15:17:49]   ERROR: (client.py:380)| HTTPSConnectionPool(host='testflinger.canonical.com', port=443): Max retries exceeded with url: /v1/result/4c07d47c-cebc-4b30-a6ce-bf7fcd38eaaf/serial_output (Caused by ResponseError('too many 500 error responses'))
[26-03-03 15:17:49]    INFO: (client.py:381)| Fallback to new log endpoint
[26-03-03 15:18:00]   ERROR: (client.py:380)| HTTPSConnectionPool(host='testflinger.canonical.com', port=443): Max retries exceeded with url: /v1/result/4c07d47c-cebc-4b30-a6ce-bf7fcd38eaaf/serial_output (Caused by ResponseError('too many 500 error responses'))
[26-03-03 15:18:00]    INFO: (client.py:381)| Fallback to new log endpoint
```

Jobs are then stuck trying to send all chunks for serial logging which takes 3 retries for each chunk. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
NA
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
