### PR TITLE
feat(devices): [maas] add ephemeral deployments

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -308,7 +308,7 @@ class Maas2:
 
     def deploy_node(
         self,
-        distro: str = "bionic",
+        distro: str = "jammy",
         kernel: str | None = None,
         user_data: str | None = None,
         storage_data: list[dict] | None = None,

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -83,7 +83,7 @@ class Maas2:
         # Check if this is a device where we need to clear the tpm (dawson)
         if self.config.get("clear_tpm"):
             self.clear_tpm()
-        provision_data = self.job_data.get("provision_data")
+        provision_data = self.job_data.get("provision_data") or {}
         # Default to a safe LTS if no distro is specified
         distro = provision_data.get("distro", "jammy")
         kernel = provision_data.get("kernel")
@@ -311,7 +311,7 @@ class Maas2:
         distro: str = "bionic",
         kernel: str | None = None,
         user_data: str | None = None,
-        storage_data: dict | None = None,
+        storage_data: list[dict] | None = None,
         ephemeral: bool = False,
     ) -> None:
         """Deploy the node in MAAS with the specified parameters.
@@ -526,13 +526,21 @@ class Maas2:
         """
         cmd = ["maas", self.maas_user, "version", "read"]
 
-        # Using the retry with a faster backoff to avoid long delays
-        proc = self.run_maas_cmd_with_retry(
-            cmd, max_retries=3, backoff_start=10
-        )
-        output_dict = json.loads(proc.stdout.decode())
-        version_str = output_dict.get("version") if output_dict else None
-        if not version_str:
+        try:
+            # Using the retry with a faster backoff to avoid long delays
+            proc = self.run_maas_cmd_with_retry(
+                cmd, max_retries=3, backoff_start=10
+            )
+            output_dict = json.loads(proc.stdout.decode())
+            version_str = output_dict.get("version") if output_dict else None
+            if not version_str:
+                return None
+
+            self._logger_info(f"MAAS version detected: {version_str}")
+            return tuple(int(x) for x in version_str.split("."))
+        except (ProvisioningError, ValueError) as exc:
+            self._logger_warning(
+                f"Unable to determine MAAS version: {exc}. "
+                "Proceeding without ephemeral deployment"
+            )
             return None
-        self._logger_info(f"MAAS version detected: {version_str}")
-        return tuple(int(x) for x in version_str.split("."))

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/maas2.py
@@ -35,6 +35,8 @@ from testflinger_device_connectors.devices.maas2.maas_storage import (
 
 logger = logging.getLogger(__name__)
 
+MAAS_EPHEMERAL_SUPPORT_VERSION = (3, 5, 0)
+
 
 class Maas2:
     """Device Connector for Maas2."""
@@ -87,7 +89,8 @@ class Maas2:
         kernel = provision_data.get("kernel")
         user_data = provision_data.get("user_data")
         storage_data = provision_data.get("disks")
-        self.deploy_node(distro, kernel, user_data, storage_data)
+        ephemeral = provision_data.get("ephemeral", False)
+        self.deploy_node(distro, kernel, user_data, storage_data, ephemeral)
 
     def cleanup(self):
         """Try to release the node in maas at the end of the job."""
@@ -304,8 +307,21 @@ class Maas2:
             retry_count += 1
 
     def deploy_node(
-        self, distro="bionic", kernel=None, user_data=None, storage_data=None
-    ):
+        self,
+        distro: str = "bionic",
+        kernel: str | None = None,
+        user_data: str | None = None,
+        storage_data: dict | None = None,
+        ephemeral: bool = False,
+    ) -> None:
+        """Deploy the node in MAAS with the specified parameters.
+
+        :param distro: The distribution series to deploy (default: bionic)
+        :param kernel: Optional kernel to use for deployment
+        :param user_data: Optional user data to pass to the deployment
+        :param storage_data: Optional storage configuration to apply
+        :param ephemeral: Whether to deploy the node as ephemeral (RAM only)
+        """
         # Deploy the node in maas, default to bionic if nothing is specified
         self.recover()
         status = self.node_status()
@@ -366,6 +382,16 @@ class Maas2:
         if user_data:
             data = base64.b64encode(user_data.encode()).decode()
             cmd.append("user_data={}".format(data))
+
+        # Ephemeral deployment is only supported in MAAS >= 3.5.0
+        if (
+            ephemeral
+            and (maas_version := self.get_maas_version()) is not None
+            and maas_version >= MAAS_EPHEMERAL_SUPPORT_VERSION
+        ):
+            cmd.append("ephemeral_deploy=true")
+            self._logger_info("Deployment set to ephemeral")
+
         proc = self.run_maas_cmd_with_retry(cmd)
 
         # Make sure the device is available before returning
@@ -492,3 +518,21 @@ class Maas2:
             # set-storage-layout failed, log the output if not already done
             if not self.debug:
                 self._logger_error(output)
+
+    def get_maas_version(self) -> tuple[int, ...] | None:
+        """Get MAAS instance version.
+
+        :return: MAAS version as a tuple of ints if available, else None
+        """
+        cmd = ["maas", self.maas_user, "version", "read"]
+
+        # Using the retry with a faster backoff to avoid long delays
+        proc = self.run_maas_cmd_with_retry(
+            cmd, max_retries=3, backoff_start=10
+        )
+        output_dict = json.loads(proc.stdout.decode())
+        version_str = output_dict.get("version") if output_dict else None
+        if not version_str:
+            return None
+        self._logger_info(f"MAAS version detected: {version_str}")
+        return tuple(int(x) for x in version_str.split("."))

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/conftest.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/conftest.py
@@ -35,7 +35,7 @@ def mock_config_file(tmp_path, mock_config):
     return config_yaml
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_maas_storage():
     with patch(
         "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/conftest.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/conftest.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def mock_config():
+    return {
+        "maas_user": "user",
+        "node_id": "abc",
+        "agent_name": "agent001",
+        "device_ip": "10.10.10.10",
+    }
+
+
+@pytest.fixture
+def mock_config_file(tmp_path, mock_config):
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text(yaml.safe_dump(mock_config))
+    return config_yaml
+
+
+@pytest.fixture
+def mock_maas_storage():
+    with patch(
+        "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
+        return_value=None,
+    ) as mock_storage:
+        yield mock_storage

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
@@ -61,11 +61,11 @@ def test_maas_cmd_retry(mock_config_file):
         patch("time.sleep", return_value=None) as mocked_time_sleep,
     ):
         maas2 = Maas2(config=mock_config_file, job_data=job_json)
-        cmd = "my_maas_cmd"
+        cmd = ["my_maas_cmd"]
         with pytest.raises(ProvisioningError) as err:
             maas2.run_maas_cmd_with_retry(cmd)
-            assert err.messsage == "error"
 
+        assert "error" in str(err.value)
         assert mocked_time_sleep.call_count == 6
 
 
@@ -301,8 +301,10 @@ def test_get_maas_version(mock_run_maas_cmd, mock_config_file):
 
 
 @patch.object(Maas2, "run_maas_cmd_with_retry")
-def test_get_maas_version_failure(mock_run_maas_cmd, mock_config_file):
-    """Test that get_maas_version returns None when version not retrieved."""
+def test_get_maas_version_returns_none_on_empty_response(
+    mock_run_maas_cmd, mock_config_file
+):
+    """Test that get_maas_version returns None when version key is absent."""
     job_json = mock_config_file.parent / "job.json"
     job_json.write_text(json.dumps({"provision_data": {"ephemeral": True}}))
 
@@ -313,13 +315,29 @@ def test_get_maas_version_failure(mock_run_maas_cmd, mock_config_file):
         returncode=0,
         stdout=json.dumps({}).encode(),
     )
-    version = maas2.get_maas_version()
-    assert version is None
+    assert maas2.get_maas_version() is None
     mock_run_maas_cmd.assert_called_once_with(
         ["maas", "user", "version", "read"],
         max_retries=3,
         backoff_start=10,
     )
+
+
+@patch.object(Maas2, "run_maas_cmd_with_retry")
+def test_get_maas_version_returns_none_on_provisioning_error(
+    mock_run_maas_cmd, mock_config_file, caplog
+):
+    """Test that get_maas_version returns None on ProvisioningError."""
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({"provision_data": {"ephemeral": True}}))
+
+    maas2 = Maas2(config=mock_config_file, job_data=job_json)
+
+    mock_run_maas_cmd.side_effect = ProvisioningError("maas command failed")
+
+    assert maas2.get_maas_version() is None
+    assert "Unable to determine MAAS version" in caplog.text
+    assert "Proceeding without ephemeral deployment" in caplog.text
 
 
 @patch("time.sleep")

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
@@ -371,4 +371,154 @@ def test_provision_defaults_to_jammy(tmp_path):
             maas2.provision()
 
             # Verify deploy_node was called with jammy as the default distro
-            mock_deploy.assert_called_once_with("jammy", None, None, None)
+            mock_deploy.assert_called_once_with(
+                "jammy", None, None, None, False
+            )
+
+
+@patch.object(Maas2, "run_maas_cmd_with_retry")
+def test_get_maas_version(
+    mock_run_maas_cmd, mock_maas_storage, mock_config_file
+):
+    """Test that get_maas_version returns the expected MAAS version tuple."""
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({"provision_data": {"ephemeral": True}}))
+
+    maas2 = Maas2(config=mock_config_file, job_data=job_json)
+
+    mock_run_maas_cmd.return_value = subprocess.CompletedProcess(
+        args=["maas", "user", "version", "read"],
+        returncode=0,
+        stdout=json.dumps({"version": "3.5.0"}).encode(),
+    )
+    version = maas2.get_maas_version()
+    assert version == (3, 5, 0)
+    mock_run_maas_cmd.assert_called_once_with(
+        ["maas", "user", "version", "read"],
+        max_retries=3,
+        backoff_start=10,
+    )
+
+
+@patch.object(Maas2, "run_maas_cmd_with_retry")
+def test_get_maas_version_failure(
+    mock_run_maas_cmd, mock_maas_storage, mock_config_file
+):
+    """Test that get_maas_version returns None when version not retrieved."""
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({"provision_data": {"ephemeral": True}}))
+
+    maas2 = Maas2(config=mock_config_file, job_data=job_json)
+
+    mock_run_maas_cmd.return_value = subprocess.CompletedProcess(
+        args=["maas", "user", "version", "read"],
+        returncode=0,
+        stdout=json.dumps({}).encode(),
+    )
+    version = maas2.get_maas_version()
+    assert version is None
+    mock_run_maas_cmd.assert_called_once_with(
+        ["maas", "user", "version", "read"],
+        max_retries=3,
+        backoff_start=10,
+    )
+
+
+@patch(
+    "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
+    return_value=None,
+)
+@patch("time.sleep")
+@patch.object(Maas2, "check_test_image_booted", return_value=True)
+@patch.object(Maas2, "node_status", return_value="Deployed")
+@patch.object(Maas2, "run_maas_cmd_with_retry")
+@patch.object(Maas2, "set_flat_storage_layout")
+@patch.object(Maas2, "recover")
+@patch.object(Maas2, "get_maas_version", return_value=(3, 5, 0))
+def test_get_maas_version_called_on_ephemeral(
+    mock_get_version,
+    mock_recover,
+    mock_flat_storage,
+    mock_run_cmd,
+    mock_node_status,
+    mock_check_booted,
+    mock_sleep,
+    mock_maas_storage,
+    mock_config_file,
+):
+    """Test get_maas_version is called when ephemeral is True in job data."""
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({"provision_data": {"ephemeral": True}}))
+
+    maas2 = Maas2(config=mock_config_file, job_data=job_json)
+    maas2.deploy_node(ephemeral=True)
+
+    mock_get_version.assert_called_once()
+
+
+@patch(
+    "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
+    return_value=None,
+)
+@patch("time.sleep")
+@patch.object(Maas2, "check_test_image_booted", return_value=True)
+@patch.object(Maas2, "node_status", return_value="Deployed")
+@patch.object(Maas2, "run_maas_cmd_with_retry")
+@patch.object(Maas2, "set_flat_storage_layout")
+@patch.object(Maas2, "recover")
+@patch.object(Maas2, "get_maas_version", return_value=(3, 4, 0))
+def test_ephemeral_deploy_skipped_on_old_maas_version(
+    mock_get_version,
+    mock_recover,
+    mock_flat_storage,
+    mock_run_cmd,
+    mock_node_status,
+    mock_check_booted,
+    mock_sleep,
+    mock_maas_storage,
+    mock_config_file,
+):
+    """Test ephemeral_deploy=true is not sent when MAAS version < 3.5.0."""
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({"provision_data": {"ephemeral": True}}))
+
+    maas2 = Maas2(config=mock_config_file, job_data=job_json)
+    maas2.deploy_node(ephemeral=True)
+
+    # run_maas_cmd_with_retry is called twice: allocate (0) and deploy (1)
+    deploy_cmd = mock_run_cmd.call_args_list[1][0][0]
+    assert "ephemeral_deploy=true" not in deploy_cmd
+
+
+@patch(
+    "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
+    return_value=None,
+)
+@patch("time.sleep")
+@patch.object(Maas2, "check_test_image_booted", return_value=True)
+@patch.object(Maas2, "node_status", return_value="Deployed")
+@patch.object(Maas2, "run_maas_cmd_with_retry")
+@patch.object(Maas2, "set_flat_storage_layout")
+@patch.object(Maas2, "recover")
+@patch.object(Maas2, "get_maas_version", return_value=(3, 5, 0))
+def test_non_ephemeral_deploy(
+    mock_get_version,
+    mock_recover,
+    mock_flat_storage,
+    mock_run_cmd,
+    mock_node_status,
+    mock_check_booted,
+    mock_sleep,
+    mock_maas_storage,
+    mock_config_file,
+):
+    """Test ephemeral_deploy=true is not sent when ephemeral is False."""
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({"provision_data": {"ephemeral": False}}))
+
+    maas2 = Maas2(config=mock_config_file, job_data=job_json)
+    maas2.deploy_node(ephemeral=False)
+
+    # run_maas_cmd_with_retry is called twice: allocate (0) and deploy (1)
+    deploy_cmd = mock_run_cmd.call_args_list[1][0][0]
+    assert "ephemeral_deploy=true" not in deploy_cmd

--- a/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/maas2/tests/test_maas.py
@@ -22,7 +22,6 @@ from collections import namedtuple
 from unittest.mock import patch
 
 import pytest
-import yaml
 
 from testflinger_device_connectors.devices import (
     ProvisioningError,
@@ -34,57 +33,43 @@ from testflinger_device_connectors.devices.maas2.maas_storage import (
 )
 
 
-def test_maas2_agent_invalid_storage(tmp_path):
+def test_maas2_agent_invalid_storage(mock_maas_storage, mock_config_file):
     """Test maas2 agent raises an exception when storage init fails."""
-    config_yaml = tmp_path / "config.yaml"
-    config = {"maas_user": "user", "node_id": "abc", "agent_name": "agent001"}
-    config_yaml.write_text(yaml.safe_dump(config))
+    mock_maas_storage.side_effect = MaasStorageError
 
-    job_json = tmp_path / "job.json"
-    job = {}
-    job_json.write_text(json.dumps(job))
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({}))
 
     with pytest.raises(MaasStorageError) as err:
-        Maas2(config=config_yaml, job_data=job_json)
+        Maas2(config=mock_config_file, job_data=job_json)
 
     # MaasStorageError should also be a subclass of ProvisioningError
     assert isinstance(err.value, ProvisioningError)
 
 
-def test_maas_cmd_retry(tmp_path):
+def test_maas_cmd_retry(mock_config_file):
     """Test that maas commands get retried when the command returns an
     exit code.
     """
     Process = namedtuple("Process", ["returncode", "stdout"])
-    with patch(
-        "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-        return_value=None,
+
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({}))
+
+    with (
+        patch("subprocess.run", return_value=Process(1, b"error")),
+        patch("time.sleep", return_value=None) as mocked_time_sleep,
     ):
-        with (
-            patch("subprocess.run", return_value=Process(1, b"error")),
-            patch("time.sleep", return_value=None) as mocked_time_sleep,
-        ):
-            config_yaml = tmp_path / "config.yaml"
-            config = {
-                "maas_user": "user",
-                "node_id": "abc",
-                "agent_name": "agent001",
-            }
-            config_yaml.write_text(yaml.safe_dump(config))
+        maas2 = Maas2(config=mock_config_file, job_data=job_json)
+        cmd = "my_maas_cmd"
+        with pytest.raises(ProvisioningError) as err:
+            maas2.run_maas_cmd_with_retry(cmd)
+            assert err.messsage == "error"
 
-            job_json = tmp_path / "job.json"
-            job = {}
-            job_json.write_text(json.dumps(job))
-            maas2 = Maas2(config=config_yaml, job_data=job_json)
-            cmd = "my_maas_cmd"
-            with pytest.raises(ProvisioningError) as err:
-                maas2.run_maas_cmd_with_retry(cmd)
-                assert err.messsage == "error"
-
-            assert mocked_time_sleep.call_count == 6
+        assert mocked_time_sleep.call_count == 6
 
 
-def test_reset_efi_prioritizes_current_boot_device(tmp_path):
+def test_reset_efi_prioritizes_current_boot_device(mock_config_file):
     """Test that reset_efi prioritizes the currently booted network device."""
     Process = namedtuple("Process", ["returncode", "stdout"])
 
@@ -97,39 +82,25 @@ def test_reset_efi_prioritizes_current_boot_device(tmp_path):
         Boot0002* Ethernet 1Gb 4-port Adapter - NIC (PXE IPv4)
     """)
 
-    with patch(
-        "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-        return_value=None,
-    ):
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                Process(0, efibootmgr_output.encode()),  # _get_efi_data
-                Process(0, b""),  # _set_efi_data
-            ]
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({}))
 
-            config_yaml = tmp_path / "config.yaml"
-            config = {
-                "maas_user": "user",
-                "node_id": "abc",
-                "agent_name": "agent001",
-                "device_ip": "10.10.10.10",
-            }
-            config_yaml.write_text(yaml.safe_dump(config))
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            Process(0, efibootmgr_output.encode()),  # _get_efi_data
+            Process(0, b""),  # _set_efi_data
+        ]
 
-            job_json = tmp_path / "job.json"
-            job = {}
-            job_json.write_text(json.dumps(job))
+        maas2 = Maas2(config=mock_config_file, job_data=job_json)
+        maas2.reset_efi()
 
-            maas2 = Maas2(config=config_yaml, job_data=job_json)
-            maas2.reset_efi()
-
-            set_efi_call = mock_run.call_args_list[1]
-            boot_order_arg = set_efi_call[0][0][-1]
-            expected_order = "sudo efibootmgr -o 0002,0001,0000"
-            assert expected_order in boot_order_arg
+        set_efi_call = mock_run.call_args_list[1]
+        boot_order_arg = set_efi_call[0][0][-1]
+        expected_order = "sudo efibootmgr -o 0002,0001,0000"
+        assert expected_order in boot_order_arg
 
 
-def test_reset_efi_handles_non_ipv4_current_boot(tmp_path):
+def test_reset_efi_handles_non_ipv4_current_boot(mock_config_file):
     """Test that reset_efi handles cases where current boot is not IPv4."""
     Process = namedtuple("Process", ["returncode", "stdout"])
 
@@ -142,39 +113,25 @@ def test_reset_efi_handles_non_ipv4_current_boot(tmp_path):
         Boot0002* Ethernet 1Gb 4-port Adapter - NIC (PXE IPv4)
     """)
 
-    with patch(
-        "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-        return_value=None,
-    ):
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                Process(0, efibootmgr_output.encode()),  # _get_efi_data
-                Process(0, b""),  # _set_efi_data
-            ]
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({}))
 
-            config_yaml = tmp_path / "config.yaml"
-            config = {
-                "maas_user": "user",
-                "node_id": "abc",
-                "agent_name": "agent001",
-                "device_ip": "10.10.10.10",
-            }
-            config_yaml.write_text(yaml.safe_dump(config))
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            Process(0, efibootmgr_output.encode()),  # _get_efi_data
+            Process(0, b""),  # _set_efi_data
+        ]
 
-            job_json = tmp_path / "job.json"
-            job = {}
-            job_json.write_text(json.dumps(job))
+        maas2 = Maas2(config=mock_config_file, job_data=job_json)
+        maas2.reset_efi()
 
-            maas2 = Maas2(config=config_yaml, job_data=job_json)
-            maas2.reset_efi()
-
-            set_efi_call = mock_run.call_args_list[1]
-            boot_order_arg = set_efi_call[0][0][-1]
-            expected_order = "sudo efibootmgr -o 0001,0002,0000"
-            assert expected_order in boot_order_arg
+        set_efi_call = mock_run.call_args_list[1]
+        boot_order_arg = set_efi_call[0][0][-1]
+        expected_order = "sudo efibootmgr -o 0001,0002,0000"
+        assert expected_order in boot_order_arg
 
 
-def test_maas_release_succeeds(tmp_path, capsys, caplog):
+def test_maas_release_succeeds(mock_config_file, mock_config, capsys, caplog):
     """Test MAAS release succeeds and don't return any output."""
     Process = namedtuple("Process", ["returncode", "stdout"])
 
@@ -189,35 +146,21 @@ def test_maas_release_succeeds(tmp_path, capsys, caplog):
         }
     )
 
-    with patch(
-        "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-        return_value=None,
-    ):
-        with patch("subprocess.run") as mock_run, patch("time.sleep"):
-            mock_run.side_effect = [
-                Process(0, mock_maas_output.encode()),  # maas release
-                Process(0, mock_maas_output.encode()),  # maas read
-            ]
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({}))
 
-            config_yaml = tmp_path / "config.yaml"
-            config = {
-                "maas_user": "user",
-                "node_id": "abc",
-                "agent_name": "agent001",
-                "device_ip": "10.10.10.10",
-            }
-            config_yaml.write_text(yaml.safe_dump(config))
+    with patch("subprocess.run") as mock_run, patch("time.sleep"):
+        mock_run.side_effect = [
+            Process(0, mock_maas_output.encode()),  # maas release
+            Process(0, mock_maas_output.encode()),  # maas read
+        ]
 
-            job_json = tmp_path / "job.json"
-            job = {}
-            job_json.write_text(json.dumps(job))
-
-            maas2 = Maas2(config=config_yaml, job_data=job_json)
-            with caplog.at_level(
-                logging.INFO,
-                logger="testflinger_device_connectors.devices.maas2.maas2",
-            ):
-                maas2.node_release()
+        maas2 = Maas2(config=mock_config_file, job_data=job_json)
+        with caplog.at_level(
+            logging.INFO,
+            logger="testflinger_device_connectors.devices.maas2.maas2",
+        ):
+            maas2.node_release()
 
     # Verify release and read where called
     assert mock_run.call_count == 2
@@ -226,10 +169,10 @@ def test_maas_release_succeeds(tmp_path, capsys, caplog):
     first_call_args = mock_run.call_args_list[0][0][0]
     assert first_call_args == [
         "maas",
-        config["maas_user"],
+        mock_config["maas_user"],
         "machine",
         "release",
-        config["node_id"],
+        mock_config["node_id"],
     ]
 
     # Verify release command output was captured but not printed
@@ -238,7 +181,7 @@ def test_maas_release_succeeds(tmp_path, capsys, caplog):
     assert captured_output.out == ""
 
 
-def test_maas_release_fails(tmp_path, capsys, caplog):
+def test_maas_release_fails(mock_config_file, mock_config, capsys, caplog):
     """Test MAAS release fails and output is properly logged."""
     Process = namedtuple("Process", ["returncode", "stdout"])
 
@@ -253,39 +196,25 @@ def test_maas_release_fails(tmp_path, capsys, caplog):
         }
     )
 
-    with patch(
-        "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-        return_value=None,
-    ):
-        with patch("subprocess.run") as mock_run, patch("time.sleep"):
-            mock_run.side_effect = [
-                Process(0, mock_maas_output.encode()),  # maas release
-            ] + [
-                Process(0, mock_maas_output.encode())  # maas read (30 times)
-            ] * 30
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({}))
 
-            config_yaml = tmp_path / "config.yaml"
-            config = {
-                "maas_user": "user",
-                "node_id": "abc",
-                "agent_name": "agent001",
-                "device_ip": "10.10.10.10",
-            }
-            config_yaml.write_text(yaml.safe_dump(config))
+    with patch("subprocess.run") as mock_run, patch("time.sleep"):
+        mock_run.side_effect = [
+            Process(0, mock_maas_output.encode()),  # maas release
+        ] + [
+            Process(0, mock_maas_output.encode())  # maas read (30 times)
+        ] * 30
 
-            job_json = tmp_path / "job.json"
-            job = {}
-            job_json.write_text(json.dumps(job))
-
-            maas2 = Maas2(config=config_yaml, job_data=job_json)
-            with (
-                caplog.at_level(
-                    logging.ERROR,
-                    logger="testflinger_device_connectors.devices.maas2.maas2",
-                ),
-                pytest.raises(RecoveryError),
-            ):
-                maas2.node_release()
+        maas2 = Maas2(config=mock_config_file, job_data=job_json)
+        with (
+            caplog.at_level(
+                logging.ERROR,
+                logger="testflinger_device_connectors.devices.maas2.maas2",
+            ),
+            pytest.raises(RecoveryError),
+        ):
+            maas2.node_release()
 
     # Verify no output to console, this is handled by the logger
     captured_output = capsys.readouterr()
@@ -293,37 +222,26 @@ def test_maas_release_fails(tmp_path, capsys, caplog):
 
     # Verify errors were logged
     assert (
-        f'Device {config["agent_name"]} still in "Deployed" state'
+        f'Device {mock_config["agent_name"]} still in "Deployed" state'
         in caplog.text
     )
     assert mock_maas_output in caplog.text
 
 
-def test_set_flat_storage_layout_no_output(tmp_path, capsys):
+def test_set_flat_storage_layout_no_output(
+    mock_config_file, mock_config, capsys
+):
     """Test set_flat_storage_layout does not print any output."""
     Process = namedtuple("Process", ["returncode", "stdout"])
 
-    with patch(
-        "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-        return_value=None,
-    ):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Process(0, b"storage layout set")
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({}))
 
-            config_yaml = tmp_path / "config.yaml"
-            config = {
-                "maas_user": "user",
-                "node_id": "abc",
-                "agent_name": "agent001",
-            }
-            config_yaml.write_text(yaml.safe_dump(config))
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = Process(0, b"storage layout set")
 
-            job_json = tmp_path / "job.json"
-            job = {}
-            job_json.write_text(json.dumps(job))
-
-            maas2 = Maas2(config=config_yaml, job_data=job_json)
-            maas2.set_flat_storage_layout()
+        maas2 = Maas2(config=mock_config_file, job_data=job_json)
+        maas2.set_flat_storage_layout()
 
     # Verify command was called
     assert mock_run.call_count == 1
@@ -332,10 +250,10 @@ def test_set_flat_storage_layout_no_output(tmp_path, capsys):
     call_args = mock_run.call_args_list[0][0][0]
     assert call_args == [
         "maas",
-        config["maas_user"],
+        mock_config["maas_user"],
         "machine",
         "set-storage-layout",
-        config["node_id"],
+        mock_config["node_id"],
         "storage_layout=flat",
     ]
 
@@ -345,41 +263,23 @@ def test_set_flat_storage_layout_no_output(tmp_path, capsys):
     assert captured_output.out == ""
 
 
-def test_provision_defaults_to_jammy(tmp_path):
+def test_provision_defaults_to_jammy(mock_config_file):
     """Test that provision defaults to jammy when no distro is specified."""
-    with patch(
-        "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-        return_value=None,
-    ):
-        config_yaml = tmp_path / "config.yaml"
-        config = {
-            "maas_user": "user",
-            "node_id": "abc",
-            "agent_name": "agent001",
-        }
-        config_yaml.write_text(yaml.safe_dump(config))
+    job_json = mock_config_file.parent / "job.json"
+    job_json.write_text(json.dumps({"provision_data": {}}))
 
-        job_json = tmp_path / "job.json"
-        # Job data with provision_data but no distro specified
-        job = {"provision_data": {}}
-        job_json.write_text(json.dumps(job))
+    maas2 = Maas2(config=mock_config_file, job_data=job_json)
 
-        maas2 = Maas2(config=config_yaml, job_data=job_json)
+    # Mock the deploy_node method to verify it's called with jammy
+    with patch.object(maas2, "deploy_node") as mock_deploy:
+        maas2.provision()
 
-        # Mock the deploy_node method to verify it's called with jammy
-        with patch.object(maas2, "deploy_node") as mock_deploy:
-            maas2.provision()
-
-            # Verify deploy_node was called with jammy as the default distro
-            mock_deploy.assert_called_once_with(
-                "jammy", None, None, None, False
-            )
+        # Verify deploy_node was called with jammy as the default distro
+        mock_deploy.assert_called_once_with("jammy", None, None, None, False)
 
 
 @patch.object(Maas2, "run_maas_cmd_with_retry")
-def test_get_maas_version(
-    mock_run_maas_cmd, mock_maas_storage, mock_config_file
-):
+def test_get_maas_version(mock_run_maas_cmd, mock_config_file):
     """Test that get_maas_version returns the expected MAAS version tuple."""
     job_json = mock_config_file.parent / "job.json"
     job_json.write_text(json.dumps({"provision_data": {"ephemeral": True}}))
@@ -401,9 +301,7 @@ def test_get_maas_version(
 
 
 @patch.object(Maas2, "run_maas_cmd_with_retry")
-def test_get_maas_version_failure(
-    mock_run_maas_cmd, mock_maas_storage, mock_config_file
-):
+def test_get_maas_version_failure(mock_run_maas_cmd, mock_config_file):
     """Test that get_maas_version returns None when version not retrieved."""
     job_json = mock_config_file.parent / "job.json"
     job_json.write_text(json.dumps({"provision_data": {"ephemeral": True}}))
@@ -424,10 +322,6 @@ def test_get_maas_version_failure(
     )
 
 
-@patch(
-    "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-    return_value=None,
-)
 @patch("time.sleep")
 @patch.object(Maas2, "check_test_image_booted", return_value=True)
 @patch.object(Maas2, "node_status", return_value="Deployed")
@@ -443,7 +337,6 @@ def test_get_maas_version_called_on_ephemeral(
     mock_node_status,
     mock_check_booted,
     mock_sleep,
-    mock_maas_storage,
     mock_config_file,
 ):
     """Test get_maas_version is called when ephemeral is True in job data."""
@@ -456,10 +349,6 @@ def test_get_maas_version_called_on_ephemeral(
     mock_get_version.assert_called_once()
 
 
-@patch(
-    "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-    return_value=None,
-)
 @patch("time.sleep")
 @patch.object(Maas2, "check_test_image_booted", return_value=True)
 @patch.object(Maas2, "node_status", return_value="Deployed")
@@ -475,7 +364,6 @@ def test_ephemeral_deploy_skipped_on_old_maas_version(
     mock_node_status,
     mock_check_booted,
     mock_sleep,
-    mock_maas_storage,
     mock_config_file,
 ):
     """Test ephemeral_deploy=true is not sent when MAAS version < 3.5.0."""
@@ -490,10 +378,6 @@ def test_ephemeral_deploy_skipped_on_old_maas_version(
     assert "ephemeral_deploy=true" not in deploy_cmd
 
 
-@patch(
-    "testflinger_device_connectors.devices.maas2.maas2.MaasStorage",
-    return_value=None,
-)
 @patch("time.sleep")
 @patch.object(Maas2, "check_test_image_booted", return_value=True)
 @patch.object(Maas2, "node_status", return_value="Deployed")
@@ -509,7 +393,6 @@ def test_non_ephemeral_deploy(
     mock_node_status,
     mock_check_booted,
     mock_sleep,
-    mock_maas_storage,
     mock_config_file,
 ):
     """Test ephemeral_deploy=true is not sent when ephemeral is False."""

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -104,6 +104,7 @@ class MAASProvisionData(Schema):
     user_data = fields.String(required=False)
     # [TODO] Specify Nested schema to improve validation
     disks = fields.List(fields.Dict(), required=False)
+    ephemeral = fields.Boolean(required=False)
 
 
 class MultiProvisionData(Schema):


### PR DESCRIPTION
## Description
This add MAAS ephemeral deployment that is available since [MAAS 3.5+](https://canonical.com/maas/docs/about-deploying-machines#p-17464-ephemeral-os-deployments-maas-35)

From release notes:

> - The entire operating system runs from memory, with no disk installation.
> - This is useful for stateless workloads, temporary testing, or security-sensitive use cases.
> - For Ubuntu images, MAAS configures full networking automatically. For non-Ubuntu images, only the PXE interface is configured; additional interfaces must be set up manually.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-724](https://warthogs.atlassian.net/browse/CERTTF-724)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests and fixture for this feature. As a bonus, I reused the fixture for the current tests in `test_maas.py` to reduce the amount of configuration lines in tests. 

Additionally, tested on staging environment:
```
testflinger-cli --server https://testflinger-staging.canonical.com submit -p ~/Desktop/Testflinger/staging.yaml
...
026-04-01 22:23:32,936 audino INFO: DEVICE CONNECTOR: MAAS: Acquiring node
2026-04-01 22:23:35,669 audino INFO: DEVICE CONNECTOR: MAAS: Starting node audino with distro noble
2026-04-01 22:23:37,491 audino INFO: DEVICE CONNECTOR: MAAS: MAAS version detected: 3.7.1
2026-04-01 22:23:37,491 audino INFO: DEVICE CONNECTOR: MAAS: Deployment set to ephemeral
2026-04-01 22:23:41,860 audino INFO: DEVICE CONNECTOR: MAAS: Timeout value: 60 minutes.
2026-04-01 22:24:41,920 audino INFO: DEVICE CONNECTOR: MAAS: 1 minutes passed since deployment.
2026-04-01 22:25:44,297 audino INFO: DEVICE CONNECTOR: MAAS: 2 minutes passed since deployment.
2026-04-01 22:26:46,560 audino INFO: DEVICE CONNECTOR: MAAS: 3 minutes passed since deployment.
2026-04-01 22:26:48,830 audino INFO: DEVICE CONNECTOR: MAAS: Checking if test image booted.
2026-04-01 22:27:02,525 audino INFO: DEVICE CONNECTOR: MAAS: Deployed and booted.
```

Validate ephemeral deployment (no mounted disk):
```
lsblk 
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
loop0         7:0    0 267.9M  0 loop /media/root-ro
nvme0n1     259:0    0 372.6G  0 disk 
├─nvme0n1p1 259:1    0   512M  0 part 
└─nvme0n1p2 259:2    0 372.1G  0 part 

df -h
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           6.3G  2.0M  6.3G   1% /run
efivarfs        176K  123K   48K  72% /sys/firmware/efi/efivars
tmpfs-root       32G   66M   32G   1% /media/root-rw
overlayroot      32G   66M   32G   1% /
copymods         32G   39M   32G   1% /usr/lib/modules
tmpfs            32G     0   32G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           6.3G   12K  6.3G   1% /run/user/1000
```


<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-724]: https://warthogs.atlassian.net/browse/CERTTF-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ