### PR TITLE
Update: Increase timeout in oemscript

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
@@ -120,7 +120,7 @@ class OemScript:
         ]
         proc = subprocess.run(
             cmd,
-            timeout=60 * 60,  # 1 hour - just in case
+            timeout=90 * 60,  # 1.5 hour - just in case
             check=False,
         )
         if proc.returncode:


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->
In the SRU test run, some desktops failed when executing the following command due to insufficient timeout:
`ssh -o StrictHostKeyChecking=no ubuntu@10.102.164.81 sudo apt-get -o DPkg::Lock::Timeout=-1 purge -y ubiquity`
The auto‑refresh process was still running in the background, preventing `apt-get` from completing within the original timeout window. To avoid this issue, we should increase the timeout value so the session can pass successfully.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->
http://10.102.156.15:8080/job/cert-oem-sru-jammy-desktop-hp-z8-fury-g5-workstation-c31158/
http://10.102.156.15:8080/job/cert-oem-sru-jammy-desktop-lenovo-thinkstation-px-c31329/

```
Waiting for cache lock: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4404 (apt)
...
2026-04-10 02:28:45,857 lenovo-thinkstation-px-c31329 ERROR: DEVICE CONNECTOR: Command '[PosixPath('/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_device_connectors/devices/oemscript/../../data/muxpi/oemscript/recovery-from-iso.sh'), '--ubr', '--dut-iso-url', 'https://tel-image-cache.canonical.com/oem-share/sutton/20240304_doc/pc-sutton-jammy-amd64-X03-20240304-752.iso', '--inject-ssh-key', '/home/ubuntu/.ssh/id_rsa.pub', '-t', '10.102.164.81']' timed out after 3599.999986393377 seconds
```

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
