### PR TITLE
fix(agent-charm): set ActiveStatus on_secret_changed

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -202,7 +202,9 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         secret = self.typed_config.credentials_secret
         if secret and event.secret.id == secret.id:
             logger.info("Credentials secret changed, re-authenticating")
-            self._update_refresh_token()
+            if not self._update_refresh_token():
+                return
+            self.unit.status = ops.ActiveStatus()
 
     def _on_update_status(self, _):
         """Periodically check token expiration and re-authenticate if needed.
@@ -271,6 +273,7 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         ):
             return self._block("Authentication with Testflinger server failed")
 
+        logger.info("Authentication with Testflinger server succeeded")
         return True
 
     def on_config_changed(self, _):

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -163,6 +163,34 @@ def test_authentication_triggered_on_secret_change(
     mock_authenticate_with_server.assert_called_once()
 
 
+@patch("testflinger_client.authenticate", return_value=True)
+def test_secret_changed_active_on_successful_authentication(
+    mock_authenticate, ctx, state_in, secret
+):
+    """Test active status when secret changes and authentication succeeds."""
+    state = state_in(
+        config={"credentials-secret": secret.id},
+        secrets=[secret],
+    )
+    state_out = ctx.run(ctx.on.secret_changed(secret), state=state)
+    assert state_out.unit_status == testing.ActiveStatus()
+
+
+@patch("testflinger_client.authenticate", return_value=False)
+def test_secret_changed_blocked_on_authentication_failure(
+    mock_authenticate, ctx, state_in, secret
+):
+    """Test blocked status when secret changes but authentication fails."""
+    state = state_in(
+        config={"credentials-secret": secret.id},
+        secrets=[secret],
+    )
+    state_out = ctx.run(ctx.on.secret_changed(secret), state=state)
+    assert state_out.unit_status == testing.BlockedStatus(
+        "Authentication with Testflinger server failed"
+    )
+
+
 @patch("charm.TestflingerAgentHostCharm._authenticate_with_server")
 def test_authentication_triggered_on_update_status(
     mock_authenticate_with_server, ctx, state_in

--- a/docs/how-to/administer-agent-hosts/deploy-testflinger-agent-host.rst
+++ b/docs/how-to/administer-agent-hosts/deploy-testflinger-agent-host.rst
@@ -141,24 +141,31 @@ Create a Juju secret with the necessary key/value pairs and take note of the sec
 
 .. code-block:: shell
 
-  $ juju add-secret <secret_name> client-id='<client_id>' client-secret='<client_secret>'
+  $ juju add-secret <secret_name> client-id='<client_id>' secret-key='<client_secret>'
   secret:<secret URI>
 
 .. note::
 
-  The keys in the secret must be ``client-id`` and ``client-secret`` as shown above.
+  The keys in the secret must be ``client-id`` and ``secret-key`` as shown above.
 
 Grant the Testflinger agent host application access to the secret.
 
 .. code-block:: shell
 
-  $ juju grant-access <agent-host-application> secret:<secret URI>
+  $ juju grant-secret <secret URI>|<name> <agent-host-application>
 
 Finally, add the secret URI to the agent host charm's configuration:
 
 .. code-block:: shell
 
   $ juju config <agent-host-application> credentials-secret='secret:<secret URI>'
+
+.. tip::
+
+  You can also specify the config option while refreshing the charm application:
+
+  ``$ juju refresh <agent-host-application> --config credentials-secret='secret:<secret URI>'``
+
 
 For more information on how to manage Juju secrets, refer to the `Juju Secrets documentation <https://documentation.ubuntu.com/juju/3.6/howto/manage-secrets/>`_.
 


### PR DESCRIPTION
## Description
While following the docs, realized I made a typo in the keys required (just in docs), this of course lead to a blocked unit with Invalid Secret. Updating the secret authenticated the unit but did not clear automatically the BlockedStatus. 

Impact is minimal as on next `update-status` hook, this is set to Active but adding the fix for intended behavior. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
Updated Docs with correct keys and a tip during application refresh. 
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added couple of unit tests for `on_secret_changed()`
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
