### PR TITLE
update: skip pre_provision_hook for muxpi.

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
@@ -30,6 +30,10 @@ logger = logging.getLogger(__name__)
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
+    def pre_provision_hook(self):
+        """Skip control host power cycle for muxpi devices."""
+        pass
+
     def provision(self, args):
         """Provision device when the command is invoked."""
         with open(args.config) as configfile:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -19,7 +19,26 @@ from unittest.mock import MagicMock
 import pytest
 
 from testflinger_device_connectors.devices import ProvisioningError
+from testflinger_device_connectors.devices import DefaultControlHost
+from testflinger_device_connectors.devices.muxpi import DeviceConnector
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
+
+
+def test_pre_provision_hook_is_noop(mocker):
+    """Test that muxpi skips the control host power cycle."""
+    mocker.patch("builtins.open", mocker.mock_open())
+    mock_power_cycle = mocker.patch.object(DefaultControlHost, "power_cycle")
+    device = DeviceConnector(
+        {
+            "device_ip": "1.1.1.1",
+            "control_host": "control-host",
+            "control_host_reboot_script": ["reboot-cmd"],
+        }
+    )
+
+    device.pre_provision_hook()
+
+    mock_power_cycle.assert_not_called()
 
 
 def test_check_ce_oem_iot_image(mocker):

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -18,8 +18,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from testflinger_device_connectors.devices import ProvisioningError
-from testflinger_device_connectors.devices import DefaultControlHost
+from testflinger_device_connectors.devices import (
+    DefaultControlHost,
+    ProvisioningError,
+)
 from testflinger_device_connectors.devices.muxpi import DeviceConnector
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
 


### PR DESCRIPTION
## Description

[PR #1002](https://github.com/canonical/testflinger/pull/1002)￼ introduced power-cycling the control host on every run, but this affects muxpi provisioning. To avoid that, we can override pre_provision_hook in the muxpi connector to skip the power cycle.

## Resolved issues

Many Raspberry Pis failed to provision.


## Tests

Test it locally
Original message
```
2026-04-10 03:34:20,040 rpi5b8g-001 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-04-10 03:34:20,041 rpi5b8g-001 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
```
Override pre_provision_hook
```
2026-04-10 03:35:17,373 rpi5b8g-001 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-04-10 03:35:17,377 rpi5b8g-001 INFO: DEVICE CONNECTOR: BEGIN provision
2026-04-10 03:35:17,377 rpi5b8g-001 INFO: DEVICE CONNECTOR: Provisioning device
```