### PR TITLE
feat: add rotation mechanism for Customer Master Key

### DIFF
--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -26,6 +26,9 @@ requires:
   mongodb_client:
     interface: mongodb_client
     limit: 1
+  mongodb_keyvault:
+    interface: mongodb_client
+    limit: 1
   nginx-route:
     interface: nginx-route
     limit: 1
@@ -70,6 +73,8 @@ actions:
       password:
         type: string
         description: The password to set to admin user.
+  retry-key-rotation:
+    description: Force a retry of the key rotation process for CSFLE.
 
 config:
   options:

--- a/server/charm/requirements.txt
+++ b/server/charm/requirements.txt
@@ -1,5 +1,6 @@
 pip>=26.0
 setuptools>=75.0
+setuptools-scm<10.0.0
 urllib3>=2.6.3
 ops >= 2.2.0
 bcrypt>=4.2.0

--- a/server/charm/requirements.txt
+++ b/server/charm/requirements.txt
@@ -1,6 +1,5 @@
 pip>=26.0
 setuptools>=75.0
-setuptools-scm<10.0.0
 urllib3>=2.6.3
 ops >= 2.2.0
 bcrypt>=4.2.0

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -59,6 +59,7 @@ class TestflingerCharm(ops.CharmBase):
         self.container = self.unit.get_container("testflinger")
         self._stored.set_default(
             reldata={},
+            previous_master_key="",
         )
 
         # TODO: Remove nginx route when migration to traefik route is completed
@@ -69,6 +70,11 @@ class TestflingerCharm(ops.CharmBase):
             self,
             relation_name="mongodb_client",
             database_name="testflinger_db",
+        )
+        self.mongodb_keyvault = DatabaseRequires(
+            self,
+            relation_name="mongodb_keyvault",
+            database_name="encryption",
         )
 
         # Initialize Grafana dashboard provider
@@ -95,11 +101,27 @@ class TestflingerCharm(ops.CharmBase):
             self._on_mongodb_client_relation_removed,
         )
         self.framework.observe(
+            self.mongodb_keyvault.on.database_created,
+            self._on_mongodb_keyvault_relation_changed,
+        )
+        self.framework.observe(
+            self.mongodb_keyvault.on.endpoints_changed,
+            self._on_mongodb_keyvault_relation_changed,
+        )
+        self.framework.observe(
+            self.on.mongodb_keyvault_relation_broken,
+            self._on_mongodb_keyvault_relation_changed,
+        )
+        self.framework.observe(
             self.on.testflinger_pebble_ready, self._on_testflinger_pebble_ready
         )
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(
             self.on.set_admin_password_action, self.on_set_admin_password
+        )
+        self.framework.observe(
+            self.on.retry_key_rotation_action,
+            self._on_retry_key_rotation_action,
         )
         # TODO: Remove nginx route when migration to traefik route is completed
         self.framework.observe(
@@ -294,12 +316,109 @@ class TestflingerCharm(ops.CharmBase):
         self.unit.status = ops.WaitingStatus("Waiting for database relation")
         sys.exit()
 
-    def _on_config_changed(self, _: ops.framework.EventBase) -> None:
-        """
-        Handle config changed event
-        We need to accept the event as an argument, but we don't use it.
-        """
+    def _on_mongodb_keyvault_relation_changed(
+        self, _: ops.framework.EventBase
+    ) -> None:
+        """Event is fired when the key vault relation is created or removed."""
         self._update_layer_and_restart()
+
+    def _fetch_keyvault_uri(self) -> str | None:
+        """Get the key vault MongoDB URI from the keyvault relation."""
+        for val in self.mongodb_keyvault.fetch_relation_data().values():
+            if val and "uris" in val:
+                return val["uris"]
+        return None
+
+    def _run_rotation(self, app_env: dict) -> str:
+        """Run rotate_mongo_secrets_key inside the container.
+
+        :param app_env: Environment variables to pass to the script.
+        :returns: stdout from the script.
+        :raises ops.pebble.ExecError: If the script exits with a non-zero code.
+        """
+        process = self.container.exec(
+            ["rotate_mongo_secrets_key"],
+            environment=app_env,
+        )
+        stdout, _ = process.wait_output()
+        return stdout
+
+    def _on_config_changed(self, _: ops.framework.EventBase) -> None:
+        """Handle config changed event."""
+        new_key = self.config["testflinger_secrets_master_key"]
+        stored_key = self._stored.previous_master_key
+
+        # Rotate only if master key was previously defined, has changed,
+        # and this is the leader unit.
+        if stored_key and new_key != stored_key and self.unit.is_leader():
+            if not self.container.can_connect():
+                self.unit.status = ops.WaitingStatus(
+                    "Waiting for Pebble in workload container"
+                )
+                return
+
+            # Inject both old and new master keys into the environment
+            env = {
+                **self.app_environment,
+                "TESTFLINGER_SECRETS_MASTER_KEY": stored_key,
+                "TESTFLINGER_SECRETS_NEW_MASTER_KEY": new_key,
+            }
+            try:
+                logger.info("Master key changed, rotating Data Encryption Key")
+                self._run_rotation(env)
+            except ops.pebble.ExecError as exc:
+                logger.error(
+                    "Key rotation failed: %s. "
+                    "Run the 'retry-key-rotation' action to retry.",
+                    exc.stderr,
+                )
+                self.unit.status = ops.BlockedStatus(
+                    "MongoDB CSFLE Master Key rotation failed."
+                )
+                return
+
+        logger.info("Successfully updated MongoDB CSFLE Master Key")
+        # Store the new master key for future rotations
+        self._stored.previous_master_key = new_key
+        self._update_layer_and_restart()
+
+    def _on_retry_key_rotation_action(self, event: ops.ActionEvent) -> None:
+        """Retry a failed MongoDB CSFLE Master Key rotation.
+
+        Use this when a testflinger_secrets_master_key config change left the
+        unit in BlockedStatus. The old key is read from StoredState and the
+        new key from the current config.
+        """
+        current_key = self.config["testflinger_secrets_master_key"]
+        stored_key = self._stored.previous_master_key
+
+        if not current_key:
+            event.fail("testflinger_secrets_master_key is not configured")
+            return
+
+        if not self.unit.is_leader():
+            event.fail("Action can only be executed on leader unit")
+            return
+
+        if not stored_key or stored_key == current_key:
+            event.fail("No pending key rotation found")
+            return
+
+        if not self.container.can_connect():
+            event.fail("Container is not ready")
+            return
+
+        env = {
+            **self.app_environment,
+            "TESTFLINGER_SECRETS_MASTER_KEY": stored_key,
+            "TESTFLINGER_SECRETS_NEW_MASTER_KEY": current_key,
+        }
+        try:
+            output = self._run_rotation(env)
+            self._stored.previous_master_key = current_key
+            event.set_results({"result": output.strip()})
+        except ops.pebble.ExecError as exc:
+            event.fail(f"Rotation failed: {exc.stderr}")
 
     @property
     def _pebble_layer(self):
@@ -368,6 +487,7 @@ class TestflingerCharm(ops.CharmBase):
             "TESTFLINGER_SECRETS_MASTER_KEY": self.config[
                 "testflinger_secrets_master_key"
             ],
+            "TESTFLINGER_KEY_VAULT_URI": self._fetch_keyvault_uri(),
             "HTTP_PROXY": self.config["http_proxy"],
             "HTTPS_PROXY": self.config["https_proxy"],
             "NO_PROXY": self.config["no_proxy"],

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -487,7 +487,7 @@ class TestflingerCharm(ops.CharmBase):
             "TESTFLINGER_SECRETS_MASTER_KEY": self.config[
                 "testflinger_secrets_master_key"
             ],
-            "TESTFLINGER_KEY_VAULT_URI": self._fetch_keyvault_uri(),
+            "TESTFLINGER_KEY_VAULT_URI": self._fetch_keyvault_uri() or "",
             "HTTP_PROXY": self.config["http_proxy"],
             "HTTPS_PROXY": self.config["https_proxy"],
             "NO_PROXY": self.config["no_proxy"],

--- a/server/charm/tests/integration/test_charm.py
+++ b/server/charm/tests/integration/test_charm.py
@@ -40,8 +40,9 @@ def test_deploy(charm_path: Path, juju: jubilant.Juju):
     # Deploy the mongodb-k8s charm
     juju.deploy(MONGODB_CHARM, channel="6/stable", trust=True)
 
-    # Establish the mongodb_client relation
-    juju.integrate(APP_NAME, MONGODB_CHARM)
+    # Establish the mongodb_client and mongodb_keyvault relations
+    juju.integrate(f"{APP_NAME}:mongodb_client", f"{MONGODB_CHARM}:database")
+    juju.integrate(f"{APP_NAME}:mongodb_keyvault", f"{MONGODB_CHARM}:database")
     juju.wait(jubilant.all_active)
 
 

--- a/server/charm/tests/integration/test_nginx_ingress.py
+++ b/server/charm/tests/integration/test_nginx_ingress.py
@@ -48,8 +48,9 @@ def test_deploy(charm_path: Path, juju: jubilant.Juju):
     # Deploy the mongodb-k8s charm
     juju.deploy(MONGODB_CHARM, channel="6/stable", trust=True)
 
-    # Establish the mongodb_client relation
-    juju.integrate(APP_NAME, MONGODB_CHARM)
+    # Establish the mongodb_client and mongodb_keyvault relations
+    juju.integrate(f"{APP_NAME}:mongodb_client", f"{MONGODB_CHARM}:database")
+    juju.integrate(f"{APP_NAME}:mongodb_keyvault", f"{MONGODB_CHARM}:database")
     juju.wait(jubilant.all_active)
 
     # Deploy the nginx-ingress-integrator charm

--- a/server/charm/tests/integration/test_traefik_ingress.py
+++ b/server/charm/tests/integration/test_traefik_ingress.py
@@ -55,8 +55,9 @@ def test_deploy(charm_path: Path, juju: jubilant.Juju):
     # Deploy the mongodb-k8s charm
     juju.deploy(MONGODB_CHARM, channel="6/stable", trust=True)
 
-    # Establish the mongodb_client relation
-    juju.integrate(APP_NAME, MONGODB_CHARM)
+    # Establish the mongodb_client and mongodb_keyvault relations
+    juju.integrate(f"{APP_NAME}:mongodb_client", f"{MONGODB_CHARM}:database")
+    juju.integrate(f"{APP_NAME}:mongodb_keyvault", f"{MONGODB_CHARM}:database")
     juju.wait(jubilant.all_active)
 
     # Deploy the traefik-k8s charm

--- a/server/charm/tests/unit/conftest.py
+++ b/server/charm/tests/unit/conftest.py
@@ -19,8 +19,71 @@ from ops import testing
 
 from charm import TestflingerCharm
 
+TESTFLINGER_CONTAINER = "testflinger"
+MONGO_DB_REMOTE_DATA = {
+    "endpoints": "mongodb:27017",
+    "username": "testflinger",
+    "password": "testflinger",
+    "database": "testflinger_db",
+    "uris": "mongodb://testflinger:testflinger@mongodb:27017/testflinger_db",
+}
+MONGO_KEY_VAULT_REMOTE_DATA = {
+    "endpoints": "mongodb:27017",
+    "username": "testflinger-keyvault",
+    "password": "keyvault-pass",
+    "database": "encryption",
+    "uris": (
+        "mongodb://testflinger-keyvault:keyvault-pass@mongodb:27017/encryption"
+    ),
+}
+
 
 @pytest.fixture
 def ctx() -> testing.Context:
     """Fixture for Charm context."""
     return testing.Context(TestflingerCharm)
+
+
+@pytest.fixture
+def make_state():
+    """Build test States with configurable parameters."""
+
+    def factory(
+        can_connect: bool = True,
+        config: dict | None = None,
+        stored_key: str | None = None,
+        leader: bool = True,
+    ) -> testing.State:
+        return testing.State(
+            containers=[
+                testing.Container(
+                    name=TESTFLINGER_CONTAINER, can_connect=can_connect
+                )
+            ],
+            leader=leader,
+            relations=[
+                testing.Relation(
+                    endpoint="mongodb_client",
+                    remote_app_name="mongodb",
+                    remote_app_data=MONGO_DB_REMOTE_DATA,
+                ),
+                testing.Relation(
+                    endpoint="mongodb_keyvault",
+                    remote_app_name="mongodb",
+                    remote_app_data=MONGO_KEY_VAULT_REMOTE_DATA,
+                ),
+            ],
+            config=config or {},
+            stored_states={
+                testing.StoredState(
+                    owner_path="TestflingerCharm",
+                    name="_stored",
+                    content={
+                        "reldata": {},
+                        "previous_master_key": stored_key or "",
+                    },
+                )
+            },
+        )
+
+    return factory

--- a/server/charm/tests/unit/helpers.py
+++ b/server/charm/tests/unit/helpers.py
@@ -22,6 +22,6 @@ def generate_b64_key(bytes_n: int = 96) -> str:
     """Generate a random base64-encoded key string for testing.
 
     :param bytes_n: Number of random bytes to generate before encoding.
-    :return: Base64 decoded string of the random bytes.
+    :return: Base64-encoded string of the random bytes.
     """
     return base64.b64encode(os.urandom(bytes_n)).decode()

--- a/server/charm/tests/unit/helpers.py
+++ b/server/charm/tests/unit/helpers.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Helpers for charm unit tests."""
+
+import base64
+import os
+
+
+def generate_b64_key(bytes_n: int = 96) -> str:
+    """Generate a random base64-encoded key string for testing.
+
+    :param bytes_n: Number of random bytes to generate before encoding.
+    :return: Base64 decoded string of the random bytes.
+    """
+    return base64.b64encode(os.urandom(bytes_n)).decode()

--- a/server/charm/tests/unit/test_charm.py
+++ b/server/charm/tests/unit/test_charm.py
@@ -17,6 +17,8 @@
 
 from unittest.mock import Mock, patch
 
+import helpers
+import ops
 import pytest
 from ops import testing
 
@@ -383,3 +385,149 @@ def test_traefik_no_submit_broken_relation(mock_submit_to_traefik, ctx):
 
     # Verify submit_to_traefik is still not called after relation is removed
     mock_submit_to_traefik.assert_not_called()
+
+
+@patch.object(
+    TestflingerCharm, "_run_rotation", return_value="Rotation complete."
+)
+def test_config_changed_rotates_on_master_key_change(
+    mock_rotation, ctx, make_state
+):
+    """Test rotation triggered when master key config changes."""
+    old_key = helpers.generate_b64_key()
+    new_key = helpers.generate_b64_key()
+    state_in = make_state(
+        config={"testflinger_secrets_master_key": new_key},
+        stored_key=old_key,
+    )
+
+    ctx.run(ctx.on.config_changed(), state_in)
+
+    mock_rotation.assert_called_once()
+    env_passed = mock_rotation.call_args[0][0]
+    assert env_passed["TESTFLINGER_SECRETS_MASTER_KEY"] == old_key
+    assert env_passed["TESTFLINGER_SECRETS_NEW_MASTER_KEY"] == new_key
+
+
+@patch.object(
+    TestflingerCharm, "_run_rotation", return_value="Rotation complete."
+)
+def test_config_changed_no_rotation_on_first_key_set(
+    mock_rotation, ctx, make_state
+):
+    """Test rotation not triggered when master key set for the first time."""
+    state_in = make_state(
+        config={"testflinger_secrets_master_key": helpers.generate_b64_key()}
+    )
+    ctx.run(ctx.on.config_changed(), state_in)
+
+    mock_rotation.assert_not_called()
+
+
+@patch.object(
+    TestflingerCharm,
+    "_run_rotation",
+    side_effect=ops.pebble.ExecError(
+        ["rotate_mongo_secrets_key"], 1, "", "error"
+    ),
+)
+def test_config_changed_blocks_on_rotation_failure(_, ctx, make_state):
+    """Test BlockedStatus set when key rotation fails on config change."""
+    state_in = make_state(
+        config={"testflinger_secrets_master_key": helpers.generate_b64_key()},
+        stored_key=helpers.generate_b64_key(),
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert state_out.unit_status == testing.BlockedStatus(
+        "MongoDB CSFLE Master Key rotation failed."
+    )
+
+
+@patch.object(
+    TestflingerCharm, "_run_rotation", return_value="Rotation complete."
+)
+def test_config_changed_no_rotation_on_non_leader(
+    mock_rotation, ctx, make_state
+):
+    """Test rotation not triggered on non-leader units."""
+    state_in = make_state(
+        config={"testflinger_secrets_master_key": helpers.generate_b64_key()},
+        stored_key=helpers.generate_b64_key(),
+        leader=False,
+    )
+
+    ctx.run(ctx.on.config_changed(), state_in)
+
+    mock_rotation.assert_not_called()
+
+
+@patch.object(
+    TestflingerCharm, "_run_rotation", return_value="Rotation complete."
+)
+def test_retry_key_rotation_action_success(mock_rotation, ctx, make_state):
+    """Test retry-key-rotation using stored old key and config new key."""
+    old_key = helpers.generate_b64_key()
+    new_key = helpers.generate_b64_key()
+    state_in = make_state(
+        config={"testflinger_secrets_master_key": new_key},
+        stored_key=old_key,
+    )
+
+    ctx.run(ctx.on.action("retry-key-rotation"), state_in)
+
+    mock_rotation.assert_called_once()
+    env_passed = mock_rotation.call_args[0][0]
+    assert env_passed["TESTFLINGER_SECRETS_MASTER_KEY"] == old_key
+    assert env_passed["TESTFLINGER_SECRETS_NEW_MASTER_KEY"] == new_key
+    assert ctx.action_results == {"result": "Rotation complete."}
+
+
+def test_retry_key_rotation_action_no_master_key(ctx, make_state):
+    """Test retry-key-rotation fails when no master key is configured."""
+    state_in = make_state(config={"testflinger_secrets_master_key": ""})
+    with pytest.raises(testing.ActionFailed):
+        ctx.run(ctx.on.action("retry-key-rotation"), state_in)
+
+
+def test_retry_key_rotation_action_no_pending_rotation(ctx, make_state):
+    """Test retry-key-rotation fails when there is no pending rotation."""
+    current_key = helpers.generate_b64_key()
+    state_in = make_state(
+        config={"testflinger_secrets_master_key": current_key},
+        stored_key=current_key,
+    )
+
+    with pytest.raises(testing.ActionFailed):
+        ctx.run(ctx.on.action("retry-key-rotation"), state_in)
+
+
+def test_retry_key_rotation_action_container_not_ready(ctx, make_state):
+    """Test retry-key-rotation fails when the container is not ready."""
+    state_in = make_state(
+        config={"testflinger_secrets_master_key": helpers.generate_b64_key()},
+        stored_key=helpers.generate_b64_key(),
+        can_connect=False,
+    )
+
+    with pytest.raises(testing.ActionFailed):
+        ctx.run(ctx.on.action("retry-key-rotation"), state_in)
+
+
+@patch.object(
+    TestflingerCharm,
+    "_run_rotation",
+    side_effect=ops.pebble.ExecError(
+        ["rotate_mongo_secrets_key"], 1, "", "connection refused"
+    ),
+)
+def test_retry_key_rotation_action_exec_error(_, ctx, make_state):
+    """Test retry-key-rotation fails when rotation script exits non-zero."""
+    state_in = make_state(
+        config={"testflinger_secrets_master_key": helpers.generate_b64_key()},
+        stored_key=helpers.generate_b64_key(),
+    )
+
+    with pytest.raises(testing.ActionFailed):
+        ctx.run(ctx.on.action("retry-key-rotation"), state_in)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 
 [project.scripts]
 client_credentials_admin = "testflinger.tools.client_credentials_admin:main"
+rotate_mongo_secrets_key = "testflinger.tools.rotate_mongo_secrets_key:main"
 
 [dependency-groups]
 charm = [

--- a/server/src/testflinger/secrets/__init__.py
+++ b/server/src/testflinger/secrets/__init__.py
@@ -44,6 +44,9 @@ formatter = logging.Formatter(
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
+KEY_VAULT_DATABASE = "encryption"
+KEY_VAULT_COLLECTION = "__keyVault"
+
 
 def setup_vault_store() -> VaultStore:
     """
@@ -74,6 +77,40 @@ def setup_vault_store() -> VaultStore:
     return VaultStore(client)
 
 
+def _decode_master_key(b64_key: str) -> bytes:
+    """Decode a base64-encoded master key.
+
+    :param b64_key: Base64-encoded master key string.
+    :return: Raw key bytes.
+    :raises StoreError: If the string is not valid base64.
+    """
+    try:
+        return base64.b64decode(b64_key)
+    except (binascii.Error, ValueError) as error:
+        raise StoreError(
+            "Environment variables with Mongo credentials are incorrect"
+        ) from error
+
+
+def _make_cipher(
+    key_vault_client: MongoClient,
+    master_key: bytes,
+    key_vault_namespace: str,
+) -> ClientEncryption:
+    """Create a ClientEncryption instance for the given master key.
+
+    :param key_vault_client: MongoClient with access to the key vault database.
+    :param master_key: Raw master key bytes.
+    :param key_vault_namespace: Fully-qualified key vault namespace.
+    """
+    return ClientEncryption(
+        kms_providers={"local": {"key": master_key}},
+        key_vault_namespace=key_vault_namespace,
+        key_vault_client=key_vault_client,
+        codec_options=CodecOptions(),
+    )
+
+
 def setup_mongo_store() -> MongoStore | None:
     """
     Set up MongoDB-based secrets store with Client-Side Field Level Encryption.
@@ -97,38 +134,30 @@ def setup_mongo_store() -> MongoStore | None:
     if not master_key_b64:
         return None
 
-    try:
-        master_key = base64.b64decode(master_key_b64)
-    except (binascii.Error, ValueError) as error:
-        raise StoreError(
-            "Environment variables with Mongo credentials are incorrect"
-        ) from error
+    master_key = _decode_master_key(master_key_b64)
 
     # Explicit Client-Side Field-Level Encryption
     # Reference: https://www.mongodb.com/docs/manual/core/csfle/fundamentals/manual-encryption/
     # PyMongo docs: https://pymongo.readthedocs.io/en/stable/examples/encryption.html#explicit-encryption-and-decryption
     client = MongoClient(mongo_url)
 
-    kms_providers = {"local": {"key": master_key}}
-    # database and collection where secrets are stored (the "vault")
-    ### key_vault_db = "encryption"
-    # [CAUTION] You should not use the same database for the encryption keys
-    # This is only for testing in staging, not to release in production
-    key_vault_db = client.get_default_database().name
-    key_vault_collection = "__keyVault"
+    # Production instance should use a dedicated client for the key vault.
+    # For dev testing, reuse the same MongoClient instance if URI not provided.
+    key_vault_uri = os.environ.get("TESTFLINGER_KEY_VAULT_URI")
+    key_vault_client = MongoClient(key_vault_uri) if key_vault_uri else client
+
     # human-readable name for the data key that encrypts the secrets
     key_name = "testflinger-secrets"
     # all encryption/decryption of secret values goes through the cipher
     # (i.e. a `ClientEncryption` object)
-    cipher = ClientEncryption(
-        kms_providers=kms_providers,
-        key_vault_namespace=f"{key_vault_db}.{key_vault_collection}",
-        key_vault_client=client,
-        codec_options=CodecOptions(),
+    cipher = _make_cipher(
+        key_vault_client=key_vault_client,
+        master_key=master_key,
+        key_vault_namespace=f"{KEY_VAULT_DATABASE}.{KEY_VAULT_COLLECTION}",
     )
 
     # create data encryption key, if none exists
-    key_vault = client[key_vault_db][key_vault_collection]
+    key_vault = key_vault_client[KEY_VAULT_DATABASE][KEY_VAULT_COLLECTION]
     existing_key = key_vault.find_one({"keyAltNames": key_name})
     if not existing_key:
         try:

--- a/server/src/testflinger/secrets/__init__.py
+++ b/server/src/testflinger/secrets/__init__.py
@@ -96,15 +96,17 @@ def _make_cipher(
     key_vault_client: MongoClient,
     master_key: bytes,
     key_vault_namespace: str,
+    kms_providers: dict | None = None,
 ) -> ClientEncryption:
     """Create a ClientEncryption instance for the given master key.
 
     :param key_vault_client: MongoClient with access to the key vault database.
     :param master_key: Raw master key bytes.
     :param key_vault_namespace: Fully-qualified key vault namespace.
+    :param kms_providers: Optional KMS providers map.
     """
     return ClientEncryption(
-        kms_providers={"local": {"key": master_key}},
+        kms_providers=kms_providers or {"local": {"key": master_key}},
         key_vault_namespace=key_vault_namespace,
         key_vault_client=key_vault_client,
         codec_options=CodecOptions(),

--- a/server/src/testflinger/secrets/__init__.py
+++ b/server/src/testflinger/secrets/__init__.py
@@ -26,7 +26,7 @@ from bson.codec_options import CodecOptions
 from hvac import Client
 from pymongo import MongoClient
 from pymongo.encryption import ClientEncryption
-from pymongo.errors import EncryptionError
+from pymongo.errors import DuplicateKeyError, EncryptionError
 
 from testflinger.database import get_mongo_uri
 from testflinger.secrets.exceptions import StoreError
@@ -158,12 +158,23 @@ def setup_mongo_store() -> MongoStore | None:
         key_vault_namespace=f"{KEY_VAULT_DATABASE}.{KEY_VAULT_COLLECTION}",
     )
 
-    # create data encryption key, if none exists
+    # Ensure the unique partial index on keyAltNames exists so that concurrent
+    # units cannot create duplicate DEKs for the same key_name.
     key_vault = key_vault_client[KEY_VAULT_DATABASE][KEY_VAULT_COLLECTION]
+    key_vault.create_index(
+        "keyAltNames",
+        unique=True,
+        partialFilterExpression={"keyAltNames": {"$exists": True}},
+    )
+
+    # create data encryption key, if none exists
     existing_key = key_vault.find_one({"keyAltNames": key_name})
     if not existing_key:
         try:
             cipher.create_data_key("local", key_alt_names=[key_name])
+        except DuplicateKeyError:
+            # A concurrent unit won the race and already created the DEK.
+            pass
         except EncryptionError as error:
             raise StoreError(
                 f"Failed to create data encryption key: {error}"

--- a/server/src/testflinger/secrets/__init__.py
+++ b/server/src/testflinger/secrets/__init__.py
@@ -26,7 +26,7 @@ from bson.codec_options import CodecOptions
 from hvac import Client
 from pymongo import MongoClient
 from pymongo.encryption import ClientEncryption
-from pymongo.errors import DuplicateKeyError, EncryptionError
+from pymongo.errors import DuplicateKeyError, EncryptionError, PyMongoError
 
 from testflinger.database import get_mongo_uri
 from testflinger.secrets.exceptions import StoreError
@@ -82,14 +82,20 @@ def _decode_master_key(b64_key: str) -> bytes:
 
     :param b64_key: Base64-encoded master key string.
     :return: Raw key bytes.
-    :raises StoreError: If the string is not valid base64.
+    :raises StoreError: If string is not valid base64 or incorrect length.
     """
     try:
-        return base64.b64decode(b64_key)
+        key_bytes = base64.b64decode(b64_key, validate=True)
     except (binascii.Error, ValueError) as error:
         raise StoreError(
-            "Environment variables with Mongo credentials are incorrect"
+            "Invalid TESTFLINGER_SECRETS_MASTER_KEY: value is not valid base64"
         ) from error
+    if len(key_bytes) != 96:
+        raise StoreError(
+            "Invalid TESTFLINGER_SECRETS_MASTER_KEY: "
+            "decoded key must be 96 bytes for MongoDB local KMS"
+        )
+    return key_bytes
 
 
 def _make_cipher(
@@ -161,24 +167,29 @@ def setup_mongo_store() -> MongoStore | None:
     # Ensure the unique partial index on keyAltNames exists so that concurrent
     # units cannot create duplicate DEKs for the same key_name.
     key_vault = key_vault_client[KEY_VAULT_DATABASE][KEY_VAULT_COLLECTION]
-    key_vault.create_index(
-        "keyAltNames",
-        unique=True,
-        partialFilterExpression={"keyAltNames": {"$exists": True}},
-    )
+    try:
+        key_vault.create_index(
+            "keyAltNames",
+            unique=True,
+            partialFilterExpression={"keyAltNames": {"$exists": True}},
+        )
 
-    # create data encryption key, if none exists
-    existing_key = key_vault.find_one({"keyAltNames": key_name})
-    if not existing_key:
-        try:
-            cipher.create_data_key("local", key_alt_names=[key_name])
-        except DuplicateKeyError:
-            # A concurrent unit won the race and already created the DEK.
-            pass
-        except EncryptionError as error:
-            raise StoreError(
-                f"Failed to create data encryption key: {error}"
-            ) from error
+        # create data encryption key, if none exists
+        existing_key = key_vault.find_one({"keyAltNames": key_name})
+        if not existing_key:
+            try:
+                cipher.create_data_key("local", key_alt_names=[key_name])
+            except DuplicateKeyError:
+                # A concurrent unit won the race and already created the DEK.
+                pass
+            except EncryptionError as error:
+                raise StoreError(
+                    f"Failed to create data encryption key: {error}"
+                ) from error
+    except PyMongoError as error:
+        raise StoreError(
+            f"Failed to access the key vault collection: {error}"
+        ) from error
 
     return MongoStore(client, cipher, key_name)
 

--- a/server/src/testflinger/tools/rotate_mongo_secrets_key.py
+++ b/server/src/testflinger/tools/rotate_mongo_secrets_key.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2025 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tool for rotating the MongoDB secrets master key.
+
+Re-wraps all DEKs in __keyVault under a new master key using
+rewrap_many_data_key. Secret values are not touched. Triggered automatically
+by the charm when testflinger_secrets_master_key config changes.
+
+Environment variables:
+  TESTFLINGER_SECRETS_MASTER_KEY      current master key (base64, required)
+  TESTFLINGER_SECRETS_NEW_MASTER_KEY  new master key (base64, required)
+  TESTFLINGER_KEY_VAULT_URI           key vault MongoDB URI (optional);
+                                      falls back to MONGODB_* when unset
+  MONGODB_*                           standard MongoDB connection variables
+"""
+
+import os
+import sys
+
+from pymongo import MongoClient
+
+from testflinger.database import get_mongo_uri
+from testflinger.secrets import (
+    KEY_VAULT_COLLECTION,
+    KEY_VAULT_DATABASE,
+    _decode_master_key,
+    _make_cipher,
+)
+
+
+def rotate_master_key(
+    old_master_key: bytes,
+    new_master_key: bytes,
+    key_vault_ns: str,
+    key_vault_uri: str,
+) -> None:
+    """Re-wrap all DEKs in __keyVault under a new master key.
+
+    :param old_master_key: Current master key bytes.
+    :param new_master_key: New master key bytes.
+    :param key_vault_ns: Namespace of the key vault collection
+    :param key_vault_uri: URI for the key vault database.
+    """
+    key_vault_client = MongoClient(key_vault_uri)
+    cipher = _make_cipher(
+        key_vault_client, old_master_key, key_vault_ns
+    )
+    try:
+        print("Re-wrapping DEK(s) under new master key...")
+        result = cipher.rewrap_many_data_key(
+            {},
+            provider="local",
+            master_key={"key": new_master_key},
+        )
+        count = (
+            result.bulk_write_result.modified_count
+            if result.bulk_write_result
+            else 0
+        )
+        print(f"Re-wrapped {count} DEK(s).")
+    finally:
+        cipher.close()
+
+    print("Rotation complete.")
+
+
+def main() -> None:
+    """Entry point for the rotate_mongo_secrets_key script."""
+    old_b64 = os.environ.get("TESTFLINGER_SECRETS_MASTER_KEY")
+    new_b64 = os.environ.get("TESTFLINGER_SECRETS_NEW_MASTER_KEY")
+
+    if not old_b64 or not new_b64:
+        print(
+            "Error: both TESTFLINGER_SECRETS_MASTER_KEY and "
+            "TESTFLINGER_SECRETS_NEW_MASTER_KEY are required.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Production should use a separate URI for the key vault
+    # Dev testing can build the URI from the MONGODB_* env vars
+    mongo_uri = os.environ.get("TESTFLINGER_KEY_VAULT_URI") or get_mongo_uri()
+
+    rotate_master_key(
+        old_master_key=_decode_master_key(old_b64),
+        new_master_key=_decode_master_key(new_b64),
+        key_vault_ns=f"{KEY_VAULT_DATABASE}.{KEY_VAULT_COLLECTION}",
+        key_vault_uri=mongo_uri,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/server/src/testflinger/tools/rotate_mongo_secrets_key.py
+++ b/server/src/testflinger/tools/rotate_mongo_secrets_key.py
@@ -57,45 +57,46 @@ def rotate_master_key(
     key_vault_client = MongoClient(key_vault_uri)
     print("Re-wrapping DEK(s) under new master key...")
 
-    # Create a cipher with old and new master keys as separate KMS providers.
-    # Required as rewrap_many_data_key does not support passing
-    # master_key directly to "local" KMS provider.
-    cipher = _make_cipher(
-        key_vault_client,
-        old_master_key,
-        key_vault_ns,
-        kms_providers={
-            "local": {"key": old_master_key},
-            "local:new": {"key": new_master_key},
-        },
-    )
     try:
-        result = cipher.rewrap_many_data_key({}, provider="local:new")
-        count = (
-            result.bulk_write_result.modified_count
-            if result.bulk_write_result
-            else 0
+        # Create cipher with old and new master keys as separate KMS providers.
+        # Required as rewrap_many_data_key does not support passing
+        # master_key directly to "local" KMS provider.
+        cipher = _make_cipher(
+            key_vault_client,
+            old_master_key,
+            key_vault_ns,
+            kms_providers={
+                "local": {"key": old_master_key},
+                "local:new": {"key": new_master_key},
+            },
         )
+        try:
+            result = cipher.rewrap_many_data_key({}, provider="local:new")
+            count = (
+                result.bulk_write_result.modified_count
+                if result.bulk_write_result
+                else 0
+            )
+        finally:
+            cipher.close()
+        # Set the new master key in "local" provider and rewrap back to "local"
+        cipher = _make_cipher(
+            key_vault_client,
+            new_master_key,
+            key_vault_ns,
+            kms_providers={
+                "local:new": {"key": new_master_key},
+                "local": {"key": new_master_key},
+            },
+        )
+        try:
+            cipher.rewrap_many_data_key({}, provider="local")
+        finally:
+            cipher.close()
+        print(f"Re-wrapped {count} DEK(s).")
+        print("Rotation complete.")
     finally:
-        cipher.close()
-
-    # Set the new master key in "local" provider and re-wrap back to "local"
-    cipher = _make_cipher(
-        key_vault_client,
-        new_master_key,
-        key_vault_ns,
-        kms_providers={
-            "local:new": {"key": new_master_key},
-            "local": {"key": new_master_key},
-        },
-    )
-    try:
-        cipher.rewrap_many_data_key({}, provider="local")
-    finally:
-        cipher.close()
-
-    print(f"Re-wrapped {count} DEK(s).")
-    print("Rotation complete.")
+        key_vault_client.close()
 
 
 def main() -> None:

--- a/server/src/testflinger/tools/rotate_mongo_secrets_key.py
+++ b/server/src/testflinger/tools/rotate_mongo_secrets_key.py
@@ -55,25 +55,46 @@ def rotate_master_key(
     :param key_vault_uri: URI for the key vault database.
     """
     key_vault_client = MongoClient(key_vault_uri)
+    print("Re-wrapping DEK(s) under new master key...")
+
+    # Create a cipher with old and new master keys as separate KMS providers.
+    # Required as rewrap_many_data_key does not support passing
+    # master_key directly to "local" KMS provider.
     cipher = _make_cipher(
-        key_vault_client, old_master_key, key_vault_ns
+        key_vault_client,
+        old_master_key,
+        key_vault_ns,
+        kms_providers={
+            "local": {"key": old_master_key},
+            "local:new": {"key": new_master_key},
+        },
     )
     try:
-        print("Re-wrapping DEK(s) under new master key...")
-        result = cipher.rewrap_many_data_key(
-            {},
-            provider="local",
-            master_key={"key": new_master_key},
-        )
+        result = cipher.rewrap_many_data_key({}, provider="local:new")
         count = (
             result.bulk_write_result.modified_count
             if result.bulk_write_result
             else 0
         )
-        print(f"Re-wrapped {count} DEK(s).")
     finally:
         cipher.close()
 
+    # Set the new master key in "local" provider and re-wrap back to "local"
+    cipher = _make_cipher(
+        key_vault_client,
+        new_master_key,
+        key_vault_ns,
+        kms_providers={
+            "local:new": {"key": new_master_key},
+            "local": {"key": new_master_key},
+        },
+    )
+    try:
+        cipher.rewrap_many_data_key({}, provider="local")
+    finally:
+        cipher.close()
+
+    print(f"Re-wrapped {count} DEK(s).")
     print("Rotation complete.")
 
 

--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -44,10 +44,24 @@ resource "juju_integration" "testflinger-database-relation" {
 
   application {
     name = juju_application.testflinger.name
+    endpoint = "mongodb_client"
   }
 
   application {
     offer_url = var.db_offer
+  }
+}
+
+resource "juju_integration" "testflinger_encryption_relation" {
+  model = local.app_model
+
+  application {
+    name     = juju_application.testflinger.name
+    endpoint = "mongodb_keyvault"
+  }
+
+  application {
+    offer_url = var.encryption_offer
   }
 }
 

--- a/server/terraform/variables.tf
+++ b/server/terraform/variables.tf
@@ -33,6 +33,12 @@ variable "db_offer" {
   default     = "admin/testflinger-dev-db.mongodb"
 }
 
+variable "encryption_offer" {
+  description = "Name of the juju offer for encryption database to use for the cross-model relation"
+  type        = string
+  default     = "admin/testflinger-dev-db.mongodb"
+}
+
 variable "nginx_ingress_integrator_charm_whitelist_source_range" {
   description = "Allowed client IP source ranges. The value is a comma separated list of CIDRs."
   type        = string

--- a/server/tests/test_mongo_store.py
+++ b/server/tests/test_mongo_store.py
@@ -22,7 +22,12 @@ import pytest
 from bson.binary import Binary
 from pymongo import MongoClient
 from pymongo.encryption import ClientEncryption
-from pymongo.errors import ConnectionFailure, DuplicateKeyError, EncryptionError, OperationFailure
+from pymongo.errors import (
+    ConnectionFailure,
+    DuplicateKeyError,
+    EncryptionError,
+    OperationFailure,
+)
 
 from testflinger.secrets import setup_mongo_store
 from testflinger.secrets.exceptions import (
@@ -445,7 +450,7 @@ class TestSetupMongoStore:
     def test_setup_mongo_store_key_creation_error(
         self, mocker, valid_master_key, mock_mongo_setup
     ):
-        """Test setup_mongo_store raises StoreError on unexpected EncryptionError."""
+        """Test setup_mongo_store raises StoreError on EncryptionError."""
         mock_client, mock_cipher, mock_store = mock_mongo_setup
 
         # Mock the key vault to return no existing key
@@ -472,7 +477,7 @@ class TestSetupMongoStore:
         mock_client, mock_cipher, mock_store = mock_mongo_setup
 
         mock_key_vault = mocker.Mock()
-        mock_key_vault.find_one.return_value = {"_id": "existing-key"}
+        mock_key_vault.find_one.return_value = {"_id": "existing-uuid"}
         mock_database = mocker.Mock()
         mock_database.__getitem__ = mocker.Mock(return_value=mock_key_vault)
         mock_client.__getitem__ = mocker.Mock(return_value=mock_database)

--- a/server/tests/test_mongo_store.py
+++ b/server/tests/test_mongo_store.py
@@ -394,7 +394,10 @@ class TestSetupMongoStore:
 
         with pytest.raises(
             StoreError,
-            match="Environment variables with Mongo credentials are incorrect",
+            match=(
+                "Invalid TESTFLINGER_SECRETS_MASTER_KEY: "
+                "value is not valid base64"
+            ),
         ):
             setup_mongo_store()
 
@@ -513,3 +516,43 @@ class TestSetupMongoStore:
         result = setup_mongo_store()
 
         assert result == mock_store
+
+    def test_setup_mongo_store_index_operation_failure_raises_store_error(
+        self, mocker, valid_master_key, mock_mongo_setup
+    ):
+        """Test setup_mongo_store raises StoreError on OperationFailure."""
+        mock_client, mock_cipher, mock_store = mock_mongo_setup
+
+        mock_key_vault = mocker.Mock()
+        mock_key_vault.create_index.side_effect = OperationFailure(
+            "not authorized on encryption to execute command"
+        )
+        mock_database = mocker.Mock()
+        mock_database.__getitem__ = mocker.Mock(return_value=mock_key_vault)
+        mock_client.__getitem__ = mocker.Mock(return_value=mock_database)
+
+        with pytest.raises(
+            StoreError,
+            match="Failed to access the key vault collection",
+        ):
+            setup_mongo_store()
+
+    def test_setup_mongo_store_connection_failure_raises_store_error(
+        self, mocker, valid_master_key, mock_mongo_setup
+    ):
+        """Test setup_mongo_store raises StoreError on ConnectionFailure."""
+        mock_client, mock_cipher, mock_store = mock_mongo_setup
+
+        mock_key_vault = mocker.Mock()
+        mock_key_vault.find_one.side_effect = ConnectionFailure(
+            "Connection refused"
+        )
+        mock_database = mocker.Mock()
+        mock_database.__getitem__ = mocker.Mock(return_value=mock_key_vault)
+        mock_client.__getitem__ = mocker.Mock(return_value=mock_database)
+
+        with pytest.raises(
+            StoreError,
+            match="Failed to access the key vault collection",
+        ):
+            setup_mongo_store()

--- a/server/tests/test_mongo_store.py
+++ b/server/tests/test_mongo_store.py
@@ -22,7 +22,7 @@ import pytest
 from bson.binary import Binary
 from pymongo import MongoClient
 from pymongo.encryption import ClientEncryption
-from pymongo.errors import ConnectionFailure, EncryptionError, OperationFailure
+from pymongo.errors import ConnectionFailure, DuplicateKeyError, EncryptionError, OperationFailure
 
 from testflinger.secrets import setup_mongo_store
 from testflinger.secrets.exceptions import (
@@ -445,7 +445,7 @@ class TestSetupMongoStore:
     def test_setup_mongo_store_key_creation_error(
         self, mocker, valid_master_key, mock_mongo_setup
     ):
-        """Test setup_mongo_store handles EncryptionError in key creation."""
+        """Test setup_mongo_store raises StoreError on unexpected EncryptionError."""
         mock_client, mock_cipher, mock_store = mock_mongo_setup
 
         # Mock the key vault to return no existing key
@@ -455,7 +455,6 @@ class TestSetupMongoStore:
         mock_database.__getitem__ = mocker.Mock(return_value=mock_key_vault)
         mock_client.__getitem__ = mocker.Mock(return_value=mock_database)
 
-        # Mock cipher to raise EncryptionError on key creation
         mock_cipher.create_data_key.side_effect = EncryptionError(
             "Key creation failed"
         )
@@ -465,3 +464,47 @@ class TestSetupMongoStore:
             match="Failed to create data encryption key: Key creation failed",
         ):
             setup_mongo_store()
+
+    def test_setup_mongo_store_creates_unique_index_on_key_alt_names(
+        self, mocker, valid_master_key, mock_mongo_setup
+    ):
+        """Test setup_mongo_store creates a unique partial index."""
+        mock_client, mock_cipher, mock_store = mock_mongo_setup
+
+        mock_key_vault = mocker.Mock()
+        mock_key_vault.find_one.return_value = {"_id": "existing-key"}
+        mock_database = mocker.Mock()
+        mock_database.__getitem__ = mocker.Mock(return_value=mock_key_vault)
+        mock_client.__getitem__ = mocker.Mock(return_value=mock_database)
+
+        setup_mongo_store()
+
+        mock_key_vault.create_index.assert_called_once_with(
+            "keyAltNames",
+            unique=True,
+            partialFilterExpression={"keyAltNames": {"$exists": True}},
+        )
+
+    def test_setup_mongo_store_key_exists_race_condition(
+        self, mocker, valid_master_key, mock_mongo_setup
+    ):
+        """Test setup_mongo_store completes successfully in a race condition.
+
+        This can happen on K8s deployments when multiple units start
+        simultaneously and attempt to create the same data encryption key.
+        """
+        mock_client, mock_cipher, mock_store = mock_mongo_setup
+
+        mock_key_vault = mocker.Mock()
+        mock_key_vault.find_one.side_effect = [None, {"_id": "existing-key"}]
+        mock_database = mocker.Mock()
+        mock_database.__getitem__ = mocker.Mock(return_value=mock_key_vault)
+        mock_client.__getitem__ = mocker.Mock(return_value=mock_database)
+
+        mock_cipher.create_data_key.side_effect = DuplicateKeyError(
+            "E11000 duplicate key error"
+        )
+
+        result = setup_mongo_store()
+
+        assert result == mock_store

--- a/server/tests/test_rotate_mongo_secrets_key.py
+++ b/server/tests/test_rotate_mongo_secrets_key.py
@@ -28,7 +28,7 @@ MONGO_URI = "mongodb://localhost:27017/testflinger_db"
 
 @pytest.fixture
 def mock_cipher(mocker):
-    """Mock _make_cipher to return a controlled ClientEncryption instance."""
+    """Mock ClientEncryption to return a controlled instance."""
     cipher = mocker.Mock(spec=ClientEncryption)
     cipher.rewrap_many_data_key.return_value = mocker.Mock(
         bulk_write_result=mocker.Mock(modified_count=1)
@@ -42,7 +42,7 @@ def mock_cipher(mocker):
 
 
 def test_rewrap_called_with_new_master_key(mock_cipher):
-    """Test rewrap_many_data_key called with new master key."""
+    """Test rewrap_many_data_key is called for both rotation phases."""
     old_key, new_key = os.urandom(96), os.urandom(96)
     rotate_master_key(
         old_master_key=old_key,
@@ -51,15 +51,14 @@ def test_rewrap_called_with_new_master_key(mock_cipher):
         key_vault_uri=MONGO_URI,
     )
 
-    mock_cipher.rewrap_many_data_key.assert_called_once_with(
-        {},
-        provider="local",
-        master_key={"key": new_key},
-    )
+    # Phase 1: old "local" -> "local:new" (new key)
+    mock_cipher.rewrap_many_data_key.assert_any_call({}, provider="local:new")
+    # Phase 2: "local:new" -> "local" (new key), restoring canonical name
+    mock_cipher.rewrap_many_data_key.assert_any_call({}, provider="local")
 
 
 def test_cipher_closed_on_completion(mock_cipher):
-    """Test that the cipher is closed after rotation."""
+    """Test that the cipher is closed after both rotation phases."""
     rotate_master_key(
         old_master_key=os.urandom(96),
         new_master_key=os.urandom(96),
@@ -67,7 +66,7 @@ def test_cipher_closed_on_completion(mock_cipher):
         key_vault_uri=MONGO_URI,
     )
 
-    mock_cipher.close.assert_called_once()
+    assert mock_cipher.close.call_count == 2
 
 
 def test_prints_rotation_complete(mock_cipher, capsys):

--- a/server/tests/test_rotate_mongo_secrets_key.py
+++ b/server/tests/test_rotate_mongo_secrets_key.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the rotate_mongo_secrets_key tool."""
+
+import base64
+import os
+
+import pytest
+from pymongo.encryption import ClientEncryption
+
+from testflinger.tools.rotate_mongo_secrets_key import main, rotate_master_key
+
+MONGO_URI = "mongodb://localhost:27017/testflinger_db"
+
+
+@pytest.fixture
+def mock_cipher(mocker):
+    """Mock _make_cipher to return a controlled ClientEncryption instance."""
+    cipher = mocker.Mock(spec=ClientEncryption)
+    cipher.rewrap_many_data_key.return_value = mocker.Mock(
+        bulk_write_result=mocker.Mock(modified_count=1)
+    )
+    mocker.patch(
+        "testflinger.tools.rotate_mongo_secrets_key._make_cipher",
+        return_value=cipher,
+    )
+    mocker.patch("testflinger.tools.rotate_mongo_secrets_key.MongoClient")
+    return cipher
+
+
+def test_rewrap_called_with_new_master_key(mock_cipher):
+    """Test rewrap_many_data_key called with new master key."""
+    old_key, new_key = os.urandom(96), os.urandom(96)
+    rotate_master_key(
+        old_master_key=old_key,
+        new_master_key=new_key,
+        key_vault_ns="encryption.__keyVault",
+        key_vault_uri=MONGO_URI,
+    )
+
+    mock_cipher.rewrap_many_data_key.assert_called_once_with(
+        {},
+        provider="local",
+        master_key={"key": new_key},
+    )
+
+
+def test_cipher_closed_on_completion(mock_cipher):
+    """Test that the cipher is closed after rotation."""
+    rotate_master_key(
+        old_master_key=os.urandom(96),
+        new_master_key=os.urandom(96),
+        key_vault_ns="encryption.__keyVault",
+        key_vault_uri=MONGO_URI,
+    )
+
+    mock_cipher.close.assert_called_once()
+
+
+def test_prints_rotation_complete(mock_cipher, capsys):
+    """Test complete message printed after successful rotation."""
+    rotate_master_key(
+        old_master_key=os.urandom(96),
+        new_master_key=os.urandom(96),
+        key_vault_ns="encryption.__keyVault",
+        key_vault_uri=MONGO_URI,
+    )
+
+    assert "Rotation complete." in capsys.readouterr().out
+
+
+def test_exits_when_both_keys_missing(mocker):
+    """Test script exits non-zero when both key env vars are absent."""
+    mocker.patch.dict("os.environ", {}, clear=True)
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code != 0
+
+
+def test_exits_when_new_key_missing(mocker):
+    """Test script exits non-zero when only the new key env var is absent."""
+    key = base64.b64encode(os.urandom(96)).decode()
+    mocker.patch.dict(
+        "os.environ",
+        {"TESTFLINGER_SECRETS_MASTER_KEY": key},
+        clear=True,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code != 0
+
+
+def test_calls_rotate_master_key_when_both_keys_set(mocker):
+    """Test script calls rotate_master_key() when both key env vars are set."""
+    old_key = base64.b64encode(os.urandom(96)).decode()
+    new_key = base64.b64encode(os.urandom(96)).decode()
+    mocker.patch.dict(
+        "os.environ",
+        {
+            "TESTFLINGER_SECRETS_MASTER_KEY": old_key,
+            "TESTFLINGER_SECRETS_NEW_MASTER_KEY": new_key,
+        },
+        clear=True,
+    )
+    mocker.patch(
+        "testflinger.tools.rotate_mongo_secrets_key.get_mongo_uri",
+        return_value=MONGO_URI,
+    )
+    mock_rotate = mocker.patch(
+        "testflinger.tools.rotate_mongo_secrets_key.rotate_master_key"
+    )
+
+    main()
+
+    mock_rotate.assert_called_once()
+    kwargs = mock_rotate.call_args.kwargs
+    assert kwargs["old_master_key"] != kwargs["new_master_key"]
+    assert kwargs["key_vault_uri"] == MONGO_URI


### PR DESCRIPTION
## Description
This PR adds a mechanism to allow the rotation of CMK (Customer Master Key) which is required for encrypting Data Encryption Key (DEK) in production deployment. 

On `config_change`, charm will used the StoredData to identify if master_secret_key was changed. If so, it will leverage the use of `rewrap_many_data_key` to rotate the DEK used for encrypting user secrets. This operation does not require to decrypt the secrets as all user secrets are untouched and only DEK is modified. 

This also requires a new relation to the mongdb charm unit to allow writing/reading from `encryption` database as each db is scoped to the user/password created automatically by the relation. 

Reference:
[Encryption Keys and Key Vaults](https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/keys-key-vaults/)
[CSFLE Explicit Encryption](https://www.mongodb.com/docs/manual/core/csfle/fundamentals/manual-encryption/#std-label-csfle-fundamentals-manual-encryption-client-enc)
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-887](https://warthogs.atlassian.net/browse/CERTTF-887)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Local Testing

1. build and run service containers
```
$ docker compose up -d --build
```

2. populate the database with the data of a single client
```
$ docker exec -it testflinger-server client_credentials_admin
...
{'client_id': 'test_user', 'role': 'contributor', 'max_priority': {}, 'allowed_queues': [], 'max_reservation_time': {}}
...
```

3.- Attempt to write secret (require to be authenticated as test_user)
```
testflinger-cli --server http://localhost:5000/ secret write path/to/secret my-secret-value
Secret 'path/to/secret' written successfully
```

4. Validate secret value is encrypted in the database
```
docker exec -it mongo mongosh
> use admin
> db.auth("testflinger", "testflinger")
> use testflinger_db
> db.secrets.test_user.find()
[
  {
    _id: ObjectId('69c2ce7677356e6ae6938f54'),
    key: 'path/to/secret',
    value: Binary.createFromBase64('Aktd/SQFKk6vsFbm07evgoEF/NhZBuHYBg9JIFVAF5AY4Rg0RXZvmdMguiXg28rVG2v9hA0CqMv24XDi6EMQ5/R9QyncN/cbZOGO2N2kYkFWHrQC2eUW5MiwmUOLhBBukT0=', 6)
  }
]
```
5. Validate DEK
```
> use encryption
switched to db encryption

db.getCollection("__keyVault").find()
[
  {
    _id: UUID('4b5dfd24-052a-4eaf-b056-e6d3b7af8281'),
    keyAltNames: [ 'testflinger-secrets' ],
    keyMaterial: Binary.createFromBase64('Qd60lkOqUFQibUj7chuSYR1JqevE0wHkoTz1X8GtinSgsIwJC7qylhxqBXSjp5DAGE48QsbqJDWr6oHODrjPbkw7oLMPGoIMuJ3+eN0M7Gr+BQ6i0GYF5uE0hhrObJruN5tzk4cndPS4zoWM+oqELM3S9oaNRYNy7IsTcYyAuG0LPBy9Otb6TLnck0x+eMJS20dx/jEkKKyeI6AHYs0FjA==', 0),
    creationDate: ISODate('2026-03-24T17:38:36.191Z'),
    updateDate: ISODate('2026-03-24T17:38:36.191Z'),
    status: 0,
    masterKey: { provider: 'local' }
  }
]
```
6. Run the rotation tool to rotate the master key
```
docker exec -it \
  -e TESTFLINGER_SECRETS_MASTER_KEY="<old_master_key>" \
  -e TESTFLINGER_SECRETS_NEW_MASTER_KEY="<new_master_key>" \
  testflinger-server rotate_mongo_secrets_key

Re-wrapping DEK(s) under new master key...
Re-wrapped 1 DEK(s).
Rotation complete.
```

7. Validate only the KeyMaterial and updateDate of the DEK was updated
```
db.getCollection("__keyVault").find()
[
  {
    _id: UUID('4b5dfd24-052a-4eaf-b056-e6d3b7af8281'),
    keyAltNames: [ 'testflinger-secrets' ],
    keyMaterial: Binary.createFromBase64('wFQfZ05QNA2vOi4h1/LOX++ITtPYqIWcUz9+/ihKrzrhw998+QvGQevLPaCmcIifN36Ndh2TraUshAt9y+ACeKgQb9EgJRjhulk5judb/DeoRvVbJRS7jMKid0scRmiTKutYn4/LEp6skhZOph2R0OQf5bmHmtNk1tp+3yc63k9umNoNChOCkBEVIFkb+3RymaXp9q8vJt+cSwoiO7vukg==', 0),
    creationDate: ISODate('2026-03-24T17:38:36.191Z'),
    updateDate: ISODate('2026-03-24T19:43:34.451Z'),
    status: 0,
    masterKey: { provider: 'local' }
  }
]
```

Staging Testing

1. Refresh charm to edge 272 revision released by this action run: https://github.com/canonical/testflinger/actions/runs/23510486473
2. Once units are settled, set a new mongodb relation for encryption database where DEK are to be stored:
```
juju relate -m testflinger-staging testflinger:mongodb_keyvault mongodb
```

3. Validate there are now two relation to the same mongo charm unit but different DB (each one scoped with a different user/password/access):
```
juju status -m testflinger-staging --relations
mongodb:database                               testflinger:mongodb_client                     mongodb_client           regular  
mongodb:database                               testflinger:mongodb_keyvault                   mongodb_client           regular  
```

4. Set master key by deploying Terraform plan via: https://github.com/canonical/certification-ops/actions/runs/23516697248/job/68450711479

5. Create secret:
```
testflinger-cli --server https://testflinger-staging.canonical.com secret write path/to/secret 'my-super-secret'
Secret 'path/to/secret' written successfully
```

6. Submit job with secret:
```
testflinger-cli --server https://testflinger-staging.canonical.com submit ~/Desktop/Testflinger/staging.yaml 
Job submitted successfully!
job_id: 5976918d-1e51-4009-8ab9-32dff45b59b8
```

7. Validate DEK from staging DB:
```
mongodb:PRIMARY> db.getCollection("__keyVault").find()
{ "_id" : UUID("19269794-ebf6-4964-91b5-6cefbe239673"), "keyAltNames" : [ "testflinger-secrets" ], "keyMaterial" : BinData(0,"BGo7fqrBD7iLGSFjNYOmSWddqPqg -- snip snip -- Pxho701B4y6KyNZhg=="), "creationDate" : ISODate("2026-03-24T23:14:04.063Z"), "updateDate" : ISODate("2026-03-24T23:14:04.063Z"), "status" : 0, "masterKey" : { "provider" : "local" } }
```

8. Update Master Secret Key from Vault to enable automatic rotation:
https://github.com/canonical/certification-ops/actions/runs/23553222510/job/68573868183

9. Validate DEK was updated from staging DB this should update the keyMaterial and the updateDate::
```
db.getCollection("__keyVault").find()
{ "_id" : UUID("19269794-ebf6-4964-91b5-6cefbe239673"), "keyAltNames" : [ "testflinger-secrets" ], "keyMaterial" : BinData(0,"gID16BmTgvffDUct+vDIaJ1K30vn -- snip snip -- YqeN8ad9r2f8Zl9TyKmspg=="), "creationDate" : ISODate("2026-03-24T23:14:04.063Z"), "updateDate" : ISODate("2026-03-25T16:54:23.483Z"), "status" : 0, "masterKey" : { "provider" : "local" } }
```

10. Attempt to submit new job, if decryption succeded, job will be able to be submitted:
```
testflinger-cli --server https://testflinger-staging.canonical.com submit -p ~/Desktop/Testflinger/staging.yaml 
Job submitted successfully!
job_id: a7c5b767-1222-4f42-bd1c-9dba1707ebde
This job is waiting on a node to become available.
```


<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-887]: https://warthogs.atlassian.net/browse/CERTTF-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ