### PR TITLE
Fix (breaking): `reserve` sub-command to actually work, and also work with `maas2` device_connector

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -326,12 +326,12 @@ class TestflingerCli:
             "--distro", help="Name of the distro to use for provisioning"
         )
         parser.add_argument(
-            "--keys",
+            "--key",
             "-k",
-            nargs="*",
+            action="append",
             help=(
                 "Ssh key(s) to use for reservation "
-                "(ex: -k lp:userid gh:userid)"
+                "(ex: -k lp:userid -k gh:userid)"
             ),
         )
         parser.add_argument(
@@ -1297,7 +1297,7 @@ class TestflingerCli:
                 image = f"url: {image}"
             else:
                 image = images[image]
-        ssh_keys = self.args.keys or helpers.prompt_for_ssh_keys()
+        ssh_keys = self.args.key or helpers.prompt_for_ssh_keys()
         ssh_keys_yaml = ""
         for ssh_key in ssh_keys:
             if not ssh_key.startswith("lp:") and not ssh_key.startswith("gh:"):

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -1291,7 +1291,7 @@ class TestflingerCli:
         else:
             try:
                 images = self.client.get_images(queue)
-            except OSError:
+            except (OSError, client.HTTPError):
                 logger.warning(
                     "Unable to get a list of images from the server!"
                 )

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -323,6 +323,9 @@ class TestflingerCli:
             "--image", "-i", help="Name of the image to use for provisioning"
         )
         parser.add_argument(
+            "--distro", help="Name of the distro to use for provisioning"
+        )
+        parser.add_argument(
             "--key",
             "-k",
             nargs="*",
@@ -330,6 +333,18 @@ class TestflingerCli:
                 "Ssh key(s) to use for reservation "
                 "(ex: -k lp:userid -k gh:userid)"
             ),
+        )
+        parser.add_argument(
+            "-y",
+            "--yes",
+            action="store_true",
+            help="Skip the Proceed confirmation prompt",
+        )
+        parser.add_argument(
+            "--timeout",
+            type=int,
+            default=3600,
+            help="Reservation timeout in seconds (default 3600)",
         )
 
     def _add_status_args(self, subparsers):
@@ -749,20 +764,8 @@ class TestflingerCli:
                     attachment["agent"] = str(agent_path)
                     del attachment["local"]
 
-    def submit(self):
+    def _submit(self, job_dict):
         """Submit a new test job to the server."""
-        if not self.args.filename:
-            data = sys.stdin.read()
-        else:
-            try:
-                data = self.args.filename.read_text(
-                    encoding="utf-8", errors="ignore"
-                )
-            except (PermissionError, FileNotFoundError):
-                logger.exception("Cannot read file %s", self.args.filename)
-                sys.exit(1)
-        job_dict = yaml.safe_load(data)
-
         # Check if agents are available to handle this queue
         # and warn or exit depending on options
         try:
@@ -798,11 +801,31 @@ class TestflingerCli:
                     )
 
         self.history.new(job_id, queue)
+
+        return job_id
+
+    def submit(self):
+        """Submit a new test job to the server."""
+        if not self.args.filename:
+            data = sys.stdin.read()
+        else:
+            try:
+                data = self.args.filename.read_text(
+                    encoding="utf-8", errors="ignore"
+                )
+            except (PermissionError, FileNotFoundError):
+                logger.exception("Cannot read file %s", self.args.filename)
+                sys.exit(1)
+        job_dict = yaml.safe_load(data)
+
+        job_id = self._submit(job_dict)
+
         if self.args.quiet:
             print(job_id)
         else:
             print("Job submitted successfully!")
             print(f"job_id: {job_id}")
+
         if self.args.poll:
             self.do_poll(job_id)
 
@@ -1253,46 +1276,60 @@ class TestflingerCli:
 
     def reserve(self):
         """Install and reserve a system."""
-        queues = self.do_list_queues()
-        queue = self.args.queue or helpers.prompt_for_queue(queues)
-        if queue not in queues:
-            logger.warning("'%s' is not in the list of known queues", queue)
+        queue = self.args.queue or helpers.prompt_for_queue(self.client)
         try:
             images = self.client.get_images(queue)
         except OSError:
             logger.warning("Unable to get a list of images from the server!")
             images = {}
-        image = self.args.image or helpers.prompt_for_image(images)
-        if (
-            not image.startswith(("http://", "https://"))
-            and image not in images
-        ):
-            logger.error("'%s' is not in the list of known images", image)
-        if image.startswith(("http://", "https://")):
-            image = f"url: {image}"
+
+        # Handle distro if provided
+        if self.args.distro:
+            image = f"distro: {self.args.distro}"
         else:
-            image = images[image]
+            image = self.args.image or helpers.prompt_for_image(images)
+            if (
+                not image.startswith(("http://", "https://"))
+                and image not in images
+            ):
+                logger.error("'%s' is not in the list of known images", image)
+            if image.startswith(("http://", "https://")):
+                image = f"url: {image}"
+            else:
+                image = images[image]
         ssh_keys = self.args.key or helpers.prompt_for_ssh_keys()
+        ssh_keys_yaml = ""
         for ssh_key in ssh_keys:
             if not ssh_key.startswith("lp:") and not ssh_key.startswith("gh:"):
                 logger.error("Invalid SSH key format: %s", ssh_key)
+            else:
+                ssh_keys_yaml += f"      - {ssh_key}\n"
         template = inspect.cleandoc(
             """job_queue: {queue}
-                                    provision_data:
-                                        {image}
-                                    reserve_data:
-                                        ssh_keys:"""
+            provision_data:
+                {image}
+            reserve_data:
+                ssh_keys:
+            {ssh_keys_yaml}
+                timeout: {timeout}"""
         )
-        for ssh_key in ssh_keys:
-            template += f"\n      - {ssh_key}"
-        job_data = template.format(queue=queue, image=image)
+        job_data = template.format(
+            queue=queue,
+            image=image,
+            ssh_keys_yaml=ssh_keys_yaml.rstrip("\n"),
+            timeout=self.args.timeout,
+        )
         print("\nThe following yaml will be submitted:")
         print(job_data)
         if self.args.dry_run:
             return
-        answer = input("Proceed? (Y/n) ")
+        if self.args.yes:
+            answer = "y"
+        else:
+            answer = input("Proceed? (Y/n) ")
         if answer in ("Y", "y", ""):
-            job_id = self.submit_job_data(job_data)
+            job_dict = yaml.safe_load(job_data)
+            job_id = self._submit(job_dict)
             print("Job submitted successfully!")
             print(f"job_id: {job_id}")
             self.do_poll(job_id)

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -326,12 +326,12 @@ class TestflingerCli:
             "--distro", help="Name of the distro to use for provisioning"
         )
         parser.add_argument(
-            "--key",
+            "--keys",
             "-k",
             nargs="*",
             help=(
                 "Ssh key(s) to use for reservation "
-                "(ex: -k lp:userid -k gh:userid)"
+                "(ex: -k lp:userid gh:userid)"
             ),
         )
         parser.add_argument(
@@ -1297,7 +1297,7 @@ class TestflingerCli:
                 image = f"url: {image}"
             else:
                 image = images[image]
-        ssh_keys = self.args.key or helpers.prompt_for_ssh_keys()
+        ssh_keys = self.args.keys or helpers.prompt_for_ssh_keys()
         ssh_keys_yaml = ""
         for ssh_key in ssh_keys:
             if not ssh_key.startswith("lp:") and not ssh_key.startswith("gh:"):

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -18,7 +18,6 @@
 """TestflingerCli module."""
 
 import contextlib
-import inspect
 import json
 import logging
 import os
@@ -847,7 +846,10 @@ class TestflingerCli:
             # If there are online agents, then we can proceed
             return
         message = f"No online agents available for queue {queue}. "
-        if not self.args.wait_for_available_agents:
+        if (
+            not hasattr(self.args, "wait_for_available_agents")
+            or not self.args.wait_for_available_agents
+        ):
             message = f"ERROR: {message}"
             # Since we're not waiting, we need to produce a good error message
             # to assist in understanding why the job cannot be queued.
@@ -1276,51 +1278,47 @@ class TestflingerCli:
 
     def reserve(self):
         """Install and reserve a system."""
-        queue = self.args.queue or helpers.prompt_for_queue(self.do_list_queues())
-        try:
-            images = self.client.get_images(queue)
-        except OSError:
-            logger.warning("Unable to get a list of images from the server!")
-            images = {}
+        queue = self.args.queue or helpers.prompt_for_queue(
+            self.do_list_queues()
+        )
 
         # Handle distro if provided
+        provision_data = {}
         if self.args.distro:
-            image = f"distro: {self.args.distro}"
+            if self.args.image:
+                sys.exit("--distro cannot be specified with --image")
+            provision_data = {"provision_data": {"distro": self.args.distro}}
         else:
+            try:
+                images = self.client.get_images(queue)
+            except OSError:
+                logger.warning(
+                    "Unable to get a list of images from the server!"
+                )
+                images = {}
             image = self.args.image or helpers.prompt_for_image(images)
-            if (
-                not image.startswith(("http://", "https://"))
-                and image not in images
-            ):
-                logger.warning("'%s' is not in the list of known images", image)
-            if image.startswith(("http://", "https://")):
-                image = f"url: {image}"
-            elif image:
-                image = f"url: {image}"
-        ssh_keys = self.args.keys or helpers.prompt_for_ssh_keys()
-        ssh_keys_yaml = ""
+            if image:
+                provision_data = {"provision_data": {"url": image}}
+
+        ssh_keys = self.args.key or helpers.prompt_for_ssh_keys()
         for ssh_key in ssh_keys:
             if not ssh_key.startswith("lp:") and not ssh_key.startswith("gh:"):
                 logger.error("Invalid SSH key format: %s", ssh_key)
-            else:
-                ssh_keys_yaml += f"      - {ssh_key}\n"
-        template = inspect.cleandoc(
-            """job_queue: {queue}
-            provision_data:
-                {image}
-            reserve_data:
-                ssh_keys:
-            {ssh_keys_yaml}
-                timeout: {timeout}"""
-        )
-        job_data = template.format(
-            queue=queue,
-            image=image,
-            ssh_keys_yaml=ssh_keys_yaml.rstrip("\n"),
-            timeout=self.args.timeout,
-        )
-        print("\nThe following yaml will be submitted:")
-        print(job_data)
+
+        job_dict = {
+            "job_queue": queue,
+            "reserve_data": {
+                "ssh_keys": ssh_keys,
+                "timeout": self.args.timeout,
+            },
+        }
+        job_dict.update(provision_data)
+
+        print("\nThe following job will be submitted:")
+        print(json.dumps(job_dict, indent=2))
+
+        # Note: The args --dry-run and --yes are mutually exclusive, and if
+        #       both are specified --dry-run will take precedence.
         if self.args.dry_run:
             return
         if self.args.yes:
@@ -1328,7 +1326,6 @@ class TestflingerCli:
         else:
             answer = input("Proceed? (Y/n) ")
         if answer in ("Y", "y", ""):
-            job_dict = yaml.safe_load(job_data)
             job_id = self._submit(job_dict)
             print("Job submitted successfully!")
             print(f"job_id: {job_id}")

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -1276,7 +1276,7 @@ class TestflingerCli:
 
     def reserve(self):
         """Install and reserve a system."""
-        queue = self.args.queue or helpers.prompt_for_queue(self.client)
+        queue = self.args.queue or helpers.prompt_for_queue(self.do_list_queues())
         try:
             images = self.client.get_images(queue)
         except OSError:
@@ -1292,11 +1292,11 @@ class TestflingerCli:
                 not image.startswith(("http://", "https://"))
                 and image not in images
             ):
-                logger.error("'%s' is not in the list of known images", image)
+                logger.warning("'%s' is not in the list of known images", image)
             if image.startswith(("http://", "https://")):
                 image = f"url: {image}"
-            else:
-                image = images[image]
+            elif image:
+                image = f"image: {image}"
         ssh_keys = self.args.keys or helpers.prompt_for_ssh_keys()
         ssh_keys_yaml = ""
         for ssh_key in ssh_keys:

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -56,7 +56,7 @@ def parse_filename(
     return path
 
 
-def prompt_for_image(images: dict[str, str]) -> str:
+def prompt_for_image(images: dict[str, str]) -> str | None:
     """Prompt the user to select an image from a list.
 
     :param images: A mapping of image name to image job line to choose from.
@@ -70,8 +70,19 @@ def prompt_for_image(images: dict[str, str]) -> str:
     while not image:
         image = input(input_msg).strip()
         if not image:
+            choice = "x"
+            while choice not in "yn":
+                choice = (
+                    input(
+                        "\nNo image specified, proceed with no provision data?"
+                        " (Y)es/(n)o? "
+                    )
+                    + "x"
+                )[0].lower()  # dummy character to make indexing robust
+            if choice == "y":
+                return None
             continue
-        if image == "?":
+        elif image == "?":
             if not images:
                 print(
                     "WARNING: No images defined for this device. You may also "
@@ -89,7 +100,9 @@ def prompt_for_image(images: dict[str, str]) -> str:
                 "that queue, please select another."
             )
             image = ""
-    return image
+        else:
+            image = images[image].split("url:")[-1]
+    return image.strip()
 
 
 def prompt_for_ssh_keys() -> list[str]:

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -110,7 +110,7 @@ def prompt_for_ssh_keys() -> list[str]:
     return ssh_keys
 
 
-def prompt_for_queue(queues: dict[str, str]) -> str:
+def prompt_for_queue(client) -> str:
     """Prompt the user to select a queue from a list.
 
     :param queues: A mapping of queue name to descripton to choose from.
@@ -122,6 +122,7 @@ def prompt_for_queue(queues: dict[str, str]) -> str:
         queue = input(input_msg).strip()
         if not queue:
             continue
+        queues = client.get_queues()
         if queue == "?":
             print("\nAdvertised queues on this server:")
             for name, description in queues.items():

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -110,7 +110,7 @@ def prompt_for_ssh_keys() -> list[str]:
     return ssh_keys
 
 
-def prompt_for_queue(client) -> str:
+def prompt_for_queue(queues: dict[str, str]) -> str:
     """Prompt the user to select a queue from a list.
 
     :param queues: A mapping of queue name to descripton to choose from.
@@ -122,7 +122,6 @@ def prompt_for_queue(client) -> str:
         queue = input(input_msg).strip()
         if not queue:
             continue
-        queues = client.get_queues()
         if queue == "?":
             print("\nAdvertised queues on this server:")
             for name, description in queues.items():

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,4 +1,17 @@
 # Copyright (C) 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 """Shared pytest fixtures and configuration."""
 
 import uuid

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -815,10 +815,9 @@ def test_reserve_distro_with_image_fails(requests_mock):
     assert exc_info.value.code == "--distro cannot be specified with --image"
 
 
-def test_reserve_with_yes_flag(capsys, requests_mock, monkeypatch):
+@patch("builtins.input")
+def test_reserve_with_yes_flag(mock_input, capsys, requests_mock):
     """Test reserve command with --yes flag skips confirmation prompt."""
-    from unittest.mock import Mock
-
     jobid = "testid456"
     requests_mock.get(URL + "/v1/agents/queues", json={})
     requests_mock.get(URL + "/v1/agents/images/fake", json={})
@@ -828,12 +827,9 @@ def test_reserve_with_yes_flag(capsys, requests_mock, monkeypatch):
         json=[{"name": "fake_agent", "state": "waiting"}],
     )
     # Mock input to fail if called (should not be called with -y flag)
-    mock_input = Mock(
-        side_effect=AssertionError(
-            "input() should not be called with --yes flag"
-        )
+    mock_input.side_effect = AssertionError(
+        "input() should not be called with --yes flag"
     )
-    monkeypatch.setattr("builtins.input", mock_input)
 
     sys.argv = [
         "",
@@ -878,16 +874,14 @@ def test_reserve_custom_timeout(capsys, requests_mock):
     assert '"timeout": 7200' in std.out
 
 
-def test_reserve_no_image_or_distro(capsys, requests_mock, monkeypatch):
+@patch("testflinger_cli.helpers.prompt_for_image")
+def test_reserve_no_image_or_distro(mock_image, capsys, requests_mock):
     """Test reserve when user opts to proceed with no provision data."""
-    from unittest.mock import Mock
-
     requests_mock.get(URL + "/v1/agents/queues", json={})
     requests_mock.get(URL + "/v1/agents/images/fake", json={})
 
     # Mock prompt_for_image to return None (user chooses no provision data)
-    mock_image = Mock(return_value=None)
-    monkeypatch.setattr("testflinger_cli.helpers.prompt_for_image", mock_image)
+    mock_image.return_value = None
 
     sys.argv = [
         "",

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -724,17 +724,9 @@ def test_submit_without_queue(tmp_path):
 
 
 def test_reserve(capsys, requests_mock):
-    """Ensure reserve command generates correct yaml."""
+    """Ensure reserve command generates correct JSON output."""
     requests_mock.get(URL + "/v1/agents/queues", json={})
     requests_mock.get(URL + "/v1/agents/images/fake", json={})
-    expected_yaml = (
-        "job_queue: fake\n"
-        "provision_data:\n"
-        "    url: http://face_image.xz\n"
-        "reserve_data:\n"
-        "    ssh_keys:\n"
-        "      - lp:fakeuser"
-    )
     sys.argv = [
         "",
         "reserve",
@@ -749,11 +741,59 @@ def test_reserve(capsys, requests_mock):
     tfcli = testflinger_cli.TestflingerCli()
     tfcli.reserve()
     std = capsys.readouterr()
-    assert expected_yaml in std.out
+    assert '"job_queue": "fake"' in std.out
+    assert '"url": "http://face_image.xz"' in std.out
+    assert '"ssh_keys"' in std.out
+    assert '"lp:fakeuser"' in std.out
+    assert '"timeout": 3600' in std.out
 
 
 def test_reserve_with_distro(capsys, requests_mock):
-    """Ensure reserve command with distro generates correct yaml."""
+    """Test reserve with --distro flag submits correct provision_data."""
+    jobid = "testid123"
+    requests_mock.get(URL + "/v1/agents/queues", json={})
+    requests_mock.post(URL + "/v1/job", json={"job_id": jobid})
+    requests_mock.get(
+        URL + "/v1/queues/fake/agents",
+        json=[{"name": "fake_agent", "state": "waiting"}],
+    )
+    # Mock position and result to handle polling
+    requests_mock.get(URL + f"/v1/job/{jobid}/position", text="1")
+    requests_mock.get(
+        URL + f"/v1/result/{jobid}", json={"job_state": "completed"}
+    )
+    requests_mock.get(
+        URL + f"/v1/result/{jobid}/log/output?start_fragment=0",
+        json={
+            "output": {
+                "test": {
+                    "last_fragment_number": 0,
+                    "log_data": "test output",
+                }
+            }
+        },
+    )
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "--distro",
+        "ubuntu-20.04",
+        "-k",
+        "lp:fakeuser",
+        "-d",  # dry-run to skip polling
+    ]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.reserve()
+    std = capsys.readouterr()
+    assert '"distro": "ubuntu-20.04"' in std.out
+    assert '"job_queue": "fake"' in std.out
+    assert '"ssh_keys"' in std.out
+
+
+def test_reserve_distro_with_image_fails(requests_mock):
+    """Test that --distro and --image cannot be used together."""
     requests_mock.get(URL + "/v1/agents/queues", json={})
     requests_mock.get(URL + "/v1/agents/images/fake", json={})
     sys.argv = [
@@ -762,45 +802,61 @@ def test_reserve_with_distro(capsys, requests_mock):
         "-q",
         "fake",
         "--distro",
-        "jammy",
+        "ubuntu-20.04",
+        "-i",
+        "http://face_image.xz",
         "-k",
         "lp:fakeuser",
-        "-d",  # dry-run flag prevents actual submission
-    ]
-    tfcli = testflinger_cli.TestflingerCli()
-    tfcli.reserve()
-    std = capsys.readouterr()
-    assert "distro: jammy" in std.out
-
-
-def test_reserve_with_multiple_ssh_keys(capsys, requests_mock):
-    """Ensure reserve command with multiple ssh keys generates correct
-    yaml.
-    """
-    requests_mock.get(URL + "/v1/agents/queues", json={})
-    requests_mock.get(URL + "/v1/agents/images/fake", json={})
-    sys.argv = [
-        "",
-        "reserve",
-        "-q",
-        "fake",
-        "-i",
-        "http://image_url.xz",
-        "-k",
-        "lp:user1",
-        "-k",
-        "gh:user2",
         "-d",
     ]
     tfcli = testflinger_cli.TestflingerCli()
+    with pytest.raises(SystemExit) as exc_info:
+        tfcli.reserve()
+    assert exc_info.value.code == "--distro cannot be specified with --image"
+
+
+def test_reserve_with_yes_flag(capsys, requests_mock, monkeypatch):
+    """Test reserve command with --yes flag skips confirmation prompt."""
+    from unittest.mock import Mock
+
+    jobid = "testid456"
+    requests_mock.get(URL + "/v1/agents/queues", json={})
+    requests_mock.get(URL + "/v1/agents/images/fake", json={})
+    requests_mock.post(URL + "/v1/job", json={"job_id": jobid})
+    requests_mock.get(
+        URL + "/v1/queues/fake/agents",
+        json=[{"name": "fake_agent", "state": "waiting"}],
+    )
+    # Mock input to fail if called (should not be called with -y flag)
+    mock_input = Mock(
+        side_effect=AssertionError(
+            "input() should not be called with --yes flag"
+        )
+    )
+    monkeypatch.setattr("builtins.input", mock_input)
+
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "-i",
+        "http://face_image.xz",
+        "-k",
+        "lp:fakeuser",
+        "-d",  # dry-run to skip polling
+        "-y",
+    ]
+    tfcli = testflinger_cli.TestflingerCli()
     tfcli.reserve()
     std = capsys.readouterr()
-    assert "- lp:user1" in std.out
-    assert "- gh:user2" in std.out
+    # Verify yes flag worked by checking output contains JSON
+    assert '"job_queue": "fake"' in std.out
+    assert '"url"' in std.out or '"image"' in std.out
 
 
-def test_reserve_with_custom_timeout(capsys, requests_mock):
-    """Ensure reserve command with custom timeout is included."""
+def test_reserve_custom_timeout(capsys, requests_mock):
+    """Test reserve command includes custom timeout in reserve_data."""
     requests_mock.get(URL + "/v1/agents/queues", json={})
     requests_mock.get(URL + "/v1/agents/images/fake", json={})
     sys.argv = [
@@ -809,9 +865,9 @@ def test_reserve_with_custom_timeout(capsys, requests_mock):
         "-q",
         "fake",
         "-i",
-        "http://image_url.xz",
+        "http://face_image.xz",
         "-k",
-        "lp:user",
+        "lp:fakeuser",
         "--timeout",
         "7200",
         "-d",
@@ -819,35 +875,40 @@ def test_reserve_with_custom_timeout(capsys, requests_mock):
     tfcli = testflinger_cli.TestflingerCli()
     tfcli.reserve()
     std = capsys.readouterr()
-    assert "timeout: 7200" in std.out
+    assert '"timeout": 7200' in std.out
 
 
-def test_reserve_with_yes_flag_no_poll(capsys, requests_mock):
-    """Ensure reserve command with -y flag skips confirmation prompt."""
+def test_reserve_no_image_or_distro(capsys, requests_mock, monkeypatch):
+    """Test reserve when user opts to proceed with no provision data."""
+    from unittest.mock import Mock
+
     requests_mock.get(URL + "/v1/agents/queues", json={})
     requests_mock.get(URL + "/v1/agents/images/fake", json={})
-    # Dry run to avoid actual submission
+
+    # Mock prompt_for_image to return None (user chooses no provision data)
+    mock_image = Mock(return_value=None)
+    monkeypatch.setattr("testflinger_cli.helpers.prompt_for_image", mock_image)
+
     sys.argv = [
         "",
         "reserve",
         "-q",
         "fake",
-        "-i",
-        "http://image_url.xz",
         "-k",
-        "lp:user",
-        "-y",  # skip confirmation
-        "-d",  # dry-run
+        "lp:fakeuser",
+        "-d",  # dry-run to skip polling
     ]
     tfcli = testflinger_cli.TestflingerCli()
     tfcli.reserve()
     std = capsys.readouterr()
-    # Verify yaml was generated without asking for confirmation
-    assert "http://image_url.xz" in std.out
+    assert '"job_queue": "fake"' in std.out
+    assert '"ssh_keys"' in std.out
+    # Should not have provision_data key when no image/distro provided
+    assert '"url"' not in std.out and '"distro"' not in std.out
 
 
-def test_reserve_invalid_ssh_key_format(capsys, requests_mock):
-    """Ensure reserve warns about invalid SSH key format."""
+def test_reserve_dry_run_json_output(capsys, requests_mock):
+    """Test reserve --dry-run shows JSON output without submitting."""
     requests_mock.get(URL + "/v1/agents/queues", json={})
     requests_mock.get(URL + "/v1/agents/images/fake", json={})
     sys.argv = [
@@ -856,33 +917,20 @@ def test_reserve_invalid_ssh_key_format(capsys, requests_mock):
         "-q",
         "fake",
         "-i",
-        "http://image_url.xz",
+        "http://face_image.xz",
         "-k",
-        "invalid_key_format",
+        "lp:fakeuser",
         "-d",
     ]
     tfcli = testflinger_cli.TestflingerCli()
     tfcli.reserve()
     std = capsys.readouterr()
-    # Invalid key should not appear in the yaml
-    assert "invalid_key_format" not in std.out
-
-
-def test_submit_method_internal(capsys, tmp_path, requests_mock):
-    """Test the internal _submit method with job dict."""
-    jobid = str(uuid.uuid1())
-    fake_data = {"job_queue": "fake", "provision_data": {"distro": "fake"}}
-    fake_return = {"job_id": jobid}
-    requests_mock.post(f"{URL}/v1/job", json=fake_return)
-    requests_mock.get(
-        f"{URL}/v1/queues/fake/agents",
-        json=[{"name": "fake_agent", "state": "waiting"}],
-    )
-    sys.argv = ["", "submit", "-"]
-    tfcli = testflinger_cli.TestflingerCli()
-    # Call _submit directly with job dict
-    result_job_id = tfcli._submit(fake_data)
-    assert result_job_id == jobid
+    assert "The following job will be submitted:" in std.out
+    # Verify JSON structure (not YAML)
+    assert '"job_queue"' in std.out
+    assert '"reserve_data"' in std.out
+    assert '"provision_data"' in std.out
+    assert '"ssh_keys"' in std.out
 
 
 def test_poll_args_generic_parsing():

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -752,6 +752,139 @@ def test_reserve(capsys, requests_mock):
     assert expected_yaml in std.out
 
 
+def test_reserve_with_distro(capsys, requests_mock):
+    """Ensure reserve command with distro generates correct yaml."""
+    requests_mock.get(URL + "/v1/agents/queues", json={})
+    requests_mock.get(URL + "/v1/agents/images/fake", json={})
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "--distro",
+        "jammy",
+        "-k",
+        "lp:fakeuser",
+        "-d",  # dry-run flag prevents actual submission
+    ]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.reserve()
+    std = capsys.readouterr()
+    assert "distro: jammy" in std.out
+
+
+def test_reserve_with_multiple_ssh_keys(capsys, requests_mock):
+    """Ensure reserve command with multiple ssh keys generates correct
+    yaml.
+    """
+    requests_mock.get(URL + "/v1/agents/queues", json={})
+    requests_mock.get(URL + "/v1/agents/images/fake", json={})
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "-i",
+        "http://image_url.xz",
+        "-k",
+        "lp:user1",
+        "-k",
+        "gh:user2",
+        "-d",
+    ]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.reserve()
+    std = capsys.readouterr()
+    assert "- lp:user1" in std.out
+    assert "- gh:user2" in std.out
+
+
+def test_reserve_with_custom_timeout(capsys, requests_mock):
+    """Ensure reserve command with custom timeout is included."""
+    requests_mock.get(URL + "/v1/agents/queues", json={})
+    requests_mock.get(URL + "/v1/agents/images/fake", json={})
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "-i",
+        "http://image_url.xz",
+        "-k",
+        "lp:user",
+        "--timeout",
+        "7200",
+        "-d",
+    ]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.reserve()
+    std = capsys.readouterr()
+    assert "timeout: 7200" in std.out
+
+
+def test_reserve_with_yes_flag_no_poll(capsys, requests_mock):
+    """Ensure reserve command with -y flag skips confirmation prompt."""
+    requests_mock.get(URL + "/v1/agents/queues", json={})
+    requests_mock.get(URL + "/v1/agents/images/fake", json={})
+    # Dry run to avoid actual submission
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "-i",
+        "http://image_url.xz",
+        "-k",
+        "lp:user",
+        "-y",  # skip confirmation
+        "-d",  # dry-run
+    ]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.reserve()
+    std = capsys.readouterr()
+    # Verify yaml was generated without asking for confirmation
+    assert "http://image_url.xz" in std.out
+
+
+def test_reserve_invalid_ssh_key_format(capsys, requests_mock):
+    """Ensure reserve warns about invalid SSH key format."""
+    requests_mock.get(URL + "/v1/agents/queues", json={})
+    requests_mock.get(URL + "/v1/agents/images/fake", json={})
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "-i",
+        "http://image_url.xz",
+        "-k",
+        "invalid_key_format",
+        "-d",
+    ]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.reserve()
+    std = capsys.readouterr()
+    # Invalid key should not appear in the yaml
+    assert "invalid_key_format" not in std.out
+
+
+def test_submit_method_internal(capsys, tmp_path, requests_mock):
+    """Test the internal _submit method with job dict."""
+    jobid = str(uuid.uuid1())
+    fake_data = {"job_queue": "fake", "provision_data": {"distro": "fake"}}
+    fake_return = {"job_id": jobid}
+    requests_mock.post(f"{URL}/v1/job", json=fake_return)
+    requests_mock.get(
+        f"{URL}/v1/queues/fake/agents",
+        json=[{"name": "fake_agent", "state": "waiting"}],
+    )
+    sys.argv = ["", "submit", "-"]
+    tfcli = testflinger_cli.TestflingerCli()
+    # Call _submit directly with job dict
+    result_job_id = tfcli._submit(fake_data)
+    assert result_job_id == jobid
+
+
 def test_poll_args_generic_parsing():
     """Test that generic poll arguments are parsed correctly."""
     sys.argv = [

--- a/cli/tests/test_helpers.py
+++ b/cli/tests/test_helpers.py
@@ -77,15 +77,10 @@ def test_prompt_for_queue_valid_input(monkeypatch):
     """Test prompt_for_queue returns valid queue from user input."""
     from testflinger_cli.helpers import prompt_for_queue
 
-    # Mock the client and its method
-    class MockClient:
-        def get_queues(self):
-            return {"queue1": "Description 1", "queue2": "Description 2"}
-
-    client = MockClient()
+    queues = {"queue1": "Description 1", "queue2": "Description 2"}
     monkeypatch.setattr("builtins.input", lambda _: "queue1")
 
-    result = prompt_for_queue(client)
+    result = prompt_for_queue(queues)
     assert result == "queue1"
 
 
@@ -93,15 +88,11 @@ def test_prompt_for_queue_list_queues(monkeypatch, capsys):
     """Test prompt_for_queue lists available queues when '?' is entered."""
     from testflinger_cli.helpers import prompt_for_queue
 
-    class MockClient:
-        def get_queues(self):
-            return {"queue1": "Description 1", "queue2": "Description 2"}
-
-    client = MockClient()
+    queues = {"queue1": "Description 1", "queue2": "Description 2"}
     inputs = iter(["?", "queue1"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
-    result = prompt_for_queue(client)
+    result = prompt_for_queue(queues)
     assert result == "queue1"
     captured = capsys.readouterr()
     assert "queue1" in captured.out
@@ -112,15 +103,11 @@ def test_prompt_for_queue_unknown_with_confirmation(monkeypatch):
     """Test prompt_for_queue allows unknown queue with user confirmation."""
     from testflinger_cli.helpers import prompt_for_queue
 
-    class MockClient:
-        def get_queues(self):
-            return {"queue1": "Description 1"}
-
-    client = MockClient()
+    queues = {"queue1": "Description 1"}
     inputs = iter(["unknown_queue", "y"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
-    result = prompt_for_queue(client)
+    result = prompt_for_queue(queues)
     assert result == "unknown_queue"
 
 
@@ -128,13 +115,9 @@ def test_prompt_for_queue_unknown_decline(monkeypatch):
     """Test prompt_for_queue rejects unknown queue if user declines."""
     from testflinger_cli.helpers import prompt_for_queue
 
-    class MockClient:
-        def get_queues(self):
-            return {"queue1": "Description 1"}
-
-    client = MockClient()
+    queues = {"queue1": "Description 1"}
     inputs = iter(["unknown_queue", "n", "queue1"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
-    result = prompt_for_queue(client)
+    result = prompt_for_queue(queues)
     assert result == "queue1"

--- a/cli/tests/test_helpers.py
+++ b/cli/tests/test_helpers.py
@@ -71,3 +71,70 @@ def test_pretty_yaml_dump():
         pretty_yaml_dump(multiline, indent=4, default_flow_style=False).strip()
         == result.strip()
     )
+
+
+def test_prompt_for_queue_valid_input(monkeypatch):
+    """Test prompt_for_queue returns valid queue from user input."""
+    from testflinger_cli.helpers import prompt_for_queue
+
+    # Mock the client and its method
+    class MockClient:
+        def get_queues(self):
+            return {"queue1": "Description 1", "queue2": "Description 2"}
+
+    client = MockClient()
+    monkeypatch.setattr("builtins.input", lambda _: "queue1")
+
+    result = prompt_for_queue(client)
+    assert result == "queue1"
+
+
+def test_prompt_for_queue_list_queues(monkeypatch, capsys):
+    """Test prompt_for_queue lists available queues when '?' is entered."""
+    from testflinger_cli.helpers import prompt_for_queue
+
+    class MockClient:
+        def get_queues(self):
+            return {"queue1": "Description 1", "queue2": "Description 2"}
+
+    client = MockClient()
+    inputs = iter(["?", "queue1"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    result = prompt_for_queue(client)
+    assert result == "queue1"
+    captured = capsys.readouterr()
+    assert "queue1" in captured.out
+    assert "queue2" in captured.out
+
+
+def test_prompt_for_queue_unknown_with_confirmation(monkeypatch):
+    """Test prompt_for_queue allows unknown queue with user confirmation."""
+    from testflinger_cli.helpers import prompt_for_queue
+
+    class MockClient:
+        def get_queues(self):
+            return {"queue1": "Description 1"}
+
+    client = MockClient()
+    inputs = iter(["unknown_queue", "y"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    result = prompt_for_queue(client)
+    assert result == "unknown_queue"
+
+
+def test_prompt_for_queue_unknown_decline(monkeypatch):
+    """Test prompt_for_queue rejects unknown queue if user declines."""
+    from testflinger_cli.helpers import prompt_for_queue
+
+    class MockClient:
+        def get_queues(self):
+            return {"queue1": "Description 1"}
+
+    client = MockClient()
+    inputs = iter(["unknown_queue", "n", "queue1"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    result = prompt_for_queue(client)
+    assert result == "queue1"

--- a/cli/tests/test_helpers.py
+++ b/cli/tests/test_helpers.py
@@ -3,6 +3,7 @@
 
 import textwrap
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -73,24 +74,23 @@ def test_pretty_yaml_dump():
     )
 
 
-def test_prompt_for_queue_valid_input(monkeypatch):
+@patch("builtins.input", return_value="queue1")
+def test_prompt_for_queue_valid_input(mock_input):
     """Test prompt_for_queue returns valid queue from user input."""
     from testflinger_cli.helpers import prompt_for_queue
 
     queues = {"queue1": "Description 1", "queue2": "Description 2"}
-    monkeypatch.setattr("builtins.input", lambda _: "queue1")
 
     result = prompt_for_queue(queues)
     assert result == "queue1"
 
 
-def test_prompt_for_queue_list_queues(monkeypatch, capsys):
+@patch("builtins.input", side_effect=["?", "queue1"])
+def test_prompt_for_queue_list_queues(mock_input, capsys):
     """Test prompt_for_queue lists available queues when '?' is entered."""
     from testflinger_cli.helpers import prompt_for_queue
 
     queues = {"queue1": "Description 1", "queue2": "Description 2"}
-    inputs = iter(["?", "queue1"])
-    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     result = prompt_for_queue(queues)
     assert result == "queue1"
@@ -99,25 +99,23 @@ def test_prompt_for_queue_list_queues(monkeypatch, capsys):
     assert "queue2" in captured.out
 
 
-def test_prompt_for_queue_unknown_with_confirmation(monkeypatch):
+@patch("builtins.input", side_effect=["unknown_queue", "y"])
+def test_prompt_for_queue_unknown_with_confirmation(mock_input):
     """Test prompt_for_queue allows unknown queue with user confirmation."""
     from testflinger_cli.helpers import prompt_for_queue
 
     queues = {"queue1": "Description 1"}
-    inputs = iter(["unknown_queue", "y"])
-    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     result = prompt_for_queue(queues)
     assert result == "unknown_queue"
 
 
-def test_prompt_for_queue_unknown_decline(monkeypatch):
+@patch("builtins.input", side_effect=["unknown_queue", "n", "queue1"])
+def test_prompt_for_queue_unknown_decline(mock_input):
     """Test prompt_for_queue rejects unknown queue if user declines."""
     from testflinger_cli.helpers import prompt_for_queue
 
     queues = {"queue1": "Description 1"}
-    inputs = iter(["unknown_queue", "n", "queue1"])
-    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     result = prompt_for_queue(queues)
     assert result == "queue1"


### PR DESCRIPTION
## Description

Updated `reserve` sub-command of the testflinger CLI to add `--distro`, `--timeout`, `--yes`, and fixed `--key` -> `--keys` (see also #980)

## Resolved issues

Resolves #981
Resolves CERTTF-883

## Documentation

- [ ] Documentation **NOT** updated.  Let's confirm the direction and then document.

## Web service API changes

N/A

## Tests

Yes, used for testing many other works in progress.  Unit tests added/updated.
```shell
cli (fix-reserve) $ uv run testflinger --server http://testflinger-staging.canonical.com reserve --distro noble --keys lp:ajzobro lp:other --yes --timeout 300 --queue staging
```