### PR TITLE
change: allow skipping control host power cycle via envar

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -609,6 +609,13 @@ class DefaultDevice:
 
     def pre_provision_hook(self):
         """Power cycle the control host before provisioning."""
+        if os.environ.get("DISABLE_CONTROL_HOST_POWERCYCLE"):
+            logger.info(
+                "Skipping control host power cycle "
+                "(DISABLE_CONTROL_HOST_POWERCYCLE is set)."
+            )
+            return
+
         control_host: str = str(self.config.get("control_host", ""))
         if not control_host:
             logger.debug("No control host configured for this agent.")

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -222,6 +222,25 @@ class TestPreProvisionHook:
 
         mock_power_cycle.assert_called_once()
 
+    def test_skipped_when_env_var_set(self, mocker, monkeypatch):
+        """Test hook skips power cycle when env var is set."""
+        monkeypatch.setenv("DISABLE_CONTROL_HOST_POWERCYCLE", "1")
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_power_cycle = mocker.patch.object(
+            DefaultControlHost, "power_cycle"
+        )
+        device = DefaultDevice(
+            {
+                "device_ip": "1.1.1.1",
+                "control_host": "control-host",
+                "control_host_reboot_script": ["reboot-cmd"],
+            }
+        )
+
+        device.pre_provision_hook()
+
+        mock_power_cycle.assert_not_called()
+
 
 class TestDefaultControlHostPowerCycle:
     """Tests for DefaultControlHost.power_cycle and ssh_fallback."""


### PR DESCRIPTION
## Description

Introducing an envar to skip power cycling the control host, `DISABLE_CONTROL_HOST_POWERCYCLE`. Useful when testing from source.

## Resolved issues

N/A

## Documentation

N/A

## Web service API changes

N/A

## Tests

Unit tests
