### PR TITLE
change: migrate from RPyC to REST APIs

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -585,18 +585,6 @@ wheels = [
 ]
 
 [[package]]
-name = "plumbum"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/c8/11a5f792704b70f071a3dbc329105a98e9cc8d25daaf09f733c44eb0ef8e/plumbum-1.10.0.tar.gz", hash = "sha256:f8cbf0ecec0b73ff4e349398b65112a9e3f9300e7dc019001217dcc148d5c97c", size = 320039, upload-time = "2025-10-31T05:02:48.697Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/ad/45312df6b63ba64ea35b8d8f5f0c577aac16e6b416eafe8e1cb34e03f9a7/plumbum-1.10.0-py3-none-any.whl", hash = "sha256:9583d737ac901c474d99d030e4d5eec4c4e6d2d7417b1cf49728cf3be34f6dc8", size = 127383, upload-time = "2025-10-31T05:02:47.002Z" },
-]
-
-[[package]]
 name = "prometheus-client"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -838,28 +826,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pywin32"
-version = "311"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
-    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
-    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
-    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -948,18 +914,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
-]
-
-[[package]]
-name = "rpyc"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "plumbum" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/e0/a584823afecc5d8a0c18c46da4e028876e3e34946e6e3b2c3d430cd19b18/rpyc-5.3.1.tar.gz", hash = "sha256:f2233174879faf18ae266437d5a65511ce46c817cec4edc1344f036758cfbf52", size = 61611, upload-time = "2023-02-22T03:45:02.967Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/d8/715206e54dfc54177d126f05b6ecc9526891b11ac7a4bafdb1ae4df55eab/rpyc-5.3.1-py3-none-any.whl", hash = "sha256:6e8153792ac221a80f420d2e0b241a10c6e43b105d325998b18a4e7af329f9ec", size = 74036, upload-time = "2023-02-22T03:45:00.933Z" },
 ]
 
 [[package]]
@@ -1116,7 +1070,6 @@ source = { directory = "../device-connectors" }
 dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "rpyc" },
     { name = "typing-extensions" },
     { name = "validators" },
 ]
@@ -1125,7 +1078,6 @@ dependencies = [
 requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
-    { name = "rpyc", specifier = "<6" },
     { name = "typing-extensions", specifier = "~=4.15.0" },
     { name = "validators", specifier = ">=0.34.0" },
 ]

--- a/device-connectors/pyproject.toml
+++ b/device-connectors/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.10"
 dependencies = [
     "pyyaml>=6.0.2",
     "requests>=2.32.3",
-    "rpyc<6",
     "typing-extensions~=4.15.0",
     "validators>=0.34.0",
 ]

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -222,7 +222,7 @@ class MuxPi:
                 ZapperConnector.wait_ready(control_host)
             except TimeoutError as e:
                 raise ProvisioningError(
-                    "Cannot reach out the service over RPyC"
+                    "Cannot reach the Zapper REST API"
                 ) from e
 
         # determine where to get the provisioning image from

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -110,8 +110,8 @@ def test_check_test_image_booted_fails(mocker):
 class TestMuxPiProvisionWithZapper:
     """Tests for MuxPi provision method with zapper configuration."""
 
-    def test_provision_with_zapper_waits_for_rpyc(self, mocker):
-        """Test provision waits for RPyC server when using zapper."""
+    def test_provision_with_zapper_waits_for_rest_api(self, mocker):
+        """Test provision waits for Zapper REST API when using zapper."""
         muxpi = MuxPi()
         muxpi.config = {
             "control_switch_local_cmd": "zapper sdwire set TS",

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -22,12 +22,10 @@ validating the configuration and preparing the API arguments.
 
 import json
 import logging
-import subprocess
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Tuple
 
 import requests
-import rpyc
 
 from testflinger_device_connectors.devices import (
     DefaultDevice,
@@ -44,7 +42,6 @@ class ZapperConnector(ABC, DefaultDevice):
 
     PROVISION_METHOD = ""  # to be defined in the implementation
     ZAPPER_REQUEST_TIMEOUT = 60 * 90
-    ZAPPER_SERVICE_PORT = 60000
     ZAPPER_REST_PORT = 8000
 
     def _api_post(self, endpoint: str, **kwargs) -> requests.Response:
@@ -65,63 +62,96 @@ class ZapperConnector(ABC, DefaultDevice):
         response.raise_for_status()
         return response
 
-    @staticmethod
-    def _check_rpyc_server_on_host(host: str) -> None:
-        """
-        Check if the host has an active RPyC server running.
+    def _api_get(self, endpoint: str, **kwargs) -> requests.Response:
+        """Send a GET request to the Zapper REST API.
 
-        :raises ConnectionError in case the server is not reachable.
+        :param endpoint: API endpoint path.
+        :param kwargs: Additional keyword arguments passed to requests.get.
+        :returns: The response object.
+        :raises requests.RequestException: On any request failure.
         """
-        timeout = 3
+        url = (
+            f"http://{self.config['control_host']}"
+            f":{self.ZAPPER_REST_PORT}{endpoint}"
+        )
+        logger.info("GET %s", url)
+        timeout = kwargs.pop("timeout", 30)
+        response = requests.get(url, timeout=timeout, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def _api_put(self, endpoint: str, **kwargs) -> requests.Response:
+        """Send a PUT request to the Zapper REST API.
+
+        :param endpoint: API endpoint path.
+        :param kwargs: Additional keyword arguments passed to requests.put.
+        :returns: The response object.
+        :raises requests.RequestException: On any request failure.
+        """
+        url = (
+            f"http://{self.config['control_host']}"
+            f":{self.ZAPPER_REST_PORT}{endpoint}"
+        )
+        logger.info("PUT %s", url)
+        timeout = kwargs.pop("timeout", 30)
+        response = requests.put(url, timeout=timeout, **kwargs)
+        response.raise_for_status()
+        return response
+
+    @staticmethod
+    def _check_rest_api_on_host(host: str) -> None:
+        """Check if the host has an active Zapper REST API.
+
+        :raises ConnectionError: If the API is not reachable.
+        """
         try:
-            subprocess.run(
-                [
-                    "/usr/bin/nc",
-                    "-z",
-                    "-w",
-                    str(timeout),
-                    host,
-                    str(ZapperConnector.ZAPPER_SERVICE_PORT),
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
+            url = (
+                f"http://{host}:{ZapperConnector.ZAPPER_REST_PORT}"
+                f"/api/v1/addons/"
             )
-            logger.debug("The host %s has an available RPyC server", host)
-        except subprocess.CalledProcessError as e:
+            resp = requests.get(url, timeout=3)
+            resp.raise_for_status()
+            logger.debug("The host %s has an available REST API", host)
+        except (requests.ConnectionError, requests.Timeout) as e:
             raise ConnectionError from e
 
     @staticmethod
     def wait_ready(host: str, timeout: int = 60) -> None:
-        """Wait for an RPyC server to become available on the given host.
+        """Wait for the Zapper REST API to become available on the host.
 
-        :param host: The host to check for RPyC availability.
+        :param host: The host to check for REST API availability.
         :param timeout: Maximum time to wait in seconds (default: 60).
-        :raises TimeoutError: If the server is not available within the timeout
+        :raises TimeoutError: If the API is not available within the timeout.
         """
-        logger.info(
-            "Waiting for a running RPyC server on control host %s", host
-        )
+        logger.info("Waiting for the Zapper REST API on control host %s", host)
         DefaultDevice.wait_online(
-            ZapperConnector._check_rpyc_server_on_host, host, timeout
+            ZapperConnector._check_rest_api_on_host, host, timeout
         )
 
     @staticmethod
     def typecmux_set_state(host: str, state: str) -> None:
-        """Connect to a Zapper host via RPyC and set the typecmux state.
+        """Set the typecmux state on a Zapper host via the REST API.
 
         :param host: The Zapper host to connect to.
         :param state: The state to set (e.g., "OFF", "DUT").
         """
-        connection = rpyc.connect(
-            host,
-            ZapperConnector.ZAPPER_SERVICE_PORT,
-            config={
-                "allow_public_attrs": True,
-                "sync_request_timeout": 60,
-            },
+        base = f"http://{host}:{ZapperConnector.ZAPPER_REST_PORT}"
+        resp = requests.get(
+            f"{base}/api/v1/addons/",
+            params={"addon_type": "TYPEC_MUX"},
+            timeout=10,
         )
-        connection.root.typecmux_set_state(alias="default", state=state)
+        resp.raise_for_status()
+        addons = resp.json()["addons"]
+        if not addons:
+            raise RuntimeError("No TYPEC_MUX addon found on Zapper")
+        addr = addons[0]["addr"]
+        resp = requests.put(
+            f"{base}/api/v1/addons/{addr}/typecmux/state",
+            json={"state": state},
+            timeout=10,
+        )
+        resp.raise_for_status()
         logger.info("Set typecmux state to %s on %s", state, host)
 
     @staticmethod
@@ -153,9 +183,7 @@ class ZapperConnector(ABC, DefaultDevice):
         try:
             ZapperConnector.wait_ready(control_host)
         except TimeoutError as e:
-            raise ProvisioningError(
-                "Cannot reach out the Zapper service over RPyC"
-            ) from e
+            raise ProvisioningError("Cannot reach the Zapper REST API") from e
 
         with open(args.job_data, encoding="utf-8") as job_json:
             self.job_data = json.load(job_json)
@@ -184,22 +212,11 @@ class ZapperConnector(ABC, DefaultDevice):
         raise NotImplementedError
 
     def _run(self, zapper_ip, *args, **kwargs):
-        """Run the Zapper `provision` API via RPyC. The arguments are
-        not stricly defined so that the same API can be used by different
-        implementations.
+        """Run the Zapper provisioning via the REST API.
 
-        The connector logger is passed as an argument to the Zapper API
-        in order to get a real time feedback throughout the whole execution.
+        Submits a provisioning job, streams SSE logs in real time,
+        and checks the final job status.
         """
-        connection = rpyc.connect(
-            zapper_ip,
-            self.ZAPPER_SERVICE_PORT,
-            config={
-                "allow_public_attrs": True,
-                "sync_request_timeout": self.ZAPPER_REQUEST_TIMEOUT,
-            },
-        )
-
         kwargs.update(
             {
                 "agent_name": self.config["agent_name"],
@@ -209,12 +226,35 @@ class ZapperConnector(ABC, DefaultDevice):
             }
         )
 
-        connection.root.provision(
-            self.PROVISION_METHOD,
-            *args,
-            logger=logger,
-            **kwargs,
+        resp = self._api_post(
+            "/api/v1/provision",
+            json={
+                "method": self.PROVISION_METHOD,
+                "args": list(args),
+                "kwargs": kwargs,
+            },
         )
+        job = resp.json()
+        job_id = job["job_id"]
+
+        # Stream SSE logs
+        url = (
+            f"http://{zapper_ip}:{self.ZAPPER_REST_PORT}"
+            f"/api/v1/provision/{job_id}/logs"
+        )
+        with requests.get(
+            url, stream=True, timeout=self.ZAPPER_REQUEST_TIMEOUT
+        ) as sse:
+            for line in sse.iter_lines(decode_unicode=True):
+                if line.startswith("data: "):
+                    entry = json.loads(line[6:])
+                    log_level = getattr(logging, entry["level"], logging.INFO)
+                    logger.log(log_level, entry["message"])
+
+        # Check final status
+        status = self._api_get(f"/api/v1/provision/{job_id}").json()
+        if status["status"] != "completed":
+            raise ProvisioningError(status.get("error", "Provisioning failed"))
 
     def _copy_ssh_id(self):
         """Copy the ssh id to the device."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -264,7 +264,9 @@ class ZapperConnector(ABC, DefaultDevice):
         # Check final status
         status = self._api_get(f"/api/v1/provision/{job_id}").json()
         if status["status"] != "completed":
-            raise ProvisioningError(status.get("error", "Provisioning failed"))
+            raise ProvisioningError(
+                status.get("error", "Provisioning failed for unknown reason.")
+            )
 
     def _copy_ssh_id(self):
         """Copy the ssh id to the device."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -288,10 +288,15 @@ class ZapperConnector(ABC, DefaultDevice):
             except json.JSONDecodeError:
                 logger.warning("Malformed SSE data: %s", line)
                 continue
-            log_level = getattr(
-                logging, entry.get("level", "").upper(), logging.INFO
-            )
-            logger.log(log_level, entry.get("message", line))
+            level_name = entry.get("level", "").upper()
+            log_level = getattr(logging, level_name, None)
+            if log_level is None:
+                logger.warning(
+                    "Unknown log level '%s', defaulting to INFO",
+                    entry.get("level", ""),
+                )
+                log_level = logging.INFO
+            logger.log(log_level, "[zapper] %s", entry.get("message", line))
 
     def _copy_ssh_id(self):
         """Copy the ssh id to the device."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -108,7 +108,7 @@ class ZapperConnector(ABC, DefaultDevice):
         try:
             url = (
                 f"http://{host}:{ZapperConnector.ZAPPER_REST_PORT}"
-                f"/api/v1/health"
+                f"/health"
             )
             resp = requests.get(url, timeout=3)
             resp.raise_for_status()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -246,10 +246,14 @@ class ZapperConnector(ABC, DefaultDevice):
         timeout = (self.ZAPPER_CONNECTION_TIMEOUT, self.ZAPPER_READ_TIMEOUT)
         with requests.get(url, stream=True, timeout=timeout) as sse:
             for line in sse.iter_lines(decode_unicode=True):
-                if line.startswith("data: "):
-                    entry = json.loads(line[6:])
-                    log_level = getattr(logging, entry["level"], logging.INFO)
-                    logger.log(log_level, entry["message"])
+                if not line:
+                    continue
+                if not line.startswith("data: "):
+                    logger.warning("Unexpected SSE line: %s", line)
+                    continue
+                entry = json.loads(line[6:])
+                log_level = getattr(logging, entry["level"], logging.INFO)
+                logger.log(log_level, entry["message"])
 
         # Check final status
         status = self._api_get(f"/api/v1/provision/{job_id}").json()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -106,10 +106,7 @@ class ZapperConnector(ABC, DefaultDevice):
         :raises ConnectionError: If the API is not reachable.
         """
         try:
-            url = (
-                f"http://{host}:{ZapperConnector.ZAPPER_REST_PORT}"
-                f"/health"
-            )
+            url = f"http://{host}:{ZapperConnector.ZAPPER_REST_PORT}/health"
             resp = requests.get(url, timeout=3)
             resp.raise_for_status()
             logger.debug("The host %s has an available REST API", host)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -113,7 +113,7 @@ class ZapperConnector(ABC, DefaultDevice):
             resp = requests.get(url, timeout=3)
             resp.raise_for_status()
             logger.debug("The host %s has an available REST API", host)
-        except (requests.ConnectionError, requests.Timeout) as e:
+        except requests.RequestException as e:
             raise ConnectionError from e
 
     @staticmethod
@@ -197,7 +197,7 @@ class ZapperConnector(ABC, DefaultDevice):
         )
 
         (api_args, api_kwargs) = self._validate_configuration()
-        self._run(self.config["control_host"], *api_args, **api_kwargs)
+        self._run(*api_args, **api_kwargs)
 
         self._post_run_actions(args)
 
@@ -212,7 +212,7 @@ class ZapperConnector(ABC, DefaultDevice):
         """
         raise NotImplementedError
 
-    def _run(self, zapper_ip, *args, **kwargs):
+    def _run(self, *args, **kwargs):
         """Run the Zapper provisioning via the REST API.
 
         Submits a provisioning job, streams SSE logs in real time,
@@ -238,13 +238,14 @@ class ZapperConnector(ABC, DefaultDevice):
         job = resp.json()
         job_id = job["job_id"]
 
-        url = (
-            f"http://{zapper_ip}:{self.ZAPPER_REST_PORT}"
-            f"/api/v1/provision/{job_id}/logs"
-        )
         timeout = (self.ZAPPER_CONNECTION_TIMEOUT, self.ZAPPER_READ_TIMEOUT)
         while True:
-            with requests.get(url, stream=True, timeout=timeout) as sse:
+            sse = self._api_get(
+                f"/api/v1/provision/{job_id}/logs",
+                stream=True,
+                timeout=timeout,
+            )
+            with sse:
                 self._stream_sse_logs(sse)
 
             # Check job status after the SSE stream ends

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -238,21 +238,27 @@ class ZapperConnector(ABC, DefaultDevice):
         job = resp.json()
         job_id = job["job_id"]
 
-        # Stream SSE logs
+        # Stream SSE (Server-Sent Events) logs.
+        # The SSE protocol sends newline-delimited lines in the format:
+        #   data: {"level": "INFO", "message": "..."}
+        # Empty lines act as event separators and are skipped.
+        # Lines not starting with "data: " (e.g. "event:", "retry:")
+        # are non-standard for this endpoint and logged as warnings.
         url = (
             f"http://{zapper_ip}:{self.ZAPPER_REST_PORT}"
             f"/api/v1/provision/{job_id}/logs"
         )
+        sse_data_prefix = "data: "
         timeout = (self.ZAPPER_CONNECTION_TIMEOUT, self.ZAPPER_READ_TIMEOUT)
         with requests.get(url, stream=True, timeout=timeout) as sse:
             for line in sse.iter_lines(decode_unicode=True):
                 if not line:
                     continue
-                if not line.startswith("data: "):
+                if not line.startswith(sse_data_prefix):
                     logger.warning("Unexpected SSE line: %s", line)
                     continue
                 try:
-                    entry = json.loads(line[6:])
+                    entry = json.loads(line[len(sse_data_prefix) :])
                 except json.JSONDecodeError:
                     logger.warning("Malformed SSE data: %s", line)
                     continue

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -256,7 +256,9 @@ class ZapperConnector(ABC, DefaultDevice):
                 except json.JSONDecodeError:
                     logger.warning("Malformed SSE data: %s", line)
                     continue
-                log_level = getattr(logging, entry["level"], logging.INFO)
+                log_level = getattr(
+                    logging, entry.get("level", "").upper(), logging.INFO
+                )
                 logger.log(log_level, entry["message"])
 
         # Check final status

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -259,7 +259,7 @@ class ZapperConnector(ABC, DefaultDevice):
                 log_level = getattr(
                     logging, entry.get("level", "").upper(), logging.INFO
                 )
-                logger.log(log_level, entry["message"])
+                logger.log(log_level, entry.get("message", line))
 
         # Check final status
         status = self._api_get(f"/api/v1/provision/{job_id}").json()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -41,7 +41,8 @@ class ZapperConnector(ABC, DefaultDevice):
     """
 
     PROVISION_METHOD = ""  # to be defined in the implementation
-    ZAPPER_REQUEST_TIMEOUT = 60 * 90
+    ZAPPER_CONNECTION_TIMEOUT = 30
+    ZAPPER_READ_TIMEOUT = 60 * 90
     ZAPPER_REST_PORT = 8000
 
     def _api_post(self, endpoint: str, **kwargs) -> requests.Response:
@@ -190,9 +191,9 @@ class ZapperConnector(ABC, DefaultDevice):
 
         logger.info("BEGIN provision")
         logger.info("Provisioning device")
-        self.ZAPPER_REQUEST_TIMEOUT = self.job_data["provision_data"].get(
+        self.ZAPPER_READ_TIMEOUT = self.job_data["provision_data"].get(
             "zapper_provisioning_timeout",
-            self.ZAPPER_REQUEST_TIMEOUT,
+            self.ZAPPER_READ_TIMEOUT,
         )
 
         (api_args, api_kwargs) = self._validate_configuration()
@@ -242,9 +243,8 @@ class ZapperConnector(ABC, DefaultDevice):
             f"http://{zapper_ip}:{self.ZAPPER_REST_PORT}"
             f"/api/v1/provision/{job_id}/logs"
         )
-        with requests.get(
-            url, stream=True, timeout=self.ZAPPER_REQUEST_TIMEOUT
-        ) as sse:
+        timeout = (self.ZAPPER_CONNECTION_TIMEOUT, self.ZAPPER_READ_TIMEOUT)
+        with requests.get(url, stream=True, timeout=timeout) as sse:
             for line in sse.iter_lines(decode_unicode=True):
                 if line.startswith("data: "):
                     entry = json.loads(line[6:])

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -251,7 +251,11 @@ class ZapperConnector(ABC, DefaultDevice):
                 if not line.startswith("data: "):
                     logger.warning("Unexpected SSE line: %s", line)
                     continue
-                entry = json.loads(line[6:])
+                try:
+                    entry = json.loads(line[6:])
+                except json.JSONDecodeError:
+                    logger.warning("Malformed SSE data: %s", line)
+                    continue
                 log_level = getattr(logging, entry["level"], logging.INFO)
                 logger.log(log_level, entry["message"])
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -238,41 +238,59 @@ class ZapperConnector(ABC, DefaultDevice):
         job = resp.json()
         job_id = job["job_id"]
 
-        # Stream SSE (Server-Sent Events) logs.
-        # The SSE protocol sends newline-delimited lines in the format:
-        #   data: {"level": "INFO", "message": "..."}
-        # Empty lines act as event separators and are skipped.
-        # Lines not starting with "data: " (e.g. "event:", "retry:")
-        # are non-standard for this endpoint and logged as warnings.
         url = (
             f"http://{zapper_ip}:{self.ZAPPER_REST_PORT}"
             f"/api/v1/provision/{job_id}/logs"
         )
-        sse_data_prefix = "data: "
         timeout = (self.ZAPPER_CONNECTION_TIMEOUT, self.ZAPPER_READ_TIMEOUT)
-        with requests.get(url, stream=True, timeout=timeout) as sse:
-            for line in sse.iter_lines(decode_unicode=True):
-                if not line:
-                    continue
-                if not line.startswith(sse_data_prefix):
-                    logger.warning("Unexpected SSE line: %s", line)
-                    continue
-                try:
-                    entry = json.loads(line[len(sse_data_prefix) :])
-                except json.JSONDecodeError:
-                    logger.warning("Malformed SSE data: %s", line)
-                    continue
-                log_level = getattr(
-                    logging, entry.get("level", "").upper(), logging.INFO
-                )
-                logger.log(log_level, entry.get("message", line))
+        while True:
+            with requests.get(url, stream=True, timeout=timeout) as sse:
+                self._stream_sse_logs(sse)
 
-        # Check final status
-        status = self._api_get(f"/api/v1/provision/{job_id}").json()
-        if status["status"] != "completed":
-            raise ProvisioningError(
-                status.get("error", "Provisioning failed for unknown reason.")
+            # Check job status after the SSE stream ends
+            status = self._api_get(f"/api/v1/provision/{job_id}").json()
+            if status["status"] == "running":
+                logger.warning(
+                    "SSE stream disconnected but job %s is still running,"
+                    " reconnecting...",
+                    job_id,
+                )
+                continue
+            if status["status"] != "completed":
+                raise ProvisioningError(
+                    status.get(
+                        "error",
+                        "Provisioning failed for unknown reason.",
+                    )
+                )
+            break
+
+    @staticmethod
+    def _stream_sse_logs(response: requests.Response) -> None:
+        """Parse and log Server-Sent Events from a streaming response.
+
+        The SSE protocol sends newline-delimited lines in the format:
+            data: {"level": "INFO", "message": "..."}
+        Empty lines act as event separators and are skipped.
+        Lines not starting with "data: " (e.g. "event:", "retry:")
+        are non-standard for this endpoint and logged as warnings.
+        """
+        sse_data_prefix = "data: "
+        for line in response.iter_lines(decode_unicode=True):
+            if not line:
+                continue
+            if not line.startswith(sse_data_prefix):
+                logger.warning("Unexpected SSE line: %s", line)
+                continue
+            try:
+                entry = json.loads(line[len(sse_data_prefix) :])
+            except json.JSONDecodeError:
+                logger.warning("Malformed SSE data: %s", line)
+                continue
+            log_level = getattr(
+                logging, entry.get("level", "").upper(), logging.INFO
             )
+            logger.log(log_level, entry.get("message", line))
 
     def _copy_ssh_id(self):
         """Copy the ssh id to the device."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -108,7 +108,7 @@ class ZapperConnector(ABC, DefaultDevice):
         try:
             url = (
                 f"http://{host}:{ZapperConnector.ZAPPER_REST_PORT}"
-                f"/api/v1/addons/"
+                f"/api/v1/health"
             )
             resp = requests.get(url, timeout=3)
             resp.raise_for_status()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -13,7 +13,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for Zapper base device connector."""
 
-import subprocess
 import unittest
 from unittest.mock import Mock, patch
 
@@ -21,10 +20,7 @@ import pytest
 import requests
 
 from testflinger_device_connectors.devices import ProvisioningError
-from testflinger_device_connectors.devices.zapper import (
-    ZapperConnector,
-    logger,
-)
+from testflinger_device_connectors.devices.zapper import ZapperConnector
 
 
 class MockConnector(ZapperConnector):
@@ -40,10 +36,11 @@ class MockConnector(ZapperConnector):
 class ZapperConnectorTests(unittest.TestCase):
     """Unit tests for ZapperConnector class."""
 
-    @patch("rpyc.connect")
-    def test_run(self, mock_connect):
-        """Test the `run` function connects to a Zapper via RPyC
-        and runs the `provision` API.
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_run(self, mock_post, mock_get):
+        """Test the `run` function submits a provisioning job via REST,
+        streams SSE logs, and checks final status.
         """
         args = (1, 2, 3)
         kwargs = {"key1": 1, "key2": 2}
@@ -56,21 +53,34 @@ class ZapperConnectorTests(unittest.TestCase):
             "env": {"CID": "202507-01234"},
         }
         connector = MockConnector(fake_config)
+
+        # Mock POST /api/v1/provision response
+        mock_post.return_value.raise_for_status = Mock()
+        mock_post.return_value.json.return_value = {"job_id": "job-123"}
+
+        # Mock SSE stream (no log lines)
+        mock_sse = Mock()
+        mock_sse.iter_lines.return_value = []
+        mock_sse.__enter__ = Mock(return_value=mock_sse)
+        mock_sse.__exit__ = Mock(return_value=False)
+
+        # Mock GET /api/v1/provision/job-123 (status check)
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+
+        mock_get.side_effect = [mock_sse, mock_status]
+
         connector._run("localhost", *args, **kwargs)
 
-        api = mock_connect.return_value.root.provision
-
-        kwargs["device_ip"] = "1.1.1.1"
-        kwargs["agent_name"] = "my-agent"
-        kwargs["reboot_script"] = ["cmd1", "cmd2"]
-        kwargs["cid"] = "202507-01234"
-
-        api.assert_called_with(
-            MockConnector.PROVISION_METHOD,
-            *args,
-            logger=logger,
-            **kwargs,
-        )
+        # Verify POST was called with correct provisioning payload
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs[1]["json"]
+        self.assertEqual(payload["method"], "Test")
+        self.assertEqual(payload["args"], [1, 2, 3])
+        self.assertIn("device_ip", payload["kwargs"])
+        self.assertIn("agent_name", payload["kwargs"])
 
     def test_copy_ssh_id(self):
         """Test the function collects the device info from
@@ -114,35 +124,39 @@ class ZapperConnectorTests(unittest.TestCase):
             connector._copy_ssh_id()
 
 
-class TestZapperConnectorRpycCheck:
-    """Tests for ZapperConnector RPyC server check."""
+class TestZapperConnectorRestApiCheck:
+    """Tests for ZapperConnector REST API health check."""
 
-    def test_check_rpyc_server_on_host_success(self, mocker):
-        """Test _check_rpyc_server_on_host succeeds when port is open."""
-        mock_subprocess = mocker.patch("subprocess.run")
+    def test_check_rest_api_on_host_success(self, mocker):
+        """Test _check_rest_api_on_host succeeds when API is reachable."""
+        mock_get = mocker.patch("requests.get")
+        mock_get.return_value.raise_for_status = Mock()
 
-        ZapperConnector._check_rpyc_server_on_host("test-host")
+        ZapperConnector._check_rest_api_on_host("test-host")
 
-        mock_subprocess.assert_called_once()
-        call_args = mock_subprocess.call_args
-        assert call_args[0][0] == [
-            "/usr/bin/nc",
-            "-z",
-            "-w",
-            "3",
-            "test-host",
-            "60000",
-        ]
+        mock_get.assert_called_once_with(
+            "http://test-host:8000/api/v1/addons/", timeout=3
+        )
 
-    def test_check_rpyc_server_on_host_raises_connection_error(self, mocker):
+    def test_check_rest_api_on_host_raises_connection_error(self, mocker):
         """Test the function raises ConnectionError on failure."""
         mocker.patch(
-            "subprocess.run",
-            side_effect=subprocess.CalledProcessError(1, "nc"),
+            "requests.get",
+            side_effect=requests.ConnectionError,
         )
 
         with pytest.raises(ConnectionError):
-            ZapperConnector._check_rpyc_server_on_host("test-host")
+            ZapperConnector._check_rest_api_on_host("test-host")
+
+    def test_check_rest_api_on_host_raises_on_timeout(self, mocker):
+        """Test the function raises ConnectionError on timeout."""
+        mocker.patch(
+            "requests.get",
+            side_effect=requests.Timeout,
+        )
+
+        with pytest.raises(ConnectionError):
+            ZapperConnector._check_rest_api_on_host("test-host")
 
     def test_wait_ready_success(self, mocker):
         """Test wait_ready calls wait_online with correct parameters."""
@@ -153,7 +167,7 @@ class TestZapperConnectorRpycCheck:
         ZapperConnector.wait_ready("zapper-host", timeout=30)
 
         mock_wait_online.assert_called_once_with(
-            ZapperConnector._check_rpyc_server_on_host, "zapper-host", 30
+            ZapperConnector._check_rest_api_on_host, "zapper-host", 30
         )
 
     def test_wait_ready_timeout(self, mocker):
@@ -172,35 +186,55 @@ class TestZapperConnectorTypecmux:
     """Tests for ZapperConnector typecmux operations."""
 
     def test_typecmux_set_state_success(self, mocker):
-        """Test typecmux_set_state connects and calls the remote method."""
-        mock_connect = mocker.patch("rpyc.connect")
-        mock_connection = Mock()
-        mock_connect.return_value = mock_connection
+        """Test typecmux_set_state queries addons and sets state via REST."""
+        mock_get = mocker.patch("requests.get")
+        mock_put = mocker.patch("requests.put")
+
+        mock_get.return_value.raise_for_status = Mock()
+        mock_get.return_value.json.return_value = {
+            "addons": [{"addr": "0x42"}]
+        }
+        mock_put.return_value.raise_for_status = Mock()
 
         ZapperConnector.typecmux_set_state("zapper-host", "OFF")
 
-        mock_connect.assert_called_once_with(
-            "zapper-host",
-            60000,
-            config={
-                "allow_public_attrs": True,
-                "sync_request_timeout": 60,
-            },
+        mock_get.assert_called_once_with(
+            "http://zapper-host:8000/api/v1/addons/",
+            params={"addon_type": "TYPEC_MUX"},
+            timeout=10,
         )
-        mock_connection.root.typecmux_set_state.assert_called_once_with(
-            alias="default", state="OFF"
+        mock_put.assert_called_once_with(
+            "http://zapper-host:8000/api/v1/addons/0x42/typecmux/state",
+            json={"state": "OFF"},
+            timeout=10,
         )
+
+    def test_typecmux_set_state_no_addons(self, mocker):
+        """Test typecmux_set_state raises when no TYPEC_MUX addon found."""
+        mock_get = mocker.patch("requests.get")
+        mock_get.return_value.raise_for_status = Mock()
+        mock_get.return_value.json.return_value = {"addons": []}
+
+        with pytest.raises(RuntimeError, match="No TYPEC_MUX addon"):
+            ZapperConnector.typecmux_set_state("zapper-host", "OFF")
 
     def test_typecmux_set_state_with_dut(self, mocker):
         """Test typecmux_set_state with DUT state."""
-        mock_connect = mocker.patch("rpyc.connect")
-        mock_connection = Mock()
-        mock_connect.return_value = mock_connection
+        mock_get = mocker.patch("requests.get")
+        mock_put = mocker.patch("requests.put")
+
+        mock_get.return_value.raise_for_status = Mock()
+        mock_get.return_value.json.return_value = {
+            "addons": [{"addr": "0x42"}]
+        }
+        mock_put.return_value.raise_for_status = Mock()
 
         ZapperConnector.typecmux_set_state("zapper-host", "DUT")
 
-        mock_connection.root.typecmux_set_state.assert_called_once_with(
-            alias="default", state="DUT"
+        mock_put.assert_called_once_with(
+            "http://zapper-host:8000/api/v1/addons/0x42/typecmux/state",
+            json={"state": "DUT"},
+            timeout=10,
         )
 
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -13,6 +13,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for Zapper base device connector."""
 
+import json
+import logging
 import unittest
 from unittest.mock import Mock, patch
 
@@ -329,3 +331,251 @@ class TestZapperConnectorRestApi:
         connector = MockConnector({"control_host": "zapper-host"})
         with pytest.raises(requests.HTTPError):
             connector._api_post("/api/v1/system/poweroff")
+
+
+class TestZapperConnectorRun:
+    """Tests for ZapperConnector._run SSE streaming and job lifecycle."""
+
+    @pytest.fixture()
+    def connector(self):
+        config = {
+            "device_ip": "1.1.1.1",
+            "agent_name": "my-agent",
+            "control_host": "zapper-host",
+            "reboot_script": ["cmd1"],
+            "env": {"CID": "202507-01234"},
+        }
+        return MockConnector(config)
+
+    @pytest.fixture()
+    def mock_post(self, mocker):
+        mock = mocker.patch("requests.post")
+        mock.return_value.raise_for_status = Mock()
+        mock.return_value.json.return_value = {"job_id": "job-123"}
+        return mock
+
+    def _make_sse(self, lines):
+        """Create a mock SSE response context manager."""
+        mock_sse = Mock()
+        mock_sse.iter_lines.return_value = lines
+        mock_sse.__enter__ = Mock(return_value=mock_sse)
+        mock_sse.__exit__ = Mock(return_value=False)
+        return mock_sse
+
+    def test_run_uses_separate_connection_and_read_timeouts(
+        self, mocker, connector, mock_post
+    ):
+        """Test that SSE streaming uses a (connect, read) timeout tuple."""
+        mock_get = mocker.patch("requests.get")
+        mock_sse = self._make_sse([])
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        connector._run("localhost")
+
+        # First call is the SSE stream
+        sse_call = mock_get.call_args_list[0]
+        assert sse_call[1]["timeout"] == (
+            connector.ZAPPER_CONNECTION_TIMEOUT,
+            connector.ZAPPER_READ_TIMEOUT,
+        )
+
+    def test_run_streams_sse_log_lines(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that valid SSE data lines are logged at the correct level."""
+        mock_get = mocker.patch("requests.get")
+
+        lines = [
+            'data: {"level": "INFO", "message": "Starting provisioning"}',
+            'data: {"level": "WARNING", "message": "Disk space low"}',
+        ]
+        mock_sse = self._make_sse(lines)
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with caplog.at_level(logging.DEBUG):
+            connector._run("localhost")
+
+        assert "Starting provisioning" in caplog.text
+        assert "Disk space low" in caplog.text
+
+    def test_run_logs_unexpected_non_data_lines(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that non-'data:' SSE lines are logged as warnings."""
+        mock_get = mocker.patch("requests.get")
+
+        lines = [
+            "event: error",
+            "retry: 3000",
+            'data: {"level": "INFO", "message": "ok"}',
+        ]
+        mock_sse = self._make_sse(lines)
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with caplog.at_level(logging.WARNING):
+            connector._run("localhost")
+
+        assert "Unexpected SSE line: event: error" in caplog.text
+        assert "Unexpected SSE line: retry: 3000" in caplog.text
+
+    def test_run_skips_empty_lines(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that empty SSE lines are silently skipped."""
+        mock_get = mocker.patch("requests.get")
+
+        lines = [
+            "",
+            'data: {"level": "INFO", "message": "ok"}',
+            "",
+        ]
+        mock_sse = self._make_sse(lines)
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with caplog.at_level(logging.WARNING):
+            connector._run("localhost")
+
+        assert "Unexpected SSE line" not in caplog.text
+
+    def test_run_handles_malformed_json(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that malformed JSON in SSE data is logged as a warning."""
+        mock_get = mocker.patch("requests.get")
+
+        lines = [
+            "data: {not valid json",
+            'data: {"level": "INFO", "message": "ok"}',
+        ]
+        mock_sse = self._make_sse(lines)
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with caplog.at_level(logging.DEBUG):
+            connector._run("localhost")
+
+        assert "Malformed SSE data" in caplog.text
+        assert "ok" in caplog.text
+
+    def test_run_handles_missing_level_key(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that a missing 'level' key defaults to INFO."""
+        mock_get = mocker.patch("requests.get")
+
+        lines = ['data: {"message": "no level here"}']
+        mock_sse = self._make_sse(lines)
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with caplog.at_level(logging.INFO):
+            connector._run("localhost")
+
+        assert "no level here" in caplog.text
+
+    def test_run_handles_missing_message_key(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that a missing 'message' key falls back to raw line."""
+        mock_get = mocker.patch("requests.get")
+
+        raw_line = 'data: {"level": "INFO"}'
+        lines = [raw_line]
+        mock_sse = self._make_sse(lines)
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with caplog.at_level(logging.INFO):
+            connector._run("localhost")
+
+        assert raw_line in caplog.text
+
+    def test_run_handles_invalid_log_level(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that an unrecognized log level defaults to INFO."""
+        mock_get = mocker.patch("requests.get")
+
+        lines = ['data: {"level": "ERRROR", "message": "typo level"}']
+        mock_sse = self._make_sse(lines)
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with caplog.at_level(logging.INFO):
+            connector._run("localhost")
+
+        assert "typo level" in caplog.text
+
+    def test_run_handles_lowercase_log_level(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that lowercase log levels are normalized with .upper()."""
+        mock_get = mocker.patch("requests.get")
+
+        lines = ['data: {"level": "warning", "message": "low case"}']
+        mock_sse = self._make_sse(lines)
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with caplog.at_level(logging.WARNING):
+            connector._run("localhost")
+
+        assert "low case" in caplog.text
+
+    def test_run_raises_on_failed_status(
+        self, mocker, connector, mock_post
+    ):
+        """Test that _run raises ProvisioningError on non-completed status."""
+        mock_get = mocker.patch("requests.get")
+
+        mock_sse = self._make_sse([])
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {
+            "status": "failed",
+            "error": "Device unreachable",
+        }
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with pytest.raises(ProvisioningError, match="Device unreachable"):
+            connector._run("localhost")
+
+    def test_run_raises_with_default_message_on_missing_error(
+        self, mocker, connector, mock_post
+    ):
+        """Test that a missing 'error' key uses a default error message."""
+        mock_get = mocker.patch("requests.get")
+
+        mock_sse = self._make_sse([])
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "failed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        with pytest.raises(
+            ProvisioningError,
+            match="Provisioning failed for unknown reason.",
+        ):
+            connector._run("localhost")

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -392,7 +392,9 @@ class TestZapperConnectorRun:
     def test_run_streams_sse_log_lines(
         self, mocker, connector, mock_post, caplog
     ):
-        """Test that valid SSE data lines are logged at the correct level."""
+        """Test that valid SSE data lines are logged with [zapper] prefix
+        at the correct level.
+        """
         mock_get = mocker.patch("requests.get")
 
         lines = [
@@ -408,8 +410,17 @@ class TestZapperConnectorRun:
         with caplog.at_level(logging.DEBUG):
             connector._run()
 
-        assert "Starting provisioning" in caplog.text
-        assert "Disk space low" in caplog.text
+        assert "[zapper] Starting provisioning" in caplog.text
+        assert "[zapper] Disk space low" in caplog.text
+        # Verify log levels are correct
+        info_record = next(
+            r for r in caplog.records if "Starting provisioning" in r.message
+        )
+        warn_record = next(
+            r for r in caplog.records if "Disk space low" in r.message
+        )
+        assert info_record.levelno == logging.INFO
+        assert warn_record.levelno == logging.WARNING
 
     def test_run_logs_unexpected_non_data_lines(
         self, mocker, connector, mock_post, caplog
@@ -489,10 +500,14 @@ class TestZapperConnectorRun:
         mock_status.json.return_value = {"status": "completed"}
         mock_get.side_effect = [mock_sse, mock_status]
 
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.DEBUG):
             connector._run()
 
-        assert "no level here" in caplog.text
+        assert "[zapper] no level here" in caplog.text
+        record = next(
+            r for r in caplog.records if "no level here" in r.message
+        )
+        assert record.levelno == logging.INFO
 
     def test_run_handles_missing_message_key(
         self, mocker, connector, mock_post, caplog
@@ -511,12 +526,12 @@ class TestZapperConnectorRun:
         with caplog.at_level(logging.INFO):
             connector._run()
 
-        assert raw_line in caplog.text
+        assert f"[zapper] {raw_line}" in caplog.text
 
     def test_run_handles_invalid_log_level(
         self, mocker, connector, mock_post, caplog
     ):
-        """Test that an unrecognized log level defaults to INFO."""
+        """Test that an unrecognized log level warns and defaults to INFO."""
         mock_get = mocker.patch("requests.get")
 
         lines = ['data: {"level": "ERRROR", "message": "typo level"}']
@@ -526,10 +541,12 @@ class TestZapperConnectorRun:
         mock_status.json.return_value = {"status": "completed"}
         mock_get.side_effect = [mock_sse, mock_status]
 
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.DEBUG):
             connector._run()
 
-        assert "typo level" in caplog.text
+        assert "Unknown log level 'ERRROR'" in caplog.text
+        record = next(r for r in caplog.records if "typo level" in r.message)
+        assert record.levelno == logging.INFO
 
     def test_run_handles_lowercase_log_level(
         self, mocker, connector, mock_post, caplog
@@ -547,7 +564,9 @@ class TestZapperConnectorRun:
         with caplog.at_level(logging.WARNING):
             connector._run()
 
-        assert "low case" in caplog.text
+        assert "[zapper] low case" in caplog.text
+        record = next(r for r in caplog.records if "low case" in r.message)
+        assert record.levelno == logging.WARNING
 
     def test_run_reconnects_when_job_still_running(
         self, mocker, connector, mock_post, caplog

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -136,7 +136,7 @@ class TestZapperConnectorRestApiCheck:
         ZapperConnector._check_rest_api_on_host("test-host")
 
         mock_get.assert_called_once_with(
-            "http://test-host:8000/api/v1/health", timeout=3
+            "http://test-host:8000/health", timeout=3
         )
 
     def test_check_rest_api_on_host_raises_connection_error(self, mocker):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -136,7 +136,7 @@ class TestZapperConnectorRestApiCheck:
         ZapperConnector._check_rest_api_on_host("test-host")
 
         mock_get.assert_called_once_with(
-            "http://test-host:8000/api/v1/addons/", timeout=3
+            "http://test-host:8000/api/v1/health", timeout=3
         )
 
     def test_check_rest_api_on_host_raises_connection_error(self, mocker):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -72,7 +72,7 @@ class ZapperConnectorTests(unittest.TestCase):
 
         mock_get.side_effect = [mock_sse, mock_status]
 
-        connector._run("localhost", *args, **kwargs)
+        connector._run(*args, **kwargs)
 
         # Verify POST was called with correct provisioning payload
         mock_post.assert_called_once()
@@ -155,6 +155,14 @@ class TestZapperConnectorRestApiCheck:
             "requests.get",
             side_effect=requests.Timeout,
         )
+
+        with pytest.raises(ConnectionError):
+            ZapperConnector._check_rest_api_on_host("test-host")
+
+    def test_check_rest_api_on_host_raises_on_http_error(self, mocker):
+        """Test the function raises ConnectionError on non-2xx response."""
+        mock_get = mocker.patch("requests.get")
+        mock_get.return_value.raise_for_status.side_effect = requests.HTTPError
 
         with pytest.raises(ConnectionError):
             ZapperConnector._check_rest_api_on_host("test-host")
@@ -372,7 +380,7 @@ class TestZapperConnectorRun:
         mock_status.json.return_value = {"status": "completed"}
         mock_get.side_effect = [mock_sse, mock_status]
 
-        connector._run("localhost")
+        connector._run()
 
         # First call is the SSE stream
         sse_call = mock_get.call_args_list[0]
@@ -398,7 +406,7 @@ class TestZapperConnectorRun:
         mock_get.side_effect = [mock_sse, mock_status]
 
         with caplog.at_level(logging.DEBUG):
-            connector._run("localhost")
+            connector._run()
 
         assert "Starting provisioning" in caplog.text
         assert "Disk space low" in caplog.text
@@ -421,7 +429,7 @@ class TestZapperConnectorRun:
         mock_get.side_effect = [mock_sse, mock_status]
 
         with caplog.at_level(logging.WARNING):
-            connector._run("localhost")
+            connector._run()
 
         assert "Unexpected SSE line: event: error" in caplog.text
         assert "Unexpected SSE line: retry: 3000" in caplog.text
@@ -442,7 +450,7 @@ class TestZapperConnectorRun:
         mock_get.side_effect = [mock_sse, mock_status]
 
         with caplog.at_level(logging.WARNING):
-            connector._run("localhost")
+            connector._run()
 
         assert "Unexpected SSE line" not in caplog.text
 
@@ -463,7 +471,7 @@ class TestZapperConnectorRun:
         mock_get.side_effect = [mock_sse, mock_status]
 
         with caplog.at_level(logging.DEBUG):
-            connector._run("localhost")
+            connector._run()
 
         assert "Malformed SSE data" in caplog.text
         assert "ok" in caplog.text
@@ -482,7 +490,7 @@ class TestZapperConnectorRun:
         mock_get.side_effect = [mock_sse, mock_status]
 
         with caplog.at_level(logging.INFO):
-            connector._run("localhost")
+            connector._run()
 
         assert "no level here" in caplog.text
 
@@ -501,7 +509,7 @@ class TestZapperConnectorRun:
         mock_get.side_effect = [mock_sse, mock_status]
 
         with caplog.at_level(logging.INFO):
-            connector._run("localhost")
+            connector._run()
 
         assert raw_line in caplog.text
 
@@ -519,7 +527,7 @@ class TestZapperConnectorRun:
         mock_get.side_effect = [mock_sse, mock_status]
 
         with caplog.at_level(logging.INFO):
-            connector._run("localhost")
+            connector._run()
 
         assert "typo level" in caplog.text
 
@@ -537,7 +545,7 @@ class TestZapperConnectorRun:
         mock_get.side_effect = [mock_sse, mock_status]
 
         with caplog.at_level(logging.WARNING):
-            connector._run("localhost")
+            connector._run()
 
         assert "low case" in caplog.text
 
@@ -575,7 +583,7 @@ class TestZapperConnectorRun:
         ]
 
         with caplog.at_level(logging.DEBUG):
-            connector._run("localhost")
+            connector._run()
 
         assert "step 1" in caplog.text
         assert "still running" in caplog.text
@@ -595,7 +603,7 @@ class TestZapperConnectorRun:
         mock_get.side_effect = [mock_sse, mock_status]
 
         with pytest.raises(ProvisioningError, match="Device unreachable"):
-            connector._run("localhost")
+            connector._run()
 
     def test_run_raises_with_default_message_on_missing_error(
         self, mocker, connector, mock_post
@@ -613,4 +621,4 @@ class TestZapperConnectorRun:
             ProvisioningError,
             match="Provisioning failed for unknown reason.",
         ):
-            connector._run("localhost")
+            connector._run()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -13,7 +13,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for Zapper base device connector."""
 
-import json
 import logging
 import unittest
 from unittest.mock import Mock, patch
@@ -427,9 +426,7 @@ class TestZapperConnectorRun:
         assert "Unexpected SSE line: event: error" in caplog.text
         assert "Unexpected SSE line: retry: 3000" in caplog.text
 
-    def test_run_skips_empty_lines(
-        self, mocker, connector, mock_post, caplog
-    ):
+    def test_run_skips_empty_lines(self, mocker, connector, mock_post, caplog):
         """Test that empty SSE lines are silently skipped."""
         mock_get = mocker.patch("requests.get")
 
@@ -544,9 +541,7 @@ class TestZapperConnectorRun:
 
         assert "low case" in caplog.text
 
-    def test_run_raises_on_failed_status(
-        self, mocker, connector, mock_post
-    ):
+    def test_run_raises_on_failed_status(self, mocker, connector, mock_post):
         """Test that _run raises ProvisioningError on non-completed status."""
         mock_get = mocker.patch("requests.get")
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -541,6 +541,46 @@ class TestZapperConnectorRun:
 
         assert "low case" in caplog.text
 
+    def test_run_reconnects_when_job_still_running(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that _run reconnects to SSE stream if the job is still
+        running after a disconnection.
+        """
+        mock_get = mocker.patch("requests.get")
+
+        # First SSE stream disconnects with partial logs
+        sse_1 = self._make_sse(
+            ['data: {"level": "INFO", "message": "step 1"}']
+        )
+        # Status check shows still running
+        status_running = Mock()
+        status_running.raise_for_status = Mock()
+        status_running.json.return_value = {"status": "running"}
+
+        # Second SSE stream delivers remaining logs
+        sse_2 = self._make_sse(
+            ['data: {"level": "INFO", "message": "step 2"}']
+        )
+        # Status check shows completed
+        status_completed = Mock()
+        status_completed.raise_for_status = Mock()
+        status_completed.json.return_value = {"status": "completed"}
+
+        mock_get.side_effect = [
+            sse_1,
+            status_running,
+            sse_2,
+            status_completed,
+        ]
+
+        with caplog.at_level(logging.DEBUG):
+            connector._run("localhost")
+
+        assert "step 1" in caplog.text
+        assert "still running" in caplog.text
+        assert "step 2" in caplog.text
+
     def test_run_raises_on_failed_status(self, mocker, connector, mock_post):
         """Test that _run raises ProvisioningError on non-completed status."""
         mock_get = mocker.patch("requests.get")

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -59,7 +59,7 @@ class DeviceConnector(ZapperConnector):
             self._api_post("/api/v1/system/poweroff", timeout=10)
             with contextlib.suppress(TimeoutError):
                 ZapperConnector.wait_offline(
-                    ZapperConnector._check_rpyc_server_on_host,
+                    ZapperConnector._check_rest_api_on_host,
                     control_host,
                     30,
                 )

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -613,7 +613,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "/api/v1/system/poweroff", timeout=10
         )
         mock_wait_offline.assert_called_once_with(
-            ZapperConnector._check_rpyc_server_on_host,
+            ZapperConnector._check_rest_api_on_host,
             "zapper-host",
             30,
         )

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -602,7 +602,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
     def test_pre_provision_hook_poweroff(
         self, mock_api_post, mock_wait_offline, mock_reboot, mock_wait_ready
     ):
-        """Test pre_provision_hook sends poweroff, waits for RPyC to
+        """Test pre_provision_hook sends poweroff, waits for Zapper to
         go down, reboots control host, then waits for it to come back.
         """
         connector = DeviceConnector({"control_host": "zapper-host"})

--- a/device-connectors/uv.lock
+++ b/device-connectors/uv.lock
@@ -262,18 +262,6 @@ wheels = [
 ]
 
 [[package]]
-name = "plumbum"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/c8/11a5f792704b70f071a3dbc329105a98e9cc8d25daaf09f733c44eb0ef8e/plumbum-1.10.0.tar.gz", hash = "sha256:f8cbf0ecec0b73ff4e349398b65112a9e3f9300e7dc019001217dcc148d5c97c", size = 320039, upload-time = "2025-10-31T05:02:48.697Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/ad/45312df6b63ba64ea35b8d8f5f0c577aac16e6b416eafe8e1cb34e03f9a7/plumbum-1.10.0-py3-none-any.whl", hash = "sha256:9583d737ac901c474d99d030e4d5eec4c4e6d2d7417b1cf49728cf3be34f6dc8", size = 127383, upload-time = "2025-10-31T05:02:47.002Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -324,28 +312,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
-]
-
-[[package]]
-name = "pywin32"
-version = "311"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
-    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
-    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
-    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -428,18 +394,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rpyc"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "plumbum" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/e0/a584823afecc5d8a0c18c46da4e028876e3e34946e6e3b2c3d430cd19b18/rpyc-5.3.1.tar.gz", hash = "sha256:f2233174879faf18ae266437d5a65511ce46c817cec4edc1344f036758cfbf52", size = 61611, upload-time = "2023-02-22T03:45:02.967Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/d8/715206e54dfc54177d126f05b6ecc9526891b11ac7a4bafdb1ae4df55eab/rpyc-5.3.1-py3-none-any.whl", hash = "sha256:6e8153792ac221a80f420d2e0b241a10c6e43b105d325998b18a4e7af329f9ec", size = 74036, upload-time = "2023-02-22T03:45:00.933Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -471,7 +425,6 @@ source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "rpyc" },
     { name = "typing-extensions" },
     { name = "validators" },
 ]
@@ -488,7 +441,6 @@ dev = [
 requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
-    { name = "rpyc", specifier = "<6" },
     { name = "typing-extensions", specifier = "~=4.15.0" },
     { name = "validators", specifier = ">=0.34.0" },
 ]


### PR DESCRIPTION
## Description

As per title, this PR migrate access to the control host from RPyC to REST: it should be transparent to the user.

## Resolved issues

https://github.com/canonical/testflinger/security/dependabot/20
https://github.com/canonical/testflinger/security/dependabot/30

## Documentation

N/A

## Web service API changes

N/A

## Tests

*Pending*
