### PR TITLE
fix: not really waiting until control host goes down

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -450,6 +450,19 @@ class DefaultDevice:
         else:
             raise TimeoutError
 
+    @staticmethod
+    def wait_offline(check: Callable, host: str, timeout: int) -> None:
+        """Poll the host server using `check` until it's unreachable."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                check(host)
+                time.sleep(2)
+            except ConnectionError:
+                break
+        else:
+            raise TimeoutError
+
     def _reboot_control_host(self) -> None:
         control_host_reboot_script: list[str] = [
             str(cmd)

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -439,7 +439,14 @@ class DefaultDevice:
 
     @staticmethod
     def wait_online(check: Callable, host: str, timeout: int) -> None:
-        """Poll the host server using `check` until it's available."""
+        """Poll the host server using `check` until it's available.
+
+        :param check: callable that takes a host string and raises
+            ConnectionError if the host is unreachable.
+        :param host: the host address to check.
+        :param timeout: maximum time to wait in seconds.
+        :raises TimeoutError: if the host is not available within the timeout.
+        """
         start_time = time.time()
         while time.time() - start_time < timeout:
             try:
@@ -452,7 +459,14 @@ class DefaultDevice:
 
     @staticmethod
     def wait_offline(check: Callable, host: str, timeout: int) -> None:
-        """Poll the host server using `check` until it's unreachable."""
+        """Poll the host server using `check` until it's unreachable.
+
+        :param check: callable that takes a host string and raises
+            ConnectionError if the host is unreachable.
+        :param host: the host address to check.
+        :param timeout: maximum time to wait in seconds.
+        :raises TimeoutError: if the host is still reachable after the timeout.
+        """
         start_time = time.time()
         while time.time() - start_time < timeout:
             try:

--- a/device-connectors/src/testflinger_device_connectors/devices/tests/test_devices.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/tests/test_devices.py
@@ -91,6 +91,38 @@ class DefaultDeviceTests(unittest.TestCase):
         expected = call(cmd.split(), timeout=30)
         mock_check.assert_has_calls(10 * [expected])
 
+    @patch("time.sleep", Mock())
+    @patch("time.time", side_effect=[0, 1, 2, 3])
+    def test_wait_online_success(self, _mock_time):
+        """Test wait_online returns when the check succeeds."""
+        check = Mock(side_effect=[ConnectionError, None])
+        DefaultDevice.wait_online(check, "host", 10)
+        assert check.call_count == 2
+
+    @patch("time.sleep", Mock())
+    @patch("time.time", side_effect=[0, 5, 11])
+    def test_wait_online_timeout(self, _mock_time):
+        """Test wait_online raises TimeoutError when check never succeeds."""
+        check = Mock(side_effect=ConnectionError)
+        with self.assertRaises(TimeoutError):
+            DefaultDevice.wait_online(check, "host", 10)
+
+    @patch("time.sleep", Mock())
+    @patch("time.time", side_effect=[0, 1, 2, 3])
+    def test_wait_offline_success(self, _mock_time):
+        """Test wait_offline returns when the check starts failing."""
+        check = Mock(side_effect=[None, ConnectionError])
+        DefaultDevice.wait_offline(check, "host", 10)
+        assert check.call_count == 2
+
+    @patch("time.sleep", Mock())
+    @patch("time.time", side_effect=[0, 5, 11])
+    def test_wait_offline_timeout(self, _mock_time):
+        """Test wait_offline raises TimeoutError when host stays online."""
+        check = Mock()
+        with self.assertRaises(TimeoutError):
+            DefaultDevice.wait_offline(check, "host", 10)
+
     def test_write_device_info(self):
         """Validate device-info file can be read upon class initialization."""
         fake_config = {"device_ip": "10.10.10.10", "agent_name": "fake_agent"}

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -58,7 +58,7 @@ class DeviceConnector(ZapperConnector):
             logger.info("Attempt to power cycle the control host.")
             self._api_post("/api/v1/system/poweroff", timeout=10)
             with contextlib.suppress(TimeoutError):
-                ZapperConnector.wait_online(
+                ZapperConnector.wait_offline(
                     ZapperConnector._check_rpyc_server_on_host,
                     control_host,
                     30,

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -593,10 +593,10 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
     @patch.object(DeviceConnector, "wait_ready")
     @patch.object(DeviceConnector, "_reboot_control_host")
-    @patch.object(ZapperConnector, "wait_online")
+    @patch.object(ZapperConnector, "wait_offline")
     @patch.object(DeviceConnector, "_api_post")
     def test_pre_provision_hook_poweroff(
-        self, mock_api_post, mock_wait_online, mock_reboot, mock_wait_ready
+        self, mock_api_post, mock_wait_offline, mock_reboot, mock_wait_ready
     ):
         """Test pre_provision_hook sends poweroff, waits for RPyC to
         go down, reboots control host, then waits for it to come back.
@@ -608,7 +608,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         mock_api_post.assert_called_once_with(
             "/api/v1/system/poweroff", timeout=10
         )
-        mock_wait_online.assert_called_once_with(
+        mock_wait_offline.assert_called_once_with(
             ZapperConnector._check_rpyc_server_on_host,
             "zapper-host",
             30,


### PR DESCRIPTION
## Description

While dealing with a configuration issue, I noticed the busy loop waiting for the control host to be down is not really waiting: most of the time it's just returning immediately. This PR adds a dedicated handler to wait until it's offline.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

Added for coverage.
