### PR TITLE
new: add serial logger to iot provisioning method

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -18,7 +18,10 @@ import contextlib
 import logging
 from typing import Any, Dict, Tuple
 
-from testflinger_device_connectors.devices import ProvisioningError
+from testflinger_device_connectors.devices import (
+    ProvisioningError,
+    SerialLogger,
+)
 from testflinger_device_connectors.devices.zapper import ZapperConnector
 from testflinger_device_connectors.devices.zapper_iot.parser import (
     validate_urls,
@@ -98,6 +101,19 @@ class DeviceConnector(ZapperConnector):
         provisioning_data["urls"] = urls
 
         return ((), provisioning_data)
+
+    def provision(self, args):
+        """Provision device with serial logging."""
+        serial_host = self.config.get("serial_host")
+        serial_port = self.config.get("serial_port")
+        serial_proc = SerialLogger(
+            serial_host, serial_port, "provision-serial.log"
+        )
+        serial_proc.start()
+        try:
+            super().provision(args)
+        finally:
+            serial_proc.stop()
 
     def _post_run_actions(self, args):
         """Run further actions after Zapper API returns successfully."""

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from testflinger_device_connectors.devices import ProvisioningError
 from testflinger_device_connectors.devices.zapper_iot import DeviceConnector
@@ -257,6 +257,61 @@ class ZapperIoTTests(unittest.TestCase):
 
         with self.assertRaises(ProvisioningError):
             device._validate_configuration()
+
+    @patch("testflinger_device_connectors.devices.zapper_iot.SerialLogger")
+    @patch(
+        "testflinger_device_connectors.devices.zapper.ZapperConnector.provision"
+    )
+    def test_provision_wraps_super_with_serial_logger(
+        self, mock_super_provision, mock_serial_logger_factory
+    ):
+        """Test that provision starts SerialLogger before provisioning
+        and stops it afterwards.
+        """
+        mock_serial_proc = MagicMock()
+        mock_serial_logger_factory.return_value = mock_serial_proc
+
+        fake_config = {
+            "control_host": "zapper-host",
+            "serial_host": "serial-host",
+            "serial_port": 3000,
+        }
+        device = DeviceConnector(fake_config)
+        args = MagicMock()
+        device.provision(args)
+
+        mock_serial_logger_factory.assert_called_once_with(
+            "serial-host", 3000, "provision-serial.log"
+        )
+        mock_serial_proc.start.assert_called_once()
+        mock_super_provision.assert_called_once_with(args)
+        mock_serial_proc.stop.assert_called_once()
+
+    @patch("testflinger_device_connectors.devices.zapper_iot.SerialLogger")
+    @patch(
+        "testflinger_device_connectors.devices.zapper.ZapperConnector.provision"
+    )
+    def test_provision_stops_serial_logger_on_failure(
+        self, mock_super_provision, mock_serial_logger_factory
+    ):
+        """Test that SerialLogger is stopped even when provisioning fails."""
+        mock_serial_proc = MagicMock()
+        mock_serial_logger_factory.return_value = mock_serial_proc
+        mock_super_provision.side_effect = ProvisioningError("fail")
+
+        fake_config = {
+            "control_host": "zapper-host",
+            "serial_host": "serial-host",
+            "serial_port": 3000,
+        }
+        device = DeviceConnector(fake_config)
+        args = MagicMock()
+
+        with self.assertRaises(ProvisioningError):
+            device.provision(args)
+
+        mock_serial_proc.start.assert_called_once()
+        mock_serial_proc.stop.assert_called_once()
 
     @patch.object(DeviceConnector, "_copy_ssh_id")
     def test_post_run_actions_copy_ssh_id_no_provision_plan(


### PR DESCRIPTION
## Description

Currently only used in `muxpi`, the serial logger allows to get logs in both the provision and the test phase from a serial logger using `ser2net`. The proposed change enables it also for devices using `zapper_iot`.

## Resolved issues

Part of https://warthogs.atlassian.net/browse/ZAP-1164

## Documentation

N/A

## Web service API changes

N/A

## Tests

The server side is not ready for it, but anyway this is a 1-1 porting from muxpi.
