### PR TITLE
fix(submit): allow submit to be called by nested composite actions

### DIFF
--- a/.github/actions/queue-status/action.yaml
+++ b/.github/actions/queue-status/action.yaml
@@ -35,7 +35,7 @@ runs:
   steps:
     # Use testflinger-setup by copying action from adjacent directory.
     # This is required so we can use the same reference as the one
-    # checkout by external workflow or action.
+    # checked out by external workflow or action.
     - name: Stage testflinger-setup from adjacent action directory
       shell: bash
       env:

--- a/.github/actions/queue-status/action.yaml
+++ b/.github/actions/queue-status/action.yaml
@@ -33,19 +33,17 @@ outputs:
 runs:
   using: composite
   steps:
-    # This action is necessary as a workaround for https://github.com/actions/runner/issues/895.
-    # Since contexts cannot be used in the `uses:` key, we can't guarantee that this action will
-    # use the same branch of testflinger-setup
-    - name: Checkout testflinger actions
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    # Use testflinger-setup by copying action from adjacent directory.
+    # This is required so we can use the same reference as the one
+    # checkout by external workflow or action.
+    - name: Stage testflinger-setup from adjacent action directory
+      shell: bash
       env:
-        GITHUB_REF: ${{ github.action_ref }}
-      with:
-        repository: canonical/testflinger
-        ref: ${{ env.GITHUB_REF }}
-        path: _tmp_testflinger-actions
-        sparse-checkout: .github/actions/testflinger-setup
-        persist-credentials: false
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        mkdir -p _tmp_testflinger-actions/.github/actions
+        cp -r "$ACTION_PATH/../testflinger-setup" \
+              _tmp_testflinger-actions/.github/actions/testflinger-setup
 
     - name: Setup Testflinger
       uses: ./_tmp_testflinger-actions/.github/actions/testflinger-setup

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -41,7 +41,7 @@ runs:
 
     # Use testflinger-setup by copying action from adjacent directory.
     # This is required so we can use the same reference as the one
-    # checkout by external workflow or action.
+    # checked out by external workflow or action.
     - name: Stage testflinger-setup from adjacent action directory
       shell: bash
       env:

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -39,19 +39,17 @@ runs:
   using: composite
   steps:
 
-    # This action is necessary as a workaround for https://github.com/actions/runner/issues/895.
-    # Since contexts cannot be used in the `uses:` key, we can't guarantee that this action will
-    # use the same branch of testflinger-setup
-    - name: Checkout testflinger actions
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    # Use testflinger-setup by copying action from adjacent directory.
+    # This is required so we can use the same reference as the one
+    # checkout by external workflow or action.
+    - name: Stage testflinger-setup from adjacent action directory
+      shell: bash
       env:
-        GITHUB_REF: ${{ github.action_ref }}
-      with:
-        repository: canonical/testflinger
-        ref: ${{ env.GITHUB_REF }}
-        path: _tmp_testflinger-actions
-        sparse-checkout: .github/actions/testflinger-setup
-        persist-credentials: false
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        mkdir -p _tmp_testflinger-actions/.github/actions
+        cp -r "$ACTION_PATH/../testflinger-setup" \
+              _tmp_testflinger-actions/.github/actions/testflinger-setup
 
     - name: Setup Testflinger
       uses: ./_tmp_testflinger-actions/.github/actions/testflinger-setup


### PR DESCRIPTION
## Description
The current `github_ref` that is used so the `testflinger-setup` has the same reference as the submit action and it work in almost all but one edge case. 

Whenever calling the submit action from another composite action in "Repo B" which is then called from a third repo called "Repo C" and using a specified hash or tag, it will not honor the revision from which the submit action is called e.g.
repoC: uses `actionB@my-branch`
repoB: `actionB` uses `submit@submit/v1.4.4`

The `github_ref` will then be set to `my-branch` which does not exist in this repository causing a failure. 
To enable developers to test local changes on composite action, this PR changes to `github.action_path` to create a local copy of the `testflinger-setup`. This uses the same reference as the submit action without needing a `github_ref`

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
NA
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Tested on this run for backward compatibility calling this submit action from another workflow: https://github.com/canonical/tf-submit-action-test/actions/runs/24295950198/job/70940894955

Dev has also confirmed this approach works on this MM thread: https://chat.canonical.com/canonical/pl/w3g3pi4d5insfb5ndny7srzema
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
