### PR TITLE
[New] send SSH keys as a dedicated argument

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -91,8 +91,7 @@ class DeviceConnector(ZapperConnector):
         """Autoinstall-related keys are pre-fixed with `autoinstall_`.
 
         If any of those arguments are provided and valid, the function
-        returns an autoinstall_conf dictionary, including the agent
-        SSH public key.
+        returns an autoinstall_conf dictionary.
         """
         autoinstall_conf = {}
 
@@ -132,8 +131,6 @@ class DeviceConnector(ZapperConnector):
         if not autoinstall_conf:
             logger.info("Autoinstall-related keys were not provided.")
             return None
-
-        autoinstall_conf["authorized_keys"] = [self._read_ssh_key()]
 
         return autoinstall_conf
 
@@ -199,6 +196,8 @@ class DeviceConnector(ZapperConnector):
             provision_data["robot_tasks"] = self.job_data["provision_data"][
                 "robot_tasks"
             ]
+
+        provision_data["authorized_keys"] = [self._read_ssh_key()]
 
         # Let's handle defaults on the Zapper side adding only the explicitly
         # specified keys to the `provision_data` dict.

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -55,6 +55,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         }
 
         connector._get_autoinstall_conf = Mock()
+        connector._read_ssh_key = Mock(return_value="mykey")
         args, kwargs = connector._validate_configuration()
 
         expected = {
@@ -63,6 +64,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "password": "ubuntu",
             "autoinstall_conf": connector._get_autoinstall_conf.return_value,
             "robot_tasks": ["job.robot", "another.robot"],
+            "authorized_keys": ["mykey"],
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
@@ -81,12 +83,14 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         }
 
         connector._get_autoinstall_conf = Mock()
+        connector._read_ssh_key = Mock(return_value="mykey")
         args, kwargs = connector._validate_configuration()
 
         expected = {
             "preset": "preset-test",
             "username": "ubuntu",
             "password": "ubuntu",
+            "authorized_keys": ["mykey"],
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
@@ -108,6 +112,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         }
 
         connector._get_autoinstall_conf = Mock()
+        connector._read_ssh_key = Mock(return_value="mykey")
         args, kwargs = connector._validate_configuration()
 
         expected = {
@@ -115,6 +120,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "preset": "preset-test",
             "username": "ubuntu",
             "password": "ubuntu",
+            "authorized_keys": ["mykey"],
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
@@ -148,6 +154,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         }
 
         connector._get_autoinstall_conf = Mock()
+        connector._read_ssh_key = Mock(return_value="mykey")
         args, kwargs = connector._validate_configuration()
 
         expected = {
@@ -162,6 +169,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "wait_until_ssh": True,
             "live_image": False,
             "ubuntu_sso_email": "username@domain.com",
+            "authorized_keys": ["mykey"],
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
@@ -192,6 +200,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         }
 
         connector._get_autoinstall_conf = Mock()
+        connector._read_ssh_key = Mock(return_value="mykey")
         args, kwargs = connector._validate_configuration()
 
         expected = {
@@ -200,6 +209,7 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "password": "u",
             "autoinstall_conf": connector._get_autoinstall_conf.return_value,
             "robot_tasks": ["job.robot", "another.robot"],
+            "authorized_keys": ["mykey"],
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
@@ -257,13 +267,11 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                 "test_password": "password",
             },
         }
-        connector._read_ssh_key = Mock(return_value="mykey")
 
         conf = connector._get_autoinstall_conf()
 
         expected = {
             "storage_layout": "lvm",
-            "authorized_keys": ["mykey"],
         }
         self.assertDictEqual(conf, expected)
 
@@ -295,14 +303,12 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         }
 
         connector._validate_base_user_data = Mock()
-        connector._read_ssh_key = Mock(return_value="mykey")
         conf = connector._get_autoinstall_conf()
 
         connector._validate_base_user_data.assert_called_once_with("content")
         expected = {
             "storage_layout": "lvm",
             "base_user_data": "content",
-            "authorized_keys": ["mykey"],
         }
         self.assertDictEqual(conf, expected)
 
@@ -328,7 +334,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             },
         }
 
-        connector._read_ssh_key = Mock(return_value="mykey")
         conf = connector._get_autoinstall_conf()
 
         user_data_oem = (
@@ -338,7 +343,6 @@ class ZapperKVMConnectorTests(unittest.TestCase):
 
         expected = {
             "storage_layout": "direct",
-            "authorized_keys": ["mykey"],
             "base_user_data": encoded_user_data.decode(),
         }
         self.assertDictEqual(conf, expected)


### PR DESCRIPTION
## Description

Independently from the situation, the server side should always be aware of the agent's public SSH key. This relies on a new dedicated and optional API argument, instead of embedding it into the autoinstall object.

## Resolved issues

Second half of https://warthogs.atlassian.net/browse/ZAP-1439

## Documentation

N/A

## Web service API changes

N/A

## Tests

```
uv run testflinger-device-connector zapper_kvm provision -c ./default.yaml job.json
```
and then check `~/.ssh/authorized_keys`
