### PR TITLE
Add release and identifier labels to phase_duration metric.

### DIFF
--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -33,6 +33,7 @@ from testflinger_agent.handlers import (
 )
 from testflinger_agent.job import TestflingerJob
 from testflinger_agent.metrics import PrometheusHandler
+from testflinger_agent.os_release import query_dut_release
 
 try:
     # attempt importing a tarfile filter, to check if filtering is supported
@@ -299,6 +300,8 @@ class TestflingerAgent:
             rundir = None
             job = None
             event_emitter = None
+            release = ""
+            identifier = self.client.config.get("identifier", "")
             try:
                 job = TestflingerJob(job_data, self.client)
                 event_emitter = EventEmitter(
@@ -384,9 +387,27 @@ class TestflingerAgent:
                     exit_code, exit_event, exit_reason = job.run_test_phase(
                         phase, rundir
                     )
-                    # Measure phase duration and report to metrics handler
+                    phase_end = time.time()
+
+                    # Query DUT release after successful provision
+                    if phase == TestPhase.PROVISION and not exit_code:
+                        device_info = job.get_device_info(rundir)
+                        if device_info and (
+                            device_ip := device_info.get(
+                                "device_info", {}
+                            ).get("device_ip")
+                        ):
+                            username = (job_data.get("test_data") or {}).get(
+                                "test_username", "ubuntu"
+                            )
+                            release = query_dut_release(device_ip, username)
+
+                    # Report phase duration to metrics handler
                     self.metrics_handler.report_phase_duration(
-                        phase, int(time.time() - phase_start)
+                        phase,
+                        int(phase_end - phase_start),
+                        identifier=identifier,
+                        release=release,
                     )
                     self.client.post_influx(phase, exit_code)
                     event_emitter.emit_event(exit_event, exit_reason)

--- a/agent/src/testflinger_agent/metrics.py
+++ b/agent/src/testflinger_agent/metrics.py
@@ -42,11 +42,19 @@ class MetricsHandler(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def report_phase_duration(self, phase: str, duration: int):
+    def report_phase_duration(
+        self,
+        phase: str,
+        duration: int,
+        identifier: str = "",
+        release: str = "",
+    ):
         """Report the duration of a job phase to the metrics backend.
 
         :param phase: Phase that reports the duration
         :param duration: The duration of the phase in seconds
+        :param identifier: CID of the device
+        :param release: OS release label of the provisioned DUT
         """
         raise NotImplementedError
 
@@ -76,7 +84,7 @@ class PrometheusHandler(MetricsHandler):
         self.phase_duration = Histogram(
             "phase_duration_seconds",
             "Duration of each job phase in seconds since last agent restart",
-            ["agent_id", "test_phase"],
+            ["agent_id", "test_phase", "identifier", "release"],
             buckets=(60, 120, 300, 600, 1800, 3600, 7200, 14400),
         )
         self.recovery_failures = Counter(
@@ -104,13 +112,23 @@ class PrometheusHandler(MetricsHandler):
         """
         self.total_failures.labels(self.agent_id, phase).inc()
 
-    def report_phase_duration(self, phase: str, duration: int):
+    def report_phase_duration(
+        self,
+        phase: str,
+        duration: int,
+        identifier: str = "",
+        release: str = "",
+    ):
         """Track phase duration and push to gateway.
 
         :param phase: Phase that reports the duration
         :param duration: The duration of the phase in seconds
+        :param identifier: CID of the device
+        :param release: OS release label of the provisioned DUT
         """
-        self.phase_duration.labels(self.agent_id, phase).observe(duration)
+        self.phase_duration.labels(
+            self.agent_id, phase, identifier, release
+        ).observe(duration)
 
     def report_recovery_failures(self):
         """Increase total recovery failures counter and push to gateway."""

--- a/agent/src/testflinger_agent/os_release.py
+++ b/agent/src/testflinger_agent/os_release.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+"""Query and parse os-release information from a provisioned DUT."""
+
+import logging
+import re
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+UNKNOWN_RELEASE = "unknown"
+
+SSH_TIMEOUT = 30
+SSH_OPTIONS = [
+    "-o",
+    "StrictHostKeyChecking=no",
+    "-o",
+    "UserKnownHostsFile=/dev/null",
+    "-o",
+    "ConnectTimeout=10",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "LogLevel=ERROR",
+]
+
+
+def query_dut_release(device_ip: str, username: str = "ubuntu") -> str:
+    """SSH into a DUT and extract the release label from /etc/os-release.
+
+    Authentication uses SSH key-based auth, no password is required.
+
+    :param device_ip: IP address of the device under test
+    :param username: SSH username (default: "ubuntu")
+    :return: Release label string, or UNKNOWN_RELEASE on failure
+    """
+    cmd = [
+        "ssh",
+        *SSH_OPTIONS,
+        f"{username}@{device_ip}",
+        "cat /etc/os-release",
+    ]
+
+    try:
+        result = subprocess.run(  # noqa: S603
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=SSH_TIMEOUT,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "Failed to query os-release from %s (rc=%d): %s",
+                device_ip,
+                result.returncode,
+                result.stderr.strip(),
+            )
+            return UNKNOWN_RELEASE
+
+        os_info = _parse_os_release(result.stdout)
+        release = _derive_release_label(os_info)
+        logger.info("DUT release detected: %s", release)
+        return release
+
+    except subprocess.TimeoutExpired:
+        logger.warning("Timed out querying os-release from %s", device_ip)
+    except Exception as exc:
+        logger.warning("Error querying os-release from %s: %s", device_ip, exc)
+
+    return UNKNOWN_RELEASE
+
+
+def _parse_os_release(content: str) -> dict:
+    """Parse /etc/os-release content into a dictionary.
+
+    :param content: Raw content of /etc/os-release
+    :return: Dictionary of key-value pairs
+    """
+    result = {}
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        value = value.strip('"')
+        result[key] = value
+    return result
+
+
+def _derive_release_label(os_info: dict) -> str:
+    """Convert parsed os-release data into a release label.
+
+    Follows the logic:
+    - Ubuntu Core: "Core {VERSION_ID}" (e.g., "Core 22")
+    - Regular Ubuntu: point release if available (e.g., "22.04.5"),
+      otherwise VERSION_ID (e.g., "22.04")
+
+    :param os_info: Dictionary from _parse_os_release()
+    :return: Release label string
+    """
+    name = os_info.get("NAME", "")
+    version_id = os_info.get("VERSION_ID", "")
+
+    if not version_id:
+        return UNKNOWN_RELEASE
+
+    if "Ubuntu Core" in name:
+        return f"Core {version_id}"
+
+    # Look for point release in VERSION or PRETTY_NAME
+    version = os_info.get("VERSION", os_info.get("PRETTY_NAME", ""))
+    point_release_re = re.compile(re.escape(version_id) + r"\.\d+")
+    match = point_release_re.search(version)
+    if match:
+        return match.group(0)
+
+    return version_id

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -905,10 +905,67 @@ class TestClient:
         )
         provision_duration_count = prometheus_client.REGISTRY.get_sample_value(
             "phase_duration_seconds_count",
-            {"agent_id": agent_id, "test_phase": TestPhase.PROVISION},
+            {
+                "agent_id": agent_id,
+                "test_phase": TestPhase.PROVISION,
+                "identifier": self.config["identifier"],
+                "release": "",
+            },
         )
         assert total_provision_failures == 1
         assert total_jobs == 1
+        assert provision_duration_count == 1
+
+    def test_agent_metrics_release_label_after_provision(
+        self, agent, requests_mock
+    ):
+        """
+        Tests that after a successful provision the release label is populated
+        in the phase_duration_seconds metric from the DUT's os-release.
+        """
+        self.config["provision_command"] = "/bin/true"
+        agent_id = self.config["agent_id"]
+        mock_job_data = {
+            "job_id": str(uuid.uuid1()),
+            "job_queue": "test",
+            "provision_data": {"url": "foo"},
+        }
+        requests_mock.get(
+            "http://127.0.0.1:8000/v1/job?queue=test",
+            [{"text": json.dumps(mock_job_data)}, {"text": "{}"}],
+        )
+        requests_mock.get(
+            f"http://127.0.0.1:8000/v1/agents/data/{agent_id}",
+            json={"state": AgentState.WAITING, "restricted_to": {}},
+        )
+        requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
+
+        device_info = {
+            "device_info": {"device_ip": "10.0.0.1", "agent_name": "test01"}
+        }
+        with (
+            patch("shutil.rmtree"),
+            patch("pathlib.Path.unlink"),
+            patch(
+                "testflinger_agent.job.TestflingerJob.get_device_info",
+                return_value=device_info,
+            ),
+            patch(
+                "testflinger_agent.agent.query_dut_release",
+                return_value="22.04.5",
+            ),
+        ):
+            agent.process_jobs()
+
+        provision_duration_count = prometheus_client.REGISTRY.get_sample_value(
+            "phase_duration_seconds_count",
+            {
+                "agent_id": agent_id,
+                "test_phase": TestPhase.PROVISION,
+                "identifier": self.config["identifier"],
+                "release": "22.04.5",
+            },
+        )
         assert provision_duration_count == 1
 
     def test_agent_recovery_failure_metrics(self, agent, requests_mock):

--- a/agent/tests/test_os_release.py
+++ b/agent/tests/test_os_release.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+"""Tests for os_release module."""
+
+import subprocess
+from unittest.mock import patch
+
+from testflinger_agent.os_release import (
+    UNKNOWN_RELEASE,
+    _derive_release_label,
+    _parse_os_release,
+    query_dut_release,
+)
+
+# Sample /etc/os-release contents for different Ubuntu variants
+
+JAMMY_OS_RELEASE = """\
+PRETTY_NAME="Ubuntu 22.04.5 LTS"
+NAME="Ubuntu"
+VERSION_ID="22.04"
+VERSION="22.04.5 LTS (Jammy Jellyfish)"
+VERSION_CODENAME=jammy
+ID=ubuntu
+ID_LIKE=debian
+"""
+
+NOBLE_OS_RELEASE = """\
+PRETTY_NAME="Ubuntu 24.04 LTS"
+NAME="Ubuntu"
+VERSION_ID="24.04"
+VERSION="24.04 LTS (Noble Numbat)"
+VERSION_CODENAME=noble
+ID=ubuntu
+ID_LIKE=debian
+"""
+
+CORE22_OS_RELEASE = """\
+NAME="Ubuntu Core"
+VERSION_ID="22"
+ID=ubuntu-core
+PRETTY_NAME="Ubuntu Core 22"
+"""
+
+CORE20_OS_RELEASE = """\
+NAME="Ubuntu Core"
+VERSION_ID="20"
+ID=ubuntu-core
+PRETTY_NAME="Ubuntu Core 20"
+"""
+
+
+class TestParseOsRelease:
+    def test_basic_parsing(self):
+        result = _parse_os_release(JAMMY_OS_RELEASE)
+        assert result["NAME"] == "Ubuntu"
+        assert result["VERSION_ID"] == "22.04"
+        assert result["VERSION"] == "22.04.5 LTS (Jammy Jellyfish)"
+
+    def test_unquoted_values(self):
+        result = _parse_os_release(JAMMY_OS_RELEASE)
+        assert result["VERSION_CODENAME"] == "jammy"
+
+    def test_empty_input(self):
+        assert _parse_os_release("") == {}
+
+    def test_malformed_lines(self):
+        content = 'no-equals\n\nNAME="Ubuntu"\n'
+        result = _parse_os_release(content)
+        assert result == {"NAME": "Ubuntu"}
+
+
+class TestDeriveReleaseLabel:
+    def test_ubuntu_point_release(self):
+        os_info = _parse_os_release(JAMMY_OS_RELEASE)
+        assert _derive_release_label(os_info) == "22.04.5"
+
+    def test_ubuntu_base_release(self):
+        os_info = _parse_os_release(NOBLE_OS_RELEASE)
+        assert _derive_release_label(os_info) == "24.04"
+
+    def test_ubuntu_core(self):
+        os_info = _parse_os_release(CORE22_OS_RELEASE)
+        assert _derive_release_label(os_info) == "Core 22"
+
+    def test_ubuntu_core_20(self):
+        os_info = _parse_os_release(CORE20_OS_RELEASE)
+        assert _derive_release_label(os_info) == "Core 20"
+
+    def test_missing_version_id(self):
+        assert _derive_release_label({"NAME": "Ubuntu"}) == UNKNOWN_RELEASE
+
+    def test_empty_dict(self):
+        assert _derive_release_label({}) == UNKNOWN_RELEASE
+
+
+class TestQueryDutRelease:
+    @patch("testflinger_agent.os_release.subprocess.run")
+    def test_successful_query(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=JAMMY_OS_RELEASE, stderr=""
+        )
+        assert query_dut_release("10.0.0.1") == "22.04.5"
+
+    @patch("testflinger_agent.os_release.subprocess.run")
+    def test_ssh_failure(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=255, stdout="", stderr="Connection refused"
+        )
+        assert query_dut_release("10.0.0.1") == UNKNOWN_RELEASE
+
+    @patch("testflinger_agent.os_release.subprocess.run")
+    def test_ssh_timeout(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="ssh", timeout=30)
+        assert query_dut_release("10.0.0.1") == UNKNOWN_RELEASE
+
+    @patch("testflinger_agent.os_release.subprocess.run")
+    def test_unexpected_exception(self, mock_run):
+        mock_run.side_effect = OSError("No such file")
+        assert query_dut_release("10.0.0.1") == UNKNOWN_RELEASE


### PR DESCRIPTION
## Description

To enable more meaningful data separation for the provisioning duration metric, this PR adds 2 labels to the `phase_duration` metric: `identifier` and `release`.

- `identifier` is derived from the `identifier` field in `testflinger-agent.conf`.
- `release` indicates the OS with which the DUT was provisioned. `release` becomes available after the provisioning phase and is applied to all subsequent phases, including provisioning. Implementation details:
  - After provisioning is finished, the TF Agent will ssh the DUT to read `/etc/os-release` information.
  - If successful, the Agent will normalizes the version to match the C3 definition (the logic is documented in [test_os_release.py](https://github.com/canonical/testflinger/blob/04af98123375cc2eca7bce64ffb3761a6133e110/agent/tests/test_os_release.py))
  - The normalization ensures consistent behavior in Grafana dashboards.

_Note: Additional rationale for the selected approach is provided in the linked ticket._

## Resolved issues

[CERTTF-832](https://warthogs.atlassian.net/browse/CERTTF-832)

## Documentation

Unit tests + linked ticket.

## Web service API changes

N/A

## Tests

Unit tests.


[CERTTF-832]: https://warthogs.atlassian.net/browse/CERTTF-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ