### PR TITLE
new: allow using 'url' instead of `urls` when only one image is required

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -90,7 +90,11 @@ class DeviceConnector(ZapperConnector):
             except (ValueError, KeyError) as e:
                 raise ProvisioningError from e
 
-        urls = self.job_data["provision_data"].get("urls", [])
+        if url := self.job_data["provision_data"].get("url"):
+            urls = [url]
+        else:
+            urls = self.job_data["provision_data"].get("urls", [])
+
         try:
             validate_urls(urls)
         except ValueError as e:

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -90,14 +90,10 @@ class DeviceConnector(ZapperConnector):
             except (ValueError, KeyError) as e:
                 raise ProvisioningError from e
 
-        url = self.job_data["provision_data"].get("url")
-        urls = self.job_data["provision_data"].get("urls", [])
-        if url and urls:
-            raise ProvisioningError(
-                "Provide only one of provision_data.url or provision_data.urls"
-            )
-        if url:
+        if url := self.job_data["provision_data"].get("url"):
             urls = [url]
+        else:
+            urls = self.job_data["provision_data"].get("urls", [])
 
         try:
             validate_urls(urls)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -90,10 +90,14 @@ class DeviceConnector(ZapperConnector):
             except (ValueError, KeyError) as e:
                 raise ProvisioningError from e
 
-        if url := self.job_data["provision_data"].get("url"):
+        url = self.job_data["provision_data"].get("url")
+        urls = self.job_data["provision_data"].get("urls", [])
+        if url and urls:
+            raise ProvisioningError(
+                "Provide only one of provision_data.url or provision_data.urls"
+            )
+        if url:
             urls = [url]
-        else:
-            urls = self.job_data["provision_data"].get("urls", [])
 
         try:
             validate_urls(urls)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -59,20 +59,6 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
-    def test_validate_configuration_both_url_and_urls(self):
-        """Test that providing both `url` and `urls` raises an error."""
-        device = DeviceConnector({"control_host": "zapper-host"})
-        device.job_data = {
-            "provision_data": {
-                "preset": "TestPreset",
-                "url": "http://test.tar.gz",
-                "urls": ["http://other.tar.gz"],
-            }
-        }
-
-        with self.assertRaises(ProvisioningError):
-            device._validate_configuration()
-
     def test_validate_configuration_ubuntu_sso_email(self):
         """Test the function username will be ubuntu_sso_email if provided."""
         device = DeviceConnector({"control_host": "zapper-host"})
@@ -118,7 +104,7 @@ class ZapperIoTTests(unittest.TestCase):
                     "run_stage": [
                         {"initial_login": {"method": "system-user"}},
                     ],
-                }
+                },
             }
         }
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -59,6 +59,20 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
+    def test_validate_configuration_both_url_and_urls(self):
+        """Test that providing both `url` and `urls` raises an error."""
+        device = DeviceConnector({"control_host": "zapper-host"})
+        device.job_data = {
+            "provision_data": {
+                "preset": "TestPreset",
+                "url": "http://test.tar.gz",
+                "urls": ["http://other.tar.gz"],
+            }
+        }
+
+        with self.assertRaises(ProvisioningError):
+            device._validate_configuration()
+
     def test_validate_configuration_ubuntu_sso_email(self):
         """Test the function username will be ubuntu_sso_email if provided."""
         device = DeviceConnector({"control_host": "zapper-host"})

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -34,6 +34,31 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
+    def test_validate_configuration_single_url(self):
+        """Test the function accepts a single `url` string
+        and converts it to `urls` list.
+        """
+        device = DeviceConnector({"control_host": "zapper-host"})
+        device.job_data = {
+            "provision_data": {
+                "preset": "TestPreset",
+                "url": "http://test.tar.gz",
+            }
+        }
+
+        args, kwargs = device._validate_configuration()
+
+        expected = {
+            "username": "ubuntu",
+            "password": "ubuntu",
+            "preset": "TestPreset",
+            "preset_kwargs": None,
+            "urls": ["http://test.tar.gz"],
+        }
+
+        self.assertEqual(args, ())
+        self.assertDictEqual(kwargs, expected)
+
     def test_validate_configuration_ubuntu_sso_email(self):
         """Test the function username will be ubuntu_sso_email if provided."""
         device = DeviceConnector({"control_host": "zapper-host"})

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -178,8 +178,14 @@ class ZapperIoTPresetProvisionData(BaseZapperProvisionData):
 
     @validates_schema
     def validate_url_or_urls(self, data, **_):
-        """Validate that either `url` or `urls` is provided."""
-        if "url" not in data and "urls" not in data:
+        """Validate that exactly one of `url` or `urls` is provided."""
+        has_url = "url" in data
+        has_urls = "urls" in data
+        if has_url and has_urls:
+            raise ValidationError(
+                "Provide only one of 'url' or 'urls', not both."
+            )
+        if not has_url and not has_urls:
             raise ValidationError("Either 'url' or 'urls' must be provided.")
 
 
@@ -197,8 +203,14 @@ class ZapperIoTCustomProvisionData(BaseZapperProvisionData):
 
     @validates_schema
     def validate_url_or_urls(self, data, **_):
-        """Validate that either `url` or `urls` is provided."""
-        if "url" not in data and "urls" not in data:
+        """Validate that exactly one of `url` or `urls` is provided."""
+        has_url = "url" in data
+        has_urls = "urls" in data
+        if has_url and has_urls:
+            raise ValidationError(
+                "Provide only one of 'url' or 'urls', not both."
+            )
+        if not has_url and not has_urls:
             raise ValidationError("Either 'url' or 'urls' must be provided.")
 
 

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -171,9 +171,16 @@ class ZapperIoTPresetProvisionData(BaseZapperProvisionData):
     This schema is used when using a preset for provisioning.
     """
 
-    urls = fields.List(fields.URL(), required=True, validate=Length(min=1))
+    url = fields.URL(required=False)
+    urls = fields.List(fields.URL(), required=False, validate=Length(min=1))
     preset = fields.String(required=True)
     preset_kwargs = fields.Dict(required=False)
+
+    @validates_schema
+    def validate_url_or_urls(self, data, **_):
+        """Validate that either `url` or `urls` is provided."""
+        if "url" not in data and "urls" not in data:
+            raise ValidationError("Either 'url' or 'urls' must be provided.")
 
 
 class ZapperIoTCustomProvisionData(BaseZapperProvisionData):
@@ -182,10 +189,17 @@ class ZapperIoTCustomProvisionData(BaseZapperProvisionData):
     This schema is used when using a custom plan for provisioning.
     """
 
-    urls = fields.List(fields.URL(), required=True, validate=Length(min=1))
+    url = fields.URL(required=False)
+    urls = fields.List(fields.URL(), required=False, validate=Length(min=1))
     ubuntu_sso_email = fields.Email(required=False)
     # [TODO] Specify Nested schema to improve validation
     provision_plan = fields.Dict(required=True)
+
+    @validates_schema
+    def validate_url_or_urls(self, data, **_):
+        """Validate that either `url` or `urls` is provided."""
+        if "url" not in data and "urls" not in data:
+            raise ValidationError("Either 'url' or 'urls' must be provided.")
 
 
 class ZapperKVMAutoinstallProvisionData(BaseZapperProvisionData):

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -326,6 +326,18 @@ def test_add_job_zapper_iot_preset_provision_data(mongo_app):
     assert HTTPStatus.OK == output.status_code
 
 
+def test_add_job_zapper_iot_preset_provision_data_single_url(mongo_app):
+    """Test that a job with zapper_iot_preset using `url` (str) works."""
+    provision_data = {
+        "url": "http://example.com/image.img.xz",
+        "preset": "fake",
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+
+
 def test_add_job_zapper_iot_custom_provision_data(mongo_app):
     """Test that a job with zapper_iot_custom provision_data works."""
     # Empty URLs fails
@@ -342,6 +354,18 @@ def test_add_job_zapper_iot_custom_provision_data(mongo_app):
     # Valid job works
     provision_data = {
         "urls": ["http://example.com/image.img.xz"],
+        "provision_plan": {},
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.OK == output.status_code
+
+
+def test_add_job_zapper_iot_custom_provision_data_single_url(mongo_app):
+    """Test that a job with zapper_iot_custom using `url` (str) works."""
+    provision_data = {
+        "url": "http://example.com/image.img.xz",
         "provision_plan": {},
     }
     job_data = {"job_queue": "test", "provision_data": provision_data}

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -338,6 +338,19 @@ def test_add_job_zapper_iot_preset_provision_data_single_url(mongo_app):
     assert HTTPStatus.OK == output.status_code
 
 
+def test_add_job_zapper_iot_preset_provision_data_both_url_and_urls(mongo_app):
+    """Test that providing both `url` and `urls` fails."""
+    provision_data = {
+        "url": "http://example.com/image.img.xz",
+        "urls": ["http://example.com/other.img.xz"],
+        "preset": "fake",
+    }
+    job_data = {"job_queue": "test", "provision_data": provision_data}
+    app, _ = mongo_app
+    output = app.post("/v1/job", json=job_data)
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == output.status_code
+
+
 def test_add_job_zapper_iot_custom_provision_data(mongo_app):
     """Test that a job with zapper_iot_custom provision_data works."""
     # Empty URLs fails


### PR DESCRIPTION
## Description

When provisioning IoT devices it's frequently needed to provide multiple assets (bootloader, rootfs, etc). There are cases where this is not needed though, and it feels awkward to still use an array ( `urls` ), which is also different from every other device connector available in this repo.

Allow using `url` instead of `urls` in case only one asset is required.

## Resolved issues

N/A

## Documentation

Yes, but not here.

## Web service API changes

N/A

## Tests

Unit testing only.
