### PR TITLE
Add set_ubuntu_boot for image provision

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
@@ -122,6 +122,41 @@ autoinstall:
         path: /usr/local/bin/rdp-setup
         permissions: '0755'
 
+      - content: |
+          #!/bin/bash
+          set_ubuntu_boot_first() {
+              local bootnum current_order new_order
+
+              # Get Ubuntu boot number
+              bootnum=$(sudo efibootmgr -v | awk 'BEGIN {IGNORECASE=1} /Boot[0-9A-F]+\**[[:space:]]+.*Ubuntu/ {print $1}' | head -n1 | cut -c5- | tr -d '*')
+
+              if [[ -z "$bootnum" ]]; then
+                  echo "No Ubuntu boot entry found" >&2
+                  return 1
+              fi
+
+              echo "Ubuntu boot entry found: $bootnum"
+
+              # Get current boot order and remove USB bootnum from it
+              current_order=$(sudo efibootmgr | grep BootOrder | cut -d: -f2 | tr -d '[:space:]')
+              current_order=${current_order//${bootnum},/}  # Remove if at beginning
+              current_order=${current_order//,${bootnum}/}  # Remove if in middle
+              current_order=${current_order//${bootnum}/}   # Remove if alone
+
+              # Build new order with Ubuntu first
+              new_order="$bootnum"
+              if [[ -n "$current_order" ]]; then
+                  new_order+=",$current_order"
+              fi
+
+              echo "Setting new boot order: $new_order"
+              sudo efibootmgr -o "$new_order"
+          }
+
+          set_ubuntu_boot_first
+        path: /usr/bin/set_ubuntu_boot.sh
+        permissions: '0755'
+
     users:
       - name: ubuntu
         groups: [adm, sudo]


### PR DESCRIPTION
that mkae sure second boot would not boot to usb

## Description
Add set_ubuntu_boot for image provision
that mkae sure second boot would not boot to usb


## Resolved issues
during provision we need to reboot for EFI to detect usb.
But it could cause system boot into usb directly.
I case this happen, we set ubuntu boot before reboot
## Documentation


## Web service API changes


## Tests
script can actually set the boot order
