### PR TITLE
change: when possible (REST allows it), always power cycle the control host

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -322,6 +322,7 @@ class DefaultControlHost:
             requests.post(url, timeout=10).raise_for_status()
             with contextlib.suppress(TimeoutError):
                 self.wait_offline(self._check_ping, 30)
+                time.sleep(10)  # extra safety time for shutdown
             self.reboot()
             self.wait_ready(timeout=300)
         except requests.RequestException:

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -146,10 +146,176 @@ class RealSerialLogger:
 
 
 class DefaultControlHost:
-    """Holds constants and defaults for control host interactions."""
+    """Manages all interactions with a control host.
+
+    Attributes:
+        host: The hostname or IP of the control host.
+        reboot_script: Ordered list of shell commands to trigger a reboot.
+    """
 
     REST_PORT = 8000
     POWEROFF_ENDPOINT = "/api/v1/system/poweroff"
+
+    def __init__(
+        self, host: str, reboot_script: Optional[list[str]] = None
+    ) -> None:
+        self.host = host
+        self.reboot_script = reboot_script or []
+
+    def _check_ssh(self) -> None:
+        """Check whether the control host has an active SSH server.
+
+        :raises ConnectionError: If the SSH server is not reachable.
+        """
+        timeout = 3
+        try:
+            subprocess.run(
+                ["/usr/bin/nc", "-z", "-w", str(timeout), self.host, "22"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            logger.debug(
+                "The control host %s has an available SSH server", self.host
+            )
+        except subprocess.CalledProcessError as e:
+            raise ConnectionError from e
+
+    def _check_rest_api(self) -> None:
+        """Check whether the control host has an active REST API.
+
+        :raises ConnectionError: If the API is not reachable.
+        """
+        try:
+            url = f"http://{self.host}:{self.REST_PORT}/health"
+            resp = requests.get(url, timeout=3)
+            resp.raise_for_status()
+            logger.debug("The host %s has an available REST API", self.host)
+        except requests.RequestException as e:
+            raise ConnectionError from e
+
+    def wait_online(self, check: Callable, timeout: int) -> None:
+        """Poll using ``check`` until it succeeds or the timeout expires.
+
+        :param check: Callable that raises ConnectionError when unreachable.
+        :param timeout: Maximum seconds to wait.
+        :raises TimeoutError: If the host is not available within the timeout.
+        """
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                check()
+                break
+            except ConnectionError:
+                time.sleep(2)
+        else:
+            raise TimeoutError
+
+    def wait_offline(self, check: Callable, timeout: int) -> None:
+        """Poll using ``check`` until it raises or the timeout expires.
+
+        :param check: Callable that raises ConnectionError when unreachable.
+        :param timeout: Maximum seconds to wait.
+        :raises TimeoutError: If the host is still reachable after the timeout.
+        """
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                check()
+                time.sleep(2)
+            except ConnectionError:
+                break
+        else:
+            raise TimeoutError
+
+    def wait_ready(self, timeout: int = 60) -> None:
+        """Wait for the REST API to become available.
+
+        :param timeout: Maximum seconds to wait (default: 60).
+        :raises TimeoutError: If the API is not available within the timeout.
+        """
+        logger.info("Waiting for the REST API on control host %s", self.host)
+        self.wait_online(self._check_rest_api, timeout)
+
+    def reboot(self) -> None:
+        """Run the configured reboot script."""
+        logger.info("Running control host reboot script")
+        for cmd in self.reboot_script:
+            try:
+                logger.info("Executing: %s", cmd)
+                subprocess.run(
+                    cmd,
+                    shell=True,
+                    check=True,
+                    timeout=60,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                logger.error(
+                    "Command failed: %s (exit code: %d)", cmd, e.returncode
+                )
+                if e.stdout:
+                    logger.error("stdout: %s", e.stdout)
+                if e.stderr:
+                    logger.error("stderr: %s", e.stderr)
+            except subprocess.TimeoutExpired:
+                logger.error("Command timed out after 60s: %s", cmd)
+            except Exception as e:
+                logger.error(
+                    "Unexpected error running command %s: %s", cmd, str(e)
+                )
+
+    def ssh_fallback(self) -> None:
+        """Reboot if SSH is unreachable, then wait for SSH to come back."""
+        with contextlib.suppress(ConnectionError):
+            self._check_ssh()
+            logger.debug("The control host is reachable over SSH.")
+            return
+
+        self.reboot()
+
+        timeout = 300
+        logger.info(
+            "Waiting for control host %s to come back online "
+            "(timeout: %d seconds)",
+            self.host,
+            timeout,
+        )
+        try:
+            self.wait_online(self._check_ssh, timeout)
+        except TimeoutError:
+            logger.error(
+                "Control host %s is not available "
+                "or the SSH server is not running after %d seconds",
+                self.host,
+                timeout,
+            )
+
+    def power_cycle(self) -> None:
+        """Power cycle the control host.
+
+        Tries to power off via the REST API, trigger a reboot, then wait for
+        the REST API to come back.  Falls back to SSH-based logic if the REST
+        API is not available.
+        """
+        try:
+            logger.info("Attempt to power cycle the control host.")
+            url = (
+                f"http://{self.host}:{self.REST_PORT}{self.POWEROFF_ENDPOINT}"
+            )
+            requests.post(url, timeout=10).raise_for_status()
+            with contextlib.suppress(TimeoutError):
+                self.wait_offline(self._check_rest_api, 30)
+            self.reboot()
+            self.wait_ready(timeout=300)
+        except requests.RequestException:
+            logger.warning(
+                "The REST API is not available on %s, "
+                "falling back to SSH-based control host check",
+                self.host,
+            )
+            self.ssh_fallback()
 
 
 class DefaultDevice:
@@ -425,130 +591,8 @@ class DefaultDevice:
         )
         time.sleep(int(timeout))
 
-    def __check_ssh_server_on_host(self, host: str) -> None:
-        """
-        Check if the host has an active SSH server running.
-
-        :raises ConnectionError in case the server is not reachable.
-        """
-        timeout = 3
-        try:
-            subprocess.run(
-                ["/usr/bin/nc", "-z", "-w", str(timeout), host, "22"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            logger.debug(
-                "The control host %s has an available SSH server", host
-            )
-        except subprocess.CalledProcessError as e:
-            raise ConnectionError from e
-
-    @staticmethod
-    def _check_rest_api_on_host(host: str) -> None:
-        """Check if the host has an active REST API.
-
-        :raises ConnectionError: If the API is not reachable.
-        """
-        try:
-            url = f"http://{host}:{DefaultControlHost.REST_PORT}/health"
-            resp = requests.get(url, timeout=3)
-            resp.raise_for_status()
-            logger.debug("The host %s has an available REST API", host)
-        except requests.RequestException as e:
-            raise ConnectionError from e
-
-    @staticmethod
-    def wait_ready(host: str, timeout: int = 60) -> None:
-        """Wait for the REST API to become available on the host.
-
-        :param host: The host to check for REST API availability.
-        :param timeout: Maximum time to wait in seconds (default: 60).
-        :raises TimeoutError: If the API is not available within the timeout.
-        """
-        logger.info("Waiting for the REST API on control host %s", host)
-        DefaultDevice.wait_online(
-            DefaultDevice._check_rest_api_on_host, host, timeout
-        )
-
-    @staticmethod
-    def wait_online(check: Callable, host: str, timeout: int) -> None:
-        """Poll the host server using `check` until it's available.
-
-        :param check: callable that takes a host string and raises
-            ConnectionError if the host is unreachable.
-        :param host: the host address to check.
-        :param timeout: maximum time to wait in seconds.
-        :raises TimeoutError: if the host is not available within the timeout.
-        """
-        start_time = time.time()
-        while time.time() - start_time < timeout:
-            try:
-                check(host)
-                break
-            except ConnectionError:
-                time.sleep(2)
-        else:
-            raise TimeoutError
-
-    @staticmethod
-    def wait_offline(check: Callable, host: str, timeout: int) -> None:
-        """Poll the host server using `check` until it's unreachable.
-
-        :param check: callable that takes a host string and raises
-            ConnectionError if the host is unreachable.
-        :param host: the host address to check.
-        :param timeout: maximum time to wait in seconds.
-        :raises TimeoutError: if the host is still reachable after the timeout.
-        """
-        start_time = time.time()
-        while time.time() - start_time < timeout:
-            try:
-                check(host)
-                time.sleep(2)
-            except ConnectionError:
-                break
-        else:
-            raise TimeoutError
-
-    def _reboot_control_host(self, reboot_script: list[str]) -> None:
-        logger.info("Running control host reboot script")
-        for cmd in reboot_script:
-            try:
-                logger.info("Executing: %s", cmd)
-                subprocess.run(
-                    cmd,
-                    shell=True,
-                    check=True,
-                    timeout=60,
-                    capture_output=True,
-                    text=True,
-                )
-            except subprocess.CalledProcessError as e:
-                logger.error(
-                    "Command failed: %s (exit code: %d)", cmd, e.returncode
-                )
-                if e.stdout:
-                    logger.error("stdout: %s", e.stdout)
-                if e.stderr:
-                    logger.error("stderr: %s", e.stderr)
-            except subprocess.TimeoutExpired:
-                logger.error("Command timed out after 60s: %s", cmd)
-            except Exception as e:
-                logger.error(
-                    "Unexpected error running command %s: %s", cmd, str(e)
-                )
-
     def pre_provision_hook(self):
-        """Power cycle the control host before provisioning.
-
-        Tries to power off the control host via the REST API, reboot it,
-        and wait for the REST API to come back online.
-
-        If the REST API is not available, falls back to an SSH-based
-        check: reboots only if SSH is unreachable, then waits for SSH.
-        """
+        """Power cycle the control host before provisioning."""
         control_host: str = str(self.config.get("control_host", ""))
         if not control_host:
             logger.debug("No control host configured for this agent.")
@@ -564,56 +608,7 @@ class DefaultDevice:
             )
             return
 
-        try:
-            logger.info("Attempt to power cycle the control host.")
-            url = (
-                f"http://{control_host}"
-                f":{DefaultControlHost.REST_PORT}"
-                f"{DefaultControlHost.POWEROFF_ENDPOINT}"
-            )
-            requests.post(url, timeout=10).raise_for_status()
-            with contextlib.suppress(TimeoutError):
-                self.wait_offline(
-                    self._check_rest_api_on_host, control_host, 30
-                )
-            self._reboot_control_host(reboot_script)
-            self.wait_ready(control_host, timeout=300)
-        except requests.RequestException:
-            logger.warning(
-                "The REST API is not available on %s, "
-                "falling back to SSH-based control host check",
-                control_host,
-            )
-            self._ssh_fallback(control_host, reboot_script)
-
-    def _ssh_fallback(
-        self, control_host: str, reboot_script: list[str]
-    ) -> None:
-        """Reboot the control host if SSH is unreachable, then wait."""
-        with contextlib.suppress(ConnectionError):
-            self.__check_ssh_server_on_host(control_host)
-            logger.debug("The control host is reachable over SSH.")
-            return
-
-        self._reboot_control_host(reboot_script)
-
-        timeout = 300
-        logger.info(
-            "Waiting for control host %s to come back online "
-            "(timeout: %d seconds)",
-            control_host,
-            timeout,
-        )
-        try:
-            self.wait_online(
-                self.__check_ssh_server_on_host, control_host, timeout
-            )
-        except TimeoutError:
-            msg = (
-                "Control host %s is not available "
-                "or the SSH server is not running after %d seconds"
-            )
-            logger.error(msg, control_host, timeout)
+        DefaultControlHost(control_host, reboot_script).power_cycle()
 
     def provision(self, args):
         """Run pre-provision hook."""

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -181,6 +181,21 @@ class DefaultControlHost:
         except subprocess.CalledProcessError as e:
             raise ConnectionError from e
 
+    def _check_ping(self) -> None:
+        """Check whether the control host responds to ping.
+
+        :raises ConnectionError: If the host does not respond.
+        """
+        try:
+            subprocess.run(
+                ["/usr/bin/ping", "-c", "1", "-W", "3", self.host],
+                check=True,
+                capture_output=True,
+            )
+            logger.debug("The control host %s responds to ping", self.host)
+        except subprocess.CalledProcessError as e:
+            raise ConnectionError from e
+
     def _check_rest_api(self) -> None:
         """Check whether the control host has an active REST API.
 
@@ -306,7 +321,7 @@ class DefaultControlHost:
             )
             requests.post(url, timeout=10).raise_for_status()
             with contextlib.suppress(TimeoutError):
-                self.wait_offline(self._check_rest_api, 30)
+                self.wait_offline(self._check_ping, 30)
             self.reboot()
             self.wait_ready(timeout=300)
         except requests.RequestException:

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -25,6 +25,7 @@ from datetime import datetime, timedelta
 from importlib import import_module
 from typing import Callable, Optional
 
+import requests
 import yaml
 
 import testflinger_device_connectors
@@ -142,6 +143,13 @@ class RealSerialLogger:
     def stop(self):
         """Stop the serial logger."""
         self.proc.terminate()
+
+
+class DefaultControlHost:
+    """Holds constants and defaults for control host interactions."""
+
+    REST_PORT = 8000
+    POWEROFF_ENDPOINT = "/api/v1/system/poweroff"
 
 
 class DefaultDevice:
@@ -438,6 +446,33 @@ class DefaultDevice:
             raise ConnectionError from e
 
     @staticmethod
+    def _check_rest_api_on_host(host: str) -> None:
+        """Check if the host has an active REST API.
+
+        :raises ConnectionError: If the API is not reachable.
+        """
+        try:
+            url = f"http://{host}:{DefaultControlHost.REST_PORT}/health"
+            resp = requests.get(url, timeout=3)
+            resp.raise_for_status()
+            logger.debug("The host %s has an available REST API", host)
+        except requests.RequestException as e:
+            raise ConnectionError from e
+
+    @staticmethod
+    def wait_ready(host: str, timeout: int = 60) -> None:
+        """Wait for the REST API to become available on the host.
+
+        :param host: The host to check for REST API availability.
+        :param timeout: Maximum time to wait in seconds (default: 60).
+        :raises TimeoutError: If the API is not available within the timeout.
+        """
+        logger.info("Waiting for the REST API on control host %s", host)
+        DefaultDevice.wait_online(
+            DefaultDevice._check_rest_api_on_host, host, timeout
+        )
+
+    @staticmethod
     def wait_online(check: Callable, host: str, timeout: int) -> None:
         """Poll the host server using `check` until it's available.
 
@@ -477,19 +512,9 @@ class DefaultDevice:
         else:
             raise TimeoutError
 
-    def _reboot_control_host(self) -> None:
-        control_host_reboot_script: list[str] = [
-            str(cmd)
-            for cmd in self.config.get("control_host_reboot_script", [])
-        ]
-        if not control_host_reboot_script:
-            logger.warning(
-                "No control_host_reboot_script configured, cannot reboot."
-            )
-            return
-
+    def _reboot_control_host(self, reboot_script: list[str]) -> None:
         logger.info("Running control host reboot script")
-        for cmd in control_host_reboot_script:
+        for cmd in reboot_script:
             try:
                 logger.info("Executing: %s", cmd)
                 subprocess.run(
@@ -516,21 +541,61 @@ class DefaultDevice:
                 )
 
     def pre_provision_hook(self):
-        """Execute control host reboot script before provisioning."""
+        """Power cycle the control host before provisioning.
+
+        Tries to power off the control host via the REST API, reboot it,
+        and wait for the REST API to come back online.
+
+        If the REST API is not available, falls back to an SSH-based
+        check: reboots only if SSH is unreachable, then waits for SSH.
+        """
         control_host: str = str(self.config.get("control_host", ""))
         if not control_host:
             logger.debug("No control host configured for this agent.")
             return
 
-        logger.info(
-            "Waiting for a running SSH server on control host %s", control_host
-        )
+        reboot_script: list[str] = [
+            str(cmd)
+            for cmd in self.config.get("control_host_reboot_script", [])
+        ]
+        if not reboot_script:
+            logger.warning(
+                "No control_host_reboot_script configured, cannot reboot."
+            )
+            return
+
+        try:
+            logger.info("Attempt to power cycle the control host.")
+            url = (
+                f"http://{control_host}"
+                f":{DefaultControlHost.REST_PORT}"
+                f"{DefaultControlHost.POWEROFF_ENDPOINT}"
+            )
+            requests.post(url, timeout=10).raise_for_status()
+            with contextlib.suppress(TimeoutError):
+                self.wait_offline(
+                    self._check_rest_api_on_host, control_host, 30
+                )
+            self._reboot_control_host(reboot_script)
+            self.wait_ready(control_host, timeout=300)
+        except requests.RequestException:
+            logger.warning(
+                "The REST API is not available on %s, "
+                "falling back to SSH-based control host check",
+                control_host,
+            )
+            self._ssh_fallback(control_host, reboot_script)
+
+    def _ssh_fallback(
+        self, control_host: str, reboot_script: list[str]
+    ) -> None:
+        """Reboot the control host if SSH is unreachable, then wait."""
         with contextlib.suppress(ConnectionError):
             self.__check_ssh_server_on_host(control_host)
             logger.debug("The control host is reachable over SSH.")
             return
 
-        self._reboot_control_host()
+        self._reboot_control_host(reboot_script)
 
         timeout = 300
         logger.info(

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -215,8 +215,6 @@ class MuxPi:
         if "zapper" not in self.config.get("control_switch_local_cmd", ""):
             self.reboot_sdwire()
             time.sleep(5)
-        else:
-            _, control_host = self.get_credentials()
 
         # determine where to get the provisioning image from
         source = self.job_data["provision_data"].get("url")

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -33,7 +33,6 @@ from testflinger_device_connectors.devices import (
     ProvisioningError,
     RecoveryError,
 )
-from testflinger_device_connectors.devices.zapper import ZapperConnector
 
 logger = logging.getLogger(__name__)
 
@@ -218,12 +217,6 @@ class MuxPi:
             time.sleep(5)
         else:
             _, control_host = self.get_credentials()
-            try:
-                ZapperConnector.wait_ready(control_host)
-            except TimeoutError as e:
-                raise ProvisioningError(
-                    "Cannot reach the Zapper REST API"
-                ) from e
 
         # determine where to get the provisioning image from
         source = self.job_data["provision_data"].get("url")

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -20,7 +20,6 @@ import pytest
 
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
-from testflinger_device_connectors.devices.zapper import ZapperConnector
 
 
 def test_check_ce_oem_iot_image(mocker):
@@ -110,8 +109,8 @@ def test_check_test_image_booted_fails(mocker):
 class TestMuxPiProvisionWithZapper:
     """Tests for MuxPi provision method with zapper configuration."""
 
-    def test_provision_with_zapper_waits_for_rest_api(self, mocker):
-        """Test provision waits for Zapper REST API when using zapper."""
+    def test_provision_with_zapper(self, mocker):
+        """Test provision proceeds normally when using zapper."""
         muxpi = MuxPi()
         muxpi.config = {
             "control_switch_local_cmd": "zapper sdwire set TS",
@@ -128,7 +127,6 @@ class TestMuxPiProvisionWithZapper:
         }
 
         mocker.patch("time.sleep")
-        mock_wait_ready = mocker.patch.object(ZapperConnector, "wait_ready")
         # Mock the rest of provision to avoid running actual provisioning
         mocker.patch.object(muxpi, "flash_test_image")
         mocker.patch.object(muxpi, "hardreset")
@@ -137,8 +135,6 @@ class TestMuxPiProvisionWithZapper:
         mocker.patch.object(muxpi, "run_post_provision_script")
 
         muxpi.provision()
-
-        mock_wait_ready.assert_called_once_with("zapper-host")
 
     def test_provision_without_zapper_reboots_sdwire(self, mocker):
         """Test provision reboots sdwire when not using zapper."""
@@ -159,7 +155,6 @@ class TestMuxPiProvisionWithZapper:
 
         mocker.patch("time.sleep")
         mock_reboot_sdwire = mocker.patch.object(muxpi, "reboot_sdwire")
-        mock_wait_ready = mocker.patch.object(ZapperConnector, "wait_ready")
         # Mock the rest of provision
         mocker.patch.object(muxpi, "flash_test_image")
         mocker.patch.object(muxpi, "hardreset")
@@ -170,4 +165,3 @@ class TestMuxPiProvisionWithZapper:
         muxpi.provision()
 
         mock_reboot_sdwire.assert_called_once()
-        mock_wait_ready.assert_not_called()

--- a/device-connectors/src/testflinger_device_connectors/devices/tests/test_devices.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/tests/test_devices.py
@@ -18,7 +18,10 @@ import subprocess
 import unittest
 from unittest.mock import Mock, call, patch
 
-from testflinger_device_connectors.devices import DefaultDevice
+from testflinger_device_connectors.devices import (
+    DefaultControlHost,
+    DefaultDevice,
+)
 
 
 class DefaultDeviceTests(unittest.TestCase):
@@ -96,7 +99,7 @@ class DefaultDeviceTests(unittest.TestCase):
     def test_wait_online_success(self, _mock_time):
         """Test wait_online returns when the check succeeds."""
         check = Mock(side_effect=[ConnectionError, None])
-        DefaultDevice.wait_online(check, "host", 10)
+        DefaultControlHost("host").wait_online(check, 10)
         assert check.call_count == 2
 
     @patch("time.sleep", Mock())
@@ -105,14 +108,14 @@ class DefaultDeviceTests(unittest.TestCase):
         """Test wait_online raises TimeoutError when check never succeeds."""
         check = Mock(side_effect=ConnectionError)
         with self.assertRaises(TimeoutError):
-            DefaultDevice.wait_online(check, "host", 10)
+            DefaultControlHost("host").wait_online(check, 10)
 
     @patch("time.sleep", Mock())
     @patch("time.time", side_effect=[0, 1, 2, 3])
     def test_wait_offline_success(self, _mock_time):
         """Test wait_offline returns when the check starts failing."""
         check = Mock(side_effect=[None, ConnectionError])
-        DefaultDevice.wait_offline(check, "host", 10)
+        DefaultControlHost("host").wait_offline(check, 10)
         assert check.call_count == 2
 
     @patch("time.sleep", Mock())
@@ -121,7 +124,7 @@ class DefaultDeviceTests(unittest.TestCase):
         """Test wait_offline raises TimeoutError when host stays online."""
         check = Mock()
         with self.assertRaises(TimeoutError):
-            DefaultDevice.wait_offline(check, "host", 10)
+            DefaultControlHost("host").wait_offline(check, 10)
 
     def test_write_device_info(self):
         """Validate device-info file can be read upon class initialization."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -139,7 +139,6 @@ class ZapperConnector(ABC, DefaultDevice):
             return
 
         try:
-            ZapperConnector.wait_ready(control_host)
             ZapperConnector.typecmux_set_state(control_host, "OFF")
         except (TimeoutError, ConnectionError, Exception) as e:
             logger.debug(
@@ -149,12 +148,6 @@ class ZapperConnector(ABC, DefaultDevice):
     def provision(self, args):
         """Provision device when the command is invoked."""
         super().provision(args)
-
-        control_host = self.config["control_host"]
-        try:
-            ZapperConnector.wait_ready(control_host)
-        except TimeoutError as e:
-            raise ProvisioningError("Cannot reach the Zapper REST API") from e
 
         with open(args.job_data, encoding="utf-8") as job_json:
             self.job_data = json.load(job_json)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -100,33 +100,6 @@ class ZapperConnector(ABC, DefaultDevice):
         return response
 
     @staticmethod
-    def _check_rest_api_on_host(host: str) -> None:
-        """Check if the host has an active Zapper REST API.
-
-        :raises ConnectionError: If the API is not reachable.
-        """
-        try:
-            url = f"http://{host}:{ZapperConnector.ZAPPER_REST_PORT}/health"
-            resp = requests.get(url, timeout=3)
-            resp.raise_for_status()
-            logger.debug("The host %s has an available REST API", host)
-        except requests.RequestException as e:
-            raise ConnectionError from e
-
-    @staticmethod
-    def wait_ready(host: str, timeout: int = 60) -> None:
-        """Wait for the Zapper REST API to become available on the host.
-
-        :param host: The host to check for REST API availability.
-        :param timeout: Maximum time to wait in seconds (default: 60).
-        :raises TimeoutError: If the API is not available within the timeout.
-        """
-        logger.info("Waiting for the Zapper REST API on control host %s", host)
-        DefaultDevice.wait_online(
-            ZapperConnector._check_rest_api_on_host, host, timeout
-        )
-
-    @staticmethod
     def typecmux_set_state(host: str, state: str) -> None:
         """Set the typecmux state on a Zapper host via the REST API.
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -21,7 +21,7 @@ import pytest
 import requests
 
 from testflinger_device_connectors.devices import (
-    DefaultDevice,
+    DefaultControlHost,
     ProvisioningError,
 )
 from testflinger_device_connectors.devices.zapper import ZapperConnector
@@ -129,65 +129,59 @@ class ZapperConnectorTests(unittest.TestCase):
 
 
 class TestZapperConnectorRestApiCheck:
-    """Tests for ZapperConnector REST API health check."""
+    """Tests for DefaultControlHost REST API health check."""
 
-    def test_check_rest_api_on_host_success(self, mocker):
-        """Test _check_rest_api_on_host succeeds when API is reachable."""
+    def test_check_rest_api_success(self, mocker):
+        """Test _check_rest_api succeeds when API is reachable."""
         mock_get = mocker.patch("requests.get")
         mock_get.return_value.raise_for_status = Mock()
 
-        ZapperConnector._check_rest_api_on_host("test-host")
+        DefaultControlHost("test-host")._check_rest_api()
 
         mock_get.assert_called_once_with(
             "http://test-host:8000/health", timeout=3
         )
 
-    def test_check_rest_api_on_host_raises_connection_error(self, mocker):
-        """Test the function raises ConnectionError on failure."""
-        mocker.patch(
-            "requests.get",
-            side_effect=requests.ConnectionError,
-        )
+    def test_check_rest_api_raises_connection_error(self, mocker):
+        """Test _check_rest_api raises ConnectionError on failure."""
+        mocker.patch("requests.get", side_effect=requests.ConnectionError)
 
         with pytest.raises(ConnectionError):
-            ZapperConnector._check_rest_api_on_host("test-host")
+            DefaultControlHost("test-host")._check_rest_api()
 
-    def test_check_rest_api_on_host_raises_on_timeout(self, mocker):
-        """Test the function raises ConnectionError on timeout."""
-        mocker.patch(
-            "requests.get",
-            side_effect=requests.Timeout,
-        )
+    def test_check_rest_api_raises_on_timeout(self, mocker):
+        """Test _check_rest_api raises ConnectionError on timeout."""
+        mocker.patch("requests.get", side_effect=requests.Timeout)
 
         with pytest.raises(ConnectionError):
-            ZapperConnector._check_rest_api_on_host("test-host")
+            DefaultControlHost("test-host")._check_rest_api()
 
-    def test_check_rest_api_on_host_raises_on_http_error(self, mocker):
-        """Test the function raises ConnectionError on non-2xx response."""
+    def test_check_rest_api_raises_on_http_error(self, mocker):
+        """Test _check_rest_api raises ConnectionError on non-2xx response."""
         mock_get = mocker.patch("requests.get")
         mock_get.return_value.raise_for_status.side_effect = requests.HTTPError
 
         with pytest.raises(ConnectionError):
-            ZapperConnector._check_rest_api_on_host("test-host")
+            DefaultControlHost("test-host")._check_rest_api()
 
     def test_wait_ready_success(self, mocker):
-        """Test wait_ready calls wait_online with correct parameters."""
-        mock_wait_online = mocker.patch.object(DefaultDevice, "wait_online")
-
-        ZapperConnector.wait_ready("zapper-host", timeout=30)
-
-        mock_wait_online.assert_called_once_with(
-            ZapperConnector._check_rest_api_on_host, "zapper-host", 30
+        """Test wait_ready calls wait_online."""
+        mock_wait_online = mocker.patch.object(
+            DefaultControlHost, "wait_online"
         )
+
+        DefaultControlHost("zapper-host").wait_ready(timeout=30)
+
+        mock_wait_online.assert_called_once()
 
     def test_wait_ready_timeout(self, mocker):
         """Test wait_ready raises TimeoutError when server unavailable."""
         mocker.patch.object(
-            DefaultDevice, "wait_online", side_effect=TimeoutError
+            DefaultControlHost, "wait_online", side_effect=TimeoutError
         )
 
         with pytest.raises(TimeoutError):
-            ZapperConnector.wait_ready("zapper-host")
+            DefaultControlHost("zapper-host").wait_ready()
 
 
 class TestZapperConnectorTypecmux:
@@ -253,28 +247,24 @@ class TestZapperConnectorDisconnectUsbStick:
         """Test disconnect_usb_stick succeeds when Zapper is available."""
         config = {"control_host": "zapper-host", "device_ip": "1.2.3.4"}
 
-        mock_wait_ready = mocker.patch.object(ZapperConnector, "wait_ready")
         mock_typecmux = mocker.patch.object(
             ZapperConnector, "typecmux_set_state"
         )
 
         ZapperConnector.disconnect_usb_stick(config)
 
-        mock_wait_ready.assert_called_once_with("zapper-host")
         mock_typecmux.assert_called_once_with("zapper-host", "OFF")
 
     def test_disconnect_usb_stick_no_control_host(self, mocker):
         """Test disconnect_usb_stick skips when no control_host."""
         config = {"device_ip": "1.2.3.4"}
 
-        mock_wait_ready = mocker.patch.object(ZapperConnector, "wait_ready")
         mock_typecmux = mocker.patch.object(
             ZapperConnector, "typecmux_set_state"
         )
 
         ZapperConnector.disconnect_usb_stick(config)
 
-        mock_wait_ready.assert_not_called()
         mock_typecmux.assert_not_called()
 
     def test_disconnect_usb_stick_timeout_non_blocking(self, mocker):
@@ -282,32 +272,22 @@ class TestZapperConnectorDisconnectUsbStick:
         config = {"control_host": "zapper-host", "device_ip": "1.2.3.4"}
 
         mocker.patch.object(
-            ZapperConnector, "wait_ready", side_effect=TimeoutError
-        )
-        mock_typecmux = mocker.patch.object(
-            ZapperConnector, "typecmux_set_state"
+            ZapperConnector, "typecmux_set_state", side_effect=TimeoutError
         )
 
         # Should not raise
         ZapperConnector.disconnect_usb_stick(config)
-
-        mock_typecmux.assert_not_called()
 
     def test_disconnect_usb_stick_connection_error_non_blocking(self, mocker):
         """Test disconnect_usb_stick handles connection error gracefully."""
         config = {"control_host": "zapper-host", "device_ip": "1.2.3.4"}
 
         mocker.patch.object(
-            ZapperConnector, "wait_ready", side_effect=ConnectionError
-        )
-        mock_typecmux = mocker.patch.object(
-            ZapperConnector, "typecmux_set_state"
+            ZapperConnector, "typecmux_set_state", side_effect=ConnectionError
         )
 
         # Should not raise
         ZapperConnector.disconnect_usb_stick(config)
-
-        mock_typecmux.assert_not_called()
 
 
 class TestZapperConnectorRestApi:

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -20,7 +20,10 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from testflinger_device_connectors.devices import ProvisioningError
+from testflinger_device_connectors.devices import (
+    DefaultDevice,
+    ProvisioningError,
+)
 from testflinger_device_connectors.devices.zapper import ZapperConnector
 
 
@@ -169,8 +172,6 @@ class TestZapperConnectorRestApiCheck:
 
     def test_wait_ready_success(self, mocker):
         """Test wait_ready calls wait_online with correct parameters."""
-        from testflinger_device_connectors.devices import DefaultDevice
-
         mock_wait_online = mocker.patch.object(DefaultDevice, "wait_online")
 
         ZapperConnector.wait_ready("zapper-host", timeout=30)
@@ -181,8 +182,6 @@ class TestZapperConnectorRestApiCheck:
 
     def test_wait_ready_timeout(self, mocker):
         """Test wait_ready raises TimeoutError when server unavailable."""
-        from testflinger_device_connectors.devices import DefaultDevice
-
         mocker.patch.object(
             DefaultDevice, "wait_online", side_effect=TimeoutError
         )

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -22,9 +22,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-import requests
 import yaml
-from typing_extensions import override
 
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.dell_oemscript import DellOemScript
@@ -42,36 +40,6 @@ class DeviceConnector(ZapperConnector):
     """Tool for provisioning baremetal with a given image."""
 
     PROVISION_METHOD = "ProvisioningKVM"
-
-    @override
-    def pre_provision_hook(self):
-        """Power off the DUT via the Zapper REST API before provisioning.
-
-        If the REST API is not available, fall back to the default
-        pre-provision hook (SSH-based control host check).
-        """
-        control_host = self.config.get("control_host", "")
-        if not control_host:
-            return super().pre_provision_hook()
-
-        try:
-            logger.info("Attempt to power cycle the control host.")
-            self._api_post("/api/v1/system/poweroff", timeout=10)
-            with contextlib.suppress(TimeoutError):
-                ZapperConnector.wait_offline(
-                    ZapperConnector._check_rest_api_on_host,
-                    control_host,
-                    30,
-                )
-            self._reboot_control_host()
-            self.wait_ready(control_host, timeout=300)
-        except requests.RequestException:
-            logger.warning(
-                "The REST API is not available on %s, "
-                "falling back to default pre-provision hook",
-                control_host,
-            )
-            super().pre_provision_hook()
 
     def _validate_base_user_data(self, encoded_user_data: str):
         """Assert `base_user_data` argument is a valid base64 encoded YAML."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -19,11 +19,9 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import requests
 import yaml
 
 from testflinger_device_connectors.devices import ProvisioningError
-from testflinger_device_connectors.devices.zapper import ZapperConnector
 from testflinger_device_connectors.devices.zapper_kvm import DeviceConnector
 
 
@@ -594,68 +592,3 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         connector = DeviceConnector(fake_config)
         key = connector._read_ssh_key()
         self.assertEqual(key, "mykey")
-
-    @patch.object(DeviceConnector, "wait_ready")
-    @patch.object(DeviceConnector, "_reboot_control_host")
-    @patch.object(ZapperConnector, "wait_offline")
-    @patch.object(DeviceConnector, "_api_post")
-    def test_pre_provision_hook_poweroff(
-        self, mock_api_post, mock_wait_offline, mock_reboot, mock_wait_ready
-    ):
-        """Test pre_provision_hook sends poweroff, waits for Zapper to
-        go down, reboots control host, then waits for it to come back.
-        """
-        connector = DeviceConnector({"control_host": "zapper-host"})
-
-        connector.pre_provision_hook()
-
-        mock_api_post.assert_called_once_with(
-            "/api/v1/system/poweroff", timeout=10
-        )
-        mock_wait_offline.assert_called_once_with(
-            ZapperConnector._check_rest_api_on_host,
-            "zapper-host",
-            30,
-        )
-        mock_reboot.assert_called_once()
-        mock_wait_ready.assert_called_once_with("zapper-host", timeout=300)
-
-    @patch(
-        "testflinger_device_connectors.devices.DefaultDevice"
-        ".pre_provision_hook"
-    )
-    @patch.object(DeviceConnector, "wait_ready")
-    @patch.object(
-        DeviceConnector,
-        "_api_post",
-        side_effect=requests.ConnectionError,
-    )
-    def test_pre_provision_hook_fallback(
-        self, mock_api_post, mock_wait_ready, mock_super_hook
-    ):
-        """Test pre_provision_hook falls back to super() when REST fails."""
-        connector = DeviceConnector({"control_host": "zapper-host"})
-
-        connector.pre_provision_hook()
-
-        mock_api_post.assert_called_once()
-        mock_wait_ready.assert_not_called()
-        mock_super_hook.assert_called_once()
-
-    @patch(
-        "testflinger_device_connectors.devices.DefaultDevice"
-        ".pre_provision_hook"
-    )
-    @patch.object(DeviceConnector, "_api_post")
-    def test_pre_provision_hook_no_control_host(
-        self, mock_api_post, mock_super_hook
-    ):
-        """Test pre_provision_hook delegates to super()
-        with no control_host.
-        """
-        connector = DeviceConnector({})
-
-        connector.pre_provision_hook()
-
-        mock_api_post.assert_not_called()
-        mock_super_hook.assert_called_once()

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -109,6 +109,32 @@ class TestCheckSshServerOnHost:
             DefaultControlHost("test-host")._check_ssh()
 
 
+class TestCheckPing:
+    """Tests for DefaultControlHost._check_ping method."""
+
+    def test_check_ping_success(self, mocker):
+        """Test ping check succeeds when host responds."""
+        mock_subprocess = mocker.patch("subprocess.run")
+
+        DefaultControlHost("test-host")._check_ping()
+
+        mock_subprocess.assert_called_once_with(
+            ["/usr/bin/ping", "-c", "1", "-W", "3", "test-host"],
+            check=True,
+            capture_output=True,
+        )
+
+    def test_check_ping_raises_connection_error(self, mocker):
+        """Test ping check raises ConnectionError when unreachable."""
+        mocker.patch(
+            "subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "ping"),
+        )
+
+        with pytest.raises(ConnectionError):
+            DefaultControlHost("test-host")._check_ping()
+
+
 class TestRebootControlHost:
     """Tests for DefaultControlHost.reboot method."""
 
@@ -208,13 +234,14 @@ class TestDefaultControlHostPowerCycle:
             DefaultControlHost, "wait_offline"
         )
         mock_wait_ready = mocker.patch.object(DefaultControlHost, "wait_ready")
+        host = DefaultControlHost("control-host", ["reboot-cmd"])
 
-        DefaultControlHost("control-host", ["reboot-cmd"]).power_cycle()
+        host.power_cycle()
 
         mock_post.assert_called_once_with(
             "http://control-host:8000/api/v1/system/poweroff", timeout=10
         )
-        mock_wait_offline.assert_called_once()
+        mock_wait_offline.assert_called_once_with(host._check_ping, 30)
         mock_reboot.assert_called_once()
         mock_wait_ready.assert_called_once_with(timeout=300)
 

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -14,6 +14,7 @@
 """Tests for the devices module."""
 
 import subprocess
+import time
 from importlib import import_module
 from itertools import product
 from unittest.mock import MagicMock, Mock
@@ -227,6 +228,7 @@ class TestDefaultControlHostPowerCycle:
 
     def test_rest_poweroff_path(self, mocker):
         """Test power_cycle powers off via REST, reboots, and waits."""
+        _ = mocker.patch.object(time, "sleep")
         mock_post = mocker.patch.object(requests, "post")
         mock_post.return_value.raise_for_status = Mock()
         mock_reboot = mocker.patch.object(DefaultControlHost, "reboot")

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -16,9 +16,10 @@
 import subprocess
 from importlib import import_module
 from itertools import product
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
+import requests
 
 from testflinger_device_connectors.cmd import STAGES
 from testflinger_device_connectors.devices import (
@@ -116,28 +117,13 @@ class TestCheckSshServerOnHost:
 class TestRebootControlHost:
     """Tests for DefaultDevice._reboot_control_host method."""
 
-    def test_reboot_control_host_no_script(self, mocker):
-        """Test reboot returns early when no script is configured."""
-        mocker.patch("builtins.open", mocker.mock_open())
-        mock_subprocess = mocker.patch("subprocess.run")
-        device = DefaultDevice({"device_ip": "1.1.1.1"})
-
-        device._reboot_control_host()
-
-        mock_subprocess.assert_not_called()
-
     def test_reboot_control_host_success(self, mocker):
         """Test reboot runs script commands successfully."""
         mocker.patch("builtins.open", mocker.mock_open())
         mock_subprocess = mocker.patch("subprocess.run")
-        device = DefaultDevice(
-            {
-                "device_ip": "1.1.1.1",
-                "control_host_reboot_script": ["cmd1", "cmd2"],
-            }
-        )
+        device = DefaultDevice({"device_ip": "1.1.1.1"})
 
-        device._reboot_control_host()
+        device._reboot_control_host(["cmd1", "cmd2"])
 
         assert mock_subprocess.call_count == 2
 
@@ -148,79 +134,114 @@ class TestRebootControlHost:
         error.stdout = "some stdout"
         error.stderr = "some stderr"
         mocker.patch("subprocess.run", side_effect=error)
-        device = DefaultDevice(
-            {
-                "device_ip": "1.1.1.1",
-                "control_host_reboot_script": ["cmd1"],
-            }
-        )
+        device = DefaultDevice({"device_ip": "1.1.1.1"})
 
         # Should not raise
-        device._reboot_control_host()
+        device._reboot_control_host(["cmd1"])
 
     def test_reboot_control_host_timeout_expired(self, mocker):
         """Test reboot handles TimeoutExpired gracefully."""
         mocker.patch("builtins.open", mocker.mock_open())
         timeout_error = subprocess.TimeoutExpired("cmd1", 60)
         mocker.patch("subprocess.run", side_effect=timeout_error)
-        device = DefaultDevice(
-            {
-                "device_ip": "1.1.1.1",
-                "control_host_reboot_script": ["cmd1"],
-            }
-        )
+        device = DefaultDevice({"device_ip": "1.1.1.1"})
 
         # Should not raise
-        device._reboot_control_host()
+        device._reboot_control_host(["cmd1"])
 
     def test_reboot_control_host_unexpected_error(self, mocker):
         """Test reboot handles unexpected exceptions gracefully."""
         mocker.patch("builtins.open", mocker.mock_open())
         mocker.patch("subprocess.run", side_effect=OSError("unexpected"))
-        device = DefaultDevice(
-            {
-                "device_ip": "1.1.1.1",
-                "control_host_reboot_script": ["cmd1"],
-            }
-        )
+        device = DefaultDevice({"device_ip": "1.1.1.1"})
 
         # Should not raise
-        device._reboot_control_host()
+        device._reboot_control_host(["cmd1"])
 
 
 class TestPreProvisionHook:
     """Tests for DefaultDevice.pre_provision_hook method."""
 
-    def test_pre_provision_hook_no_control_host(self, mocker):
+    def test_no_control_host(self, mocker):
         """Test hook returns early when no control_host configured."""
         mocker.patch("builtins.open", mocker.mock_open())
-        mock_subprocess = mocker.patch("subprocess.run")
+        mock_post = mocker.patch.object(requests, "post")
         device = DefaultDevice({"device_ip": "1.1.1.1"})
 
         device.pre_provision_hook()
 
-        # No SSH check should be called without control_host
-        mock_subprocess.assert_not_called()
+        mock_post.assert_not_called()
 
-    def test_pre_provision_hook_host_already_up(self, mocker):
-        """Test hook returns early when control host is already reachable."""
+    def test_no_reboot_script(self, mocker):
+        """Test hook returns early when no reboot script configured."""
         mocker.patch("builtins.open", mocker.mock_open())
-        mock_subprocess = mocker.patch("subprocess.run")
+        mock_post = mocker.patch.object(requests, "post")
         device = DefaultDevice(
             {"device_ip": "1.1.1.1", "control_host": "control-host"}
         )
 
         device.pre_provision_hook()
 
-        # SSH check was called once (host was up)
+        mock_post.assert_not_called()
+
+    def test_rest_poweroff_path(self, mocker):
+        """Test hook powers off via REST, reboots, and waits for REST."""
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_post = mocker.patch.object(requests, "post")
+        mock_post.return_value.raise_for_status = Mock()
+        mock_reboot = mocker.patch.object(
+            DefaultDevice, "_reboot_control_host"
+        )
+        mock_wait_offline = mocker.patch.object(DefaultDevice, "wait_offline")
+        mock_wait_ready = mocker.patch.object(DefaultDevice, "wait_ready")
+
+        device = DefaultDevice(
+            {
+                "device_ip": "1.1.1.1",
+                "control_host": "control-host",
+                "control_host_reboot_script": ["reboot-cmd"],
+            }
+        )
+
+        device.pre_provision_hook()
+
+        mock_post.assert_called_once_with(
+            "http://control-host:8000/api/v1/system/poweroff", timeout=10
+        )
+        mock_wait_offline.assert_called_once_with(
+            DefaultDevice._check_rest_api_on_host, "control-host", 30
+        )
+        mock_reboot.assert_called_once_with(["reboot-cmd"])
+        mock_wait_ready.assert_called_once_with("control-host", timeout=300)
+
+    def test_ssh_fallback_host_already_up(self, mocker):
+        """Test SSH fallback skips reboot when host is reachable."""
+        mocker.patch("builtins.open", mocker.mock_open())
+        mocker.patch.object(
+            requests, "post", side_effect=requests.ConnectionError
+        )
+        mock_subprocess = mocker.patch("subprocess.run")
+        device = DefaultDevice(
+            {
+                "device_ip": "1.1.1.1",
+                "control_host": "control-host",
+                "control_host_reboot_script": ["reboot-cmd"],
+            }
+        )
+
+        device.pre_provision_hook()
+
+        # Only the SSH check, no reboot
         mock_subprocess.assert_called_once()
 
-    def test_pre_provision_hook_reboots_and_waits(self, mocker):
-        """Test hook reboots host and waits when not reachable."""
+    def test_ssh_fallback_reboots_when_host_down(self, mocker):
+        """Test SSH fallback reboots and waits when host is unreachable."""
         mocker.patch("builtins.open", mocker.mock_open())
+        mocker.patch.object(
+            requests, "post", side_effect=requests.ConnectionError
+        )
         mocker.patch("time.sleep")
         mocker.patch("time.time", side_effect=[0, 1, 2, 3])
-        # First call fails (host down), subsequent calls succeed
         mocker.patch(
             "subprocess.run",
             side_effect=[
@@ -239,20 +260,23 @@ class TestPreProvisionHook:
 
         device.pre_provision_hook()
 
-        # Verify subprocess was called multiple times
         assert subprocess.run.call_count == 3
 
-    def test_pre_provision_hook_handles_timeout(self, mocker):
-        """Test hook handles timeout when wait_online times out."""
+    def test_ssh_fallback_handles_timeout(self, mocker):
+        """Test SSH fallback handles timeout gracefully."""
         mocker.patch("builtins.open", mocker.mock_open())
+        mocker.patch.object(
+            requests, "post", side_effect=requests.ConnectionError
+        )
         mocker.patch("time.sleep")
-        # Time progresses past timeout (need extra values for logging)
-        time_values = [0, 1, 2, 500] + [500] * 10
-        mocker.patch("time.time", side_effect=time_values)
-        # SSH check always fails
+        mocker.patch("time.time", side_effect=[0, 0, 500, 500])
         mocker.patch(
             "subprocess.run",
-            side_effect=subprocess.CalledProcessError(1, "nc"),
+            side_effect=[
+                subprocess.CalledProcessError(1, "nc"),  # SSH check fails
+                None,  # Reboot script succeeds
+                subprocess.CalledProcessError(1, "nc"),  # wait_online check
+            ],
         )
         device = DefaultDevice(
             {

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -24,6 +24,7 @@ import requests
 from testflinger_device_connectors.cmd import STAGES
 from testflinger_device_connectors.devices import (
     DEVICE_CONNECTORS,
+    DefaultControlHost,
     DefaultDevice,
     get_device_stage_func,
 )
@@ -49,16 +50,16 @@ def test_get_device_stage_func(stage, device):
 
 
 class TestWaitOnline:
-    """Tests for DefaultDevice.wait_online static method."""
+    """Tests for DefaultControlHost.wait_online method."""
 
     def test_wait_online_succeeds_immediately(self, mocker):
         """Test wait_online succeeds when check passes on first try."""
         mocker.patch("time.sleep")
         mock_check = MagicMock()
 
-        DefaultDevice.wait_online(mock_check, "test-host", 60)
+        DefaultControlHost("test-host").wait_online(mock_check, 60)
 
-        mock_check.assert_called_once_with("test-host")
+        mock_check.assert_called_once_with()
 
     def test_wait_online_retries_then_succeeds(self, mocker):
         """Test wait_online retries when check fails then succeeds."""
@@ -67,32 +68,28 @@ class TestWaitOnline:
             side_effect=[ConnectionError, ConnectionError, None]
         )
 
-        DefaultDevice.wait_online(mock_check, "test-host", 60)
+        DefaultControlHost("test-host").wait_online(mock_check, 60)
 
         assert mock_check.call_count == 3
 
     def test_wait_online_times_out(self, mocker):
         """Test wait_online raises TimeoutError when timeout is reached."""
         mocker.patch("time.sleep")
-        # Simulate time progressing past timeout
         mocker.patch("time.time", side_effect=[0, 1, 2, 100])
         mock_check = MagicMock(side_effect=ConnectionError)
 
         with pytest.raises(TimeoutError):
-            DefaultDevice.wait_online(mock_check, "test-host", 10)
+            DefaultControlHost("test-host").wait_online(mock_check, 10)
 
 
 class TestCheckSshServerOnHost:
-    """Tests for DefaultDevice.__check_ssh_server_on_host method."""
+    """Tests for DefaultControlHost._check_ssh method."""
 
     def test_check_ssh_server_success(self, mocker):
         """Test SSH check succeeds when nc command succeeds."""
-        mocker.patch("builtins.open", mocker.mock_open())
         mock_subprocess = mocker.patch("subprocess.run")
-        device = DefaultDevice({"device_ip": "1.1.1.1"})
 
-        # Access the private method
-        device._DefaultDevice__check_ssh_server_on_host("test-host")
+        DefaultControlHost("test-host")._check_ssh()
 
         mock_subprocess.assert_called_once_with(
             ["/usr/bin/nc", "-z", "-w", "3", "test-host", "22"],
@@ -103,60 +100,52 @@ class TestCheckSshServerOnHost:
 
     def test_check_ssh_server_raises_connection_error(self, mocker):
         """Test SSH check raises ConnectionError when nc fails."""
-        mocker.patch("builtins.open", mocker.mock_open())
         mocker.patch(
             "subprocess.run",
             side_effect=subprocess.CalledProcessError(1, "nc"),
         )
-        device = DefaultDevice({"device_ip": "1.1.1.1"})
 
         with pytest.raises(ConnectionError):
-            device._DefaultDevice__check_ssh_server_on_host("test-host")
+            DefaultControlHost("test-host")._check_ssh()
 
 
 class TestRebootControlHost:
-    """Tests for DefaultDevice._reboot_control_host method."""
+    """Tests for DefaultControlHost.reboot method."""
 
     def test_reboot_control_host_success(self, mocker):
         """Test reboot runs script commands successfully."""
-        mocker.patch("builtins.open", mocker.mock_open())
         mock_subprocess = mocker.patch("subprocess.run")
-        device = DefaultDevice({"device_ip": "1.1.1.1"})
 
-        device._reboot_control_host(["cmd1", "cmd2"])
+        DefaultControlHost("host", ["cmd1", "cmd2"]).reboot()
 
         assert mock_subprocess.call_count == 2
 
     def test_reboot_control_host_called_process_error(self, mocker):
         """Test reboot handles CalledProcessError gracefully."""
-        mocker.patch("builtins.open", mocker.mock_open())
         error = subprocess.CalledProcessError(1, "cmd1")
         error.stdout = "some stdout"
         error.stderr = "some stderr"
         mocker.patch("subprocess.run", side_effect=error)
-        device = DefaultDevice({"device_ip": "1.1.1.1"})
 
         # Should not raise
-        device._reboot_control_host(["cmd1"])
+        DefaultControlHost("host", ["cmd1"]).reboot()
 
     def test_reboot_control_host_timeout_expired(self, mocker):
         """Test reboot handles TimeoutExpired gracefully."""
-        mocker.patch("builtins.open", mocker.mock_open())
-        timeout_error = subprocess.TimeoutExpired("cmd1", 60)
-        mocker.patch("subprocess.run", side_effect=timeout_error)
-        device = DefaultDevice({"device_ip": "1.1.1.1"})
+        mocker.patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired("cmd1", 60),
+        )
 
         # Should not raise
-        device._reboot_control_host(["cmd1"])
+        DefaultControlHost("host", ["cmd1"]).reboot()
 
     def test_reboot_control_host_unexpected_error(self, mocker):
         """Test reboot handles unexpected exceptions gracefully."""
-        mocker.patch("builtins.open", mocker.mock_open())
         mocker.patch("subprocess.run", side_effect=OSError("unexpected"))
-        device = DefaultDevice({"device_ip": "1.1.1.1"})
 
         # Should not raise
-        device._reboot_control_host(["cmd1"])
+        DefaultControlHost("host", ["cmd1"]).reboot()
 
 
 class TestPreProvisionHook:
@@ -165,36 +154,35 @@ class TestPreProvisionHook:
     def test_no_control_host(self, mocker):
         """Test hook returns early when no control_host configured."""
         mocker.patch("builtins.open", mocker.mock_open())
-        mock_post = mocker.patch.object(requests, "post")
+        mock_power_cycle = mocker.patch.object(
+            DefaultControlHost, "power_cycle"
+        )
         device = DefaultDevice({"device_ip": "1.1.1.1"})
 
         device.pre_provision_hook()
 
-        mock_post.assert_not_called()
+        mock_power_cycle.assert_not_called()
 
     def test_no_reboot_script(self, mocker):
         """Test hook returns early when no reboot script configured."""
         mocker.patch("builtins.open", mocker.mock_open())
-        mock_post = mocker.patch.object(requests, "post")
+        mock_power_cycle = mocker.patch.object(
+            DefaultControlHost, "power_cycle"
+        )
         device = DefaultDevice(
             {"device_ip": "1.1.1.1", "control_host": "control-host"}
         )
 
         device.pre_provision_hook()
 
-        mock_post.assert_not_called()
+        mock_power_cycle.assert_not_called()
 
-    def test_rest_poweroff_path(self, mocker):
-        """Test hook powers off via REST, reboots, and waits for REST."""
+    def test_delegates_to_power_cycle(self, mocker):
+        """Test hook creates DefaultControlHost and calls power_cycle."""
         mocker.patch("builtins.open", mocker.mock_open())
-        mock_post = mocker.patch.object(requests, "post")
-        mock_post.return_value.raise_for_status = Mock()
-        mock_reboot = mocker.patch.object(
-            DefaultDevice, "_reboot_control_host"
+        mock_power_cycle = mocker.patch.object(
+            DefaultControlHost, "power_cycle"
         )
-        mock_wait_offline = mocker.patch.object(DefaultDevice, "wait_offline")
-        mock_wait_ready = mocker.patch.object(DefaultDevice, "wait_ready")
-
         device = DefaultDevice(
             {
                 "device_ip": "1.1.1.1",
@@ -204,42 +192,43 @@ class TestPreProvisionHook:
         )
 
         device.pre_provision_hook()
+
+        mock_power_cycle.assert_called_once()
+
+
+class TestDefaultControlHostPowerCycle:
+    """Tests for DefaultControlHost.power_cycle and ssh_fallback."""
+
+    def test_rest_poweroff_path(self, mocker):
+        """Test power_cycle powers off via REST, reboots, and waits."""
+        mock_post = mocker.patch.object(requests, "post")
+        mock_post.return_value.raise_for_status = Mock()
+        mock_reboot = mocker.patch.object(DefaultControlHost, "reboot")
+        mock_wait_offline = mocker.patch.object(
+            DefaultControlHost, "wait_offline"
+        )
+        mock_wait_ready = mocker.patch.object(DefaultControlHost, "wait_ready")
+
+        DefaultControlHost("control-host", ["reboot-cmd"]).power_cycle()
 
         mock_post.assert_called_once_with(
             "http://control-host:8000/api/v1/system/poweroff", timeout=10
         )
-        mock_wait_offline.assert_called_once_with(
-            DefaultDevice._check_rest_api_on_host, "control-host", 30
-        )
-        mock_reboot.assert_called_once_with(["reboot-cmd"])
-        mock_wait_ready.assert_called_once_with("control-host", timeout=300)
+        mock_wait_offline.assert_called_once()
+        mock_reboot.assert_called_once()
+        mock_wait_ready.assert_called_once_with(timeout=300)
 
     def test_ssh_fallback_host_already_up(self, mocker):
-        """Test SSH fallback skips reboot when host is reachable."""
-        mocker.patch("builtins.open", mocker.mock_open())
-        mocker.patch.object(
-            requests, "post", side_effect=requests.ConnectionError
-        )
+        """Test ssh_fallback skips reboot when host is reachable."""
         mock_subprocess = mocker.patch("subprocess.run")
-        device = DefaultDevice(
-            {
-                "device_ip": "1.1.1.1",
-                "control_host": "control-host",
-                "control_host_reboot_script": ["reboot-cmd"],
-            }
-        )
 
-        device.pre_provision_hook()
+        DefaultControlHost("control-host", ["reboot-cmd"]).ssh_fallback()
 
         # Only the SSH check, no reboot
         mock_subprocess.assert_called_once()
 
     def test_ssh_fallback_reboots_when_host_down(self, mocker):
-        """Test SSH fallback reboots and waits when host is unreachable."""
-        mocker.patch("builtins.open", mocker.mock_open())
-        mocker.patch.object(
-            requests, "post", side_effect=requests.ConnectionError
-        )
+        """Test ssh_fallback reboots and waits when host is unreachable."""
         mocker.patch("time.sleep")
         mocker.patch("time.time", side_effect=[0, 1, 2, 3])
         mocker.patch(
@@ -250,24 +239,13 @@ class TestPreProvisionHook:
                 None,  # SSH check in wait_online succeeds
             ],
         )
-        device = DefaultDevice(
-            {
-                "device_ip": "1.1.1.1",
-                "control_host": "control-host",
-                "control_host_reboot_script": ["reboot-cmd"],
-            }
-        )
 
-        device.pre_provision_hook()
+        DefaultControlHost("control-host", ["reboot-cmd"]).ssh_fallback()
 
         assert subprocess.run.call_count == 3
 
     def test_ssh_fallback_handles_timeout(self, mocker):
-        """Test SSH fallback handles timeout gracefully."""
-        mocker.patch("builtins.open", mocker.mock_open())
-        mocker.patch.object(
-            requests, "post", side_effect=requests.ConnectionError
-        )
+        """Test ssh_fallback handles timeout gracefully."""
         mocker.patch("time.sleep")
         mocker.patch("time.time", side_effect=[0, 0, 500, 500])
         mocker.patch(
@@ -278,16 +256,22 @@ class TestPreProvisionHook:
                 subprocess.CalledProcessError(1, "nc"),  # wait_online check
             ],
         )
-        device = DefaultDevice(
-            {
-                "device_ip": "1.1.1.1",
-                "control_host": "control-host",
-                "control_host_reboot_script": ["reboot-cmd"],
-            }
-        )
 
         # Should not raise - timeout is handled gracefully
-        device.pre_provision_hook()
+        DefaultControlHost("control-host", ["reboot-cmd"]).ssh_fallback()
+
+    def test_falls_back_to_ssh_when_rest_unavailable(self, mocker):
+        """Test power_cycle falls back to ssh_fallback on RequestException."""
+        mocker.patch.object(
+            requests, "post", side_effect=requests.ConnectionError
+        )
+        mock_ssh_fallback = mocker.patch.object(
+            DefaultControlHost, "ssh_fallback"
+        )
+
+        DefaultControlHost("control-host", ["reboot-cmd"]).power_cycle()
+
+        mock_ssh_fallback.assert_called_once()
 
 
 class TestProvision:


### PR DESCRIPTION
## Description

We currently power cycle the control host only if not reachable, because it might be a disruptive operation with a live system. After introducing a `poweroff` API though, this action becomes safe to do every time, making sure we always test with a clean system.

1. Move power cycling logic to a central place, common to all devices
2. Move all control host related logic into a dedicated class

## Resolved issues

Resolves https://warthogs.atlassian.net/browse/ZAP-1446

## Documentation

N/A

## Web service API changes

N/A

## Tests

Fallback (online):
```
2026-04-06 16:49:40,398 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-04-06 16:49:40,398 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-04-06 16:49:40,402 hp-pro-sff-400-g9-desktop-pc-c30464 WARNING: DEVICE CONNECTOR: The REST API is not available on 192.168.68.59, falling back to SSH-based control host check
2026-04-06 16:49:40,409 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: BEGIN provision
2026-04-06 16:49:40,409 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Provisioning device
...
```

Fallback (offline):
```
2026-04-06 16:49:52,051 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-04-06 16:49:52,052 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-04-06 16:50:02,062 hp-pro-sff-400-g9-desktop-pc-c30464 WARNING: DEVICE CONNECTOR: The REST API is not available on 192.168.68.59, falling back to SSH-based control host check
2026-04-06 16:50:05,069 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Running control host reboot script
2026-04-06 16:50:05,069 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Executing: echo "reboot_cmd 1"
2026-04-06 16:50:05,071 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Executing: echo "reboot_cmd 2"
2026-04-06 16:50:05,073 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Executing: echo "reboot_cmd 3"
2026-04-06 16:50:05,075 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Waiting for control host 192.168.68.59 to come back online (timeout: 300 seconds)
2026-04-06 16:53:27,160 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: BEGIN provision
2026-04-06 16:53:27,160 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Provisioning device
```

REST poweroff + power cycle:
```
2026-04-06 16:55:19,956 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-04-06 16:55:19,956 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-04-06 16:55:50,216 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Running control host reboot script
2026-04-06 16:55:50,216 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Executing: echo "reboot_cmd 1"
2026-04-06 16:55:50,218 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Executing: echo "reboot_cmd 2"
2026-04-06 16:55:50,220 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Executing: echo "reboot_cmd 3"
2026-04-06 16:55:50,221 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Waiting for the REST API on control host 192.168.68.59
2026-04-06 16:57:07,575 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: BEGIN provision
2026-04-06 16:57:07,575 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Provisioning device

```
