### PR TITLE
fix(cli): secret command get client_id from auth module

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -580,7 +580,9 @@ class TestflingerCli:
             "write", help="Write a secret value"
         )
         write_parser.set_defaults(func=self.secret_write)
-        write_parser.add_argument("path", help="Path for the secret")
+        write_parser.add_argument(
+            "path", help="Path for the secret", type=helpers.regex_path
+        )
         write_parser.add_argument("value", help="Value of the secret")
         self._add_auth_args(write_parser)
 
@@ -590,7 +592,9 @@ class TestflingerCli:
         )
         delete_parser.set_defaults(func=self.secret_delete)
         delete_parser.add_argument(
-            "path", help="Path for the secret to delete"
+            "path",
+            help="Path for the secret to delete",
+            type=helpers.regex_path,
         )
         self._add_auth_args(delete_parser)
 
@@ -1843,9 +1847,7 @@ class TestflingerCli:
 
         secret_data = {"value": self.args.value}
 
-        # Remove leading slash if present to build the correct endpoint URL
-        path = self.args.path.lstrip("/")
-        endpoint = f"/v1/secrets/{self.auth.client_id}/{path}"
+        endpoint = f"/v1/secrets/{self.auth.client_id}/{self.args.path}"
         try:
             self.client.put(endpoint, secret_data, headers=auth_headers)
         except client.HTTPError as exc:
@@ -1862,9 +1864,7 @@ class TestflingerCli:
         if auth_headers is None or self.auth.client_id is None:
             sys.exit("Error deleting secret: Authentication is required")
 
-        # Remove leading slash if present to build the correct endpoint URL
-        path = self.args.path.lstrip("/")
-        endpoint = f"/v1/secrets/{self.auth.client_id}/{path}"
+        endpoint = f"/v1/secrets/{self.auth.client_id}/{self.args.path}"
         try:
             self.client.delete(endpoint, headers=auth_headers)
         except client.HTTPError as exc:

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -1838,11 +1838,14 @@ class TestflingerCli:
         except CredentialsError as exc:
             sys.exit(exc)
 
-        if auth_headers is None or self.client_id is None:
+        if auth_headers is None or self.auth.client_id is None:
             sys.exit("Error writing secret: Authentication is required")
 
         secret_data = {"value": self.args.value}
-        endpoint = f"/v1/secrets/{self.client_id}/{self.args.path}"
+
+        # Remove leading slash if present to build the correct endpoint URL
+        path = self.args.path.lstrip("/")
+        endpoint = f"/v1/secrets/{self.auth.client_id}/{path}"
         try:
             self.client.put(endpoint, secret_data, headers=auth_headers)
         except client.HTTPError as exc:
@@ -1856,10 +1859,12 @@ class TestflingerCli:
         except CredentialsError as exc:
             sys.exit(exc)
 
-        if auth_headers is None or self.client_id is None:
+        if auth_headers is None or self.auth.client_id is None:
             sys.exit("Error deleting secret: Authentication is required")
 
-        endpoint = f"/v1/secrets/{self.client_id}/{self.args.path}"
+        # Remove leading slash if present to build the correct endpoint URL
+        path = self.args.path.lstrip("/")
+        endpoint = f"/v1/secrets/{self.auth.client_id}/{path}"
         try:
             self.client.delete(endpoint, headers=auth_headers)
         except client.HTTPError as exc:

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -16,9 +16,7 @@ from testflinger_cli.errors import SnapPrivateFileError
 # Only accept paths that are separated by forward slashes
 # Expected format should not start or end with a slash
 # Examples of valid paths: "path", "my/secret/path"
-PATH_PATTERN = re.compile(
-    r"^[a-zA-Z_][a-zA-Z0-9_]*(?:\/[a-zA-Z_][a-zA-Z0-9_]*)*$"
-)
+PATH_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_-]+)*$")
 
 
 def is_snap() -> bool:

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -13,6 +13,13 @@ import yaml
 from testflinger_cli.consts import SNAP_NAME, SNAP_PRIVATE_DIRS
 from testflinger_cli.errors import SnapPrivateFileError
 
+# Only accept paths that are separated by forward slashes
+# Expected format should not start or end with a slash
+# Examples of valid paths: "path", "my/secret/path"
+PATH_PATTERN = re.compile(
+    r"^[a-zA-Z_][a-zA-Z0-9_]*(?:\/[a-zA-Z_][a-zA-Z0-9_]*)*$"
+)
+
 
 def is_snap() -> bool:
     """Check if the current environment is in the Testflinger snap."""
@@ -233,3 +240,18 @@ def regex_arg(value):
         raise argparse.ArgumentTypeError(
             f"Invalid regex '{value}', error: {str(err)}"
         ) from err
+
+
+def regex_path(value, pattern: re.Pattern = PATH_PATTERN):
+    """Validate that a file path argument is a valid regex pattern.
+
+    :param value: The file path string to validate
+    :param pattern: The regex pattern to validate against
+    :return: The original value if valid
+    :raises ArgumentTypeError: If the value does not match the regex pattern
+    """
+    if not pattern.match(value):
+        raise argparse.ArgumentTypeError(
+            f"Invalid value '{value}', not a valid path"
+        )
+    return value

--- a/cli/testflinger_cli/helpers.py
+++ b/cli/testflinger_cli/helpers.py
@@ -250,6 +250,9 @@ def regex_path(value, pattern: re.Pattern = PATH_PATTERN):
     """
     if not pattern.match(value):
         raise argparse.ArgumentTypeError(
-            f"Invalid value '{value}', not a valid path"
+            f"Invalid value '{value}', not a valid path. \n"
+            "Paths must only contain alphanumeric characters, hyphens (-), "
+            "underscores (_), and forward slashes (/). Additionally, "
+            "paths must not start or end with a forward slash (/)."
         )
     return value

--- a/cli/tests/test_secret.py
+++ b/cli/tests/test_secret.py
@@ -30,10 +30,7 @@ from .test_cli import URL
 
 @pytest.mark.parametrize(
     "test_path",
-    [
-        "path",
-        "my/secret/path",
-    ],
+    ["path", "my/secret/path", "/my/secret/path"],
 )
 def test_secret_write(auth_fixture, capsys, requests_mock, test_path):
     """Test successful secret write operation."""
@@ -41,7 +38,7 @@ def test_secret_write(auth_fixture, capsys, requests_mock, test_path):
     test_value = "secret_value_123"
 
     requests_mock.put(
-        f"{URL}/v1/secrets/my_client_id/{test_path}",
+        f"{URL}/v1/secrets/my_client_id/{test_path.lstrip('/')}",
         text="OK",
         status_code=HTTPStatus.OK,
     )
@@ -93,17 +90,14 @@ def test_secret_write_http_error(auth_fixture, requests_mock):
 
 @pytest.mark.parametrize(
     "test_path",
-    [
-        "path",
-        "my/secret/path",
-    ],
+    ["path", "my/secret/path", "/my/secret/path"],
 )
 def test_secret_delete(auth_fixture, capsys, requests_mock, test_path):
     """Test successful secret delete operation."""
     auth_fixture(ServerRoles.CONTRIBUTOR)
 
     requests_mock.delete(
-        f"{URL}/v1/secrets/my_client_id/{test_path}",
+        f"{URL}/v1/secrets/my_client_id/{test_path.lstrip('/')}",
         text="OK",
         status_code=HTTPStatus.OK,
     )

--- a/cli/tests/test_secret.py
+++ b/cli/tests/test_secret.py
@@ -30,7 +30,14 @@ from .test_cli import URL
 
 @pytest.mark.parametrize(
     "test_path",
-    ["path", "my/secret/path"],
+    [
+        "path",
+        "my/secret/path",
+        "path/1234",
+        "my/1234/path",
+        "my/secret-path",
+        "my/1path",
+    ],
 )
 def test_secret_write(auth_fixture, capsys, requests_mock, test_path):
     """Test successful secret write operation."""
@@ -90,7 +97,14 @@ def test_secret_write_http_error(auth_fixture, requests_mock):
 
 @pytest.mark.parametrize(
     "test_path",
-    ["path", "my/secret/path"],
+    [
+        "path",
+        "my/secret/path",
+        "path/1234",
+        "my/1234/path",
+        "my/secret-path",
+        "my/1path",
+    ],
 )
 def test_secret_delete(auth_fixture, capsys, requests_mock, test_path):
     """Test successful secret delete operation."""

--- a/cli/tests/test_secret.py
+++ b/cli/tests/test_secret.py
@@ -30,7 +30,7 @@ from .test_cli import URL
 
 @pytest.mark.parametrize(
     "test_path",
-    ["path", "my/secret/path", "/my/secret/path"],
+    ["path", "my/secret/path"],
 )
 def test_secret_write(auth_fixture, capsys, requests_mock, test_path):
     """Test successful secret write operation."""
@@ -38,7 +38,7 @@ def test_secret_write(auth_fixture, capsys, requests_mock, test_path):
     test_value = "secret_value_123"
 
     requests_mock.put(
-        f"{URL}/v1/secrets/my_client_id/{test_path.lstrip('/')}",
+        f"{URL}/v1/secrets/my_client_id/{test_path}",
         text="OK",
         status_code=HTTPStatus.OK,
     )
@@ -90,14 +90,14 @@ def test_secret_write_http_error(auth_fixture, requests_mock):
 
 @pytest.mark.parametrize(
     "test_path",
-    ["path", "my/secret/path", "/my/secret/path"],
+    ["path", "my/secret/path"],
 )
 def test_secret_delete(auth_fixture, capsys, requests_mock, test_path):
     """Test successful secret delete operation."""
     auth_fixture(ServerRoles.CONTRIBUTOR)
 
     requests_mock.delete(
-        f"{URL}/v1/secrets/my_client_id/{test_path.lstrip('/')}",
+        f"{URL}/v1/secrets/my_client_id/{test_path}",
         text="OK",
         status_code=HTTPStatus.OK,
     )
@@ -228,3 +228,36 @@ def test_secret_invalid_token_error(requests_mock, subcommand):
         tfcli.run()
 
     assert "Please reauthenticate with server" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "test_path",
+    [
+        "/path",
+        "/my/secret/path/",
+        "invalid//path",
+        "invalid path",
+        "invalid\\path",
+        "/////path",
+        "path//////",
+    ],
+)
+def test_secret_write_invalid_path(auth_fixture, capsys, test_path):
+    """Test write operation is aborted for invalid paths."""
+    auth_fixture(ServerRoles.CONTRIBUTOR)
+    sys.argv = [
+        "",
+        "secret",
+        "write",
+        test_path,
+        "test_value",
+    ]
+    with pytest.raises(SystemExit) as exc_info:
+        testflinger_cli.TestflingerCli().run()
+
+    # Argparse exits with code 2 for argument errors
+    assert exc_info.value.code == 2
+    assert (
+        f"Invalid value '{test_path}', not a valid path"
+        in capsys.readouterr().err
+    )

--- a/cli/tests/test_secret.py
+++ b/cli/tests/test_secret.py
@@ -37,6 +37,7 @@ from .test_cli import URL
         "my/1234/path",
         "my/secret-path",
         "my/1path",
+        "my/secret_path",
     ],
 )
 def test_secret_write(auth_fixture, capsys, requests_mock, test_path):
@@ -104,6 +105,7 @@ def test_secret_write_http_error(auth_fixture, requests_mock):
         "my/1234/path",
         "my/secret-path",
         "my/1path",
+        "my/secret_path",
     ],
 )
 def test_secret_delete(auth_fixture, capsys, requests_mock, test_path):

--- a/docs/reference/secrets.rst
+++ b/docs/reference/secrets.rst
@@ -30,6 +30,7 @@ Paths must follow these constraints:
 
 - Must be unique within a client's namespace
 - Only alphanumeric characters, hyphens ``(-)``, underscores ``(_)`` and forward slashes ``(/)`` are allowed
+- Must not start and end with a forward slash ``(/)``
 
 Environment variable names must follow standard shell naming conventions:
 

--- a/server/src/testflinger/api/helpers.py
+++ b/server/src/testflinger/api/helpers.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Helpers module for v1 api."""
+
+import re
+from http import HTTPStatus
+
+from apiflask import abort
+
+PATH_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_-]+)*$")
+
+
+def validate_secret_path(path):
+    """Validate the secret path format."""
+    if not PATH_PATTERN.match(path):
+        abort(
+            HTTPStatus.UNPROCESSABLE_ENTITY,
+            message=(
+                f"Invalid value '{path}', not a valid path. \n"
+                "Paths must only contain alphanumeric characters, hyphens (-), "  # noqa: E501
+                "underscores (_), and forward slashes (/). Additionally, "
+                "paths must not start or end with a forward slash (/)."
+            ),
+        )

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -32,7 +32,7 @@ from urllib3.util.retry import Retry
 from werkzeug.routing import BaseConverter
 
 from testflinger import database
-from testflinger.api import auth, schemas
+from testflinger.api import auth, helpers, schemas
 from testflinger.api.auth import authenticate, require_role
 from testflinger.logs import LogFragment, MongoLogHandler
 from testflinger.secrets.exceptions import (
@@ -1219,6 +1219,9 @@ def secrets_put(client_id, path, json_data):
             HTTPStatus.FORBIDDEN,
             message=f"'{client_id}' doesn't match authenticated client id",
         )
+
+    # Validate the secret path, if not valid, abort with Unprocessable Entity
+    helpers.validate_secret_path(path)
     try:
         current_app.secrets_store.write(client_id, path, json_data["value"])
     except AccessError as error:
@@ -1240,6 +1243,8 @@ def secrets_delete(client_id, path):
             HTTPStatus.FORBIDDEN,
             message=f"'{client_id}' doesn't match authenticated client id",
         )
+    # Validate the secret path, if not valid, abort with Unprocessable Entity
+    helpers.validate_secret_path(path)
     try:
         current_app.secrets_store.delete(client_id, path)
     except AccessError as error:

--- a/server/tests/test_v1_secrets.py
+++ b/server/tests/test_v1_secrets.py
@@ -733,3 +733,30 @@ def test_job_get_with_missing_client_id(app_with_store, agent_auth_header):
 
     # AND: the secrets store should not have been called
     mock_secrets_store.read.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "client_id,path,value",
+    (
+        ("client_1", "invalid path", "value"),
+        ("client_1", "path////", "value"),
+        ("client_1", "invalid//path", "value"),
+    ),
+)
+def test_secrets_invalid_path(app_with_store, client_id, path, value):
+    """Test writing a secret with invalid path through the API is rejected."""
+    # GIVEN: an app with a secrets store
+    mock_secrets_store = app_with_store.application.secrets_store
+    mock_secrets_store.write.return_value = None
+
+    # WHEN: an authorised request is sent to the PUT secrets endpoint
+    token = get_access_token(app_with_store, client_id, "client_key")
+    response = app_with_store.put(
+        f"/v1/secrets/{client_id}/{path}",
+        json={"value": value},
+        headers={"Authorization": token},
+    )
+
+    # THEN: the request is unsuccessful due to invalid path
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    mock_secrets_store.write.assert_not_called()


### PR DESCRIPTION
## Description
Minor bug fix for the secrets subcommands. Currently, they are taking into account the `client_id` that is provided via arguments or environment variables. 

The auth module has `auth.client_id` attribute that should be used instead. 
This PR also removes a trailing slash in case its provided so the path can be built correctly.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves #1017 
Resolves [CERTTF-1019](https://warthogs.atlassian.net/browse/CERTTF-1019)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
All existing tests are passing. Updated secret write and delete test so it can also accept the path with leading slash

Tested on staging as well:
```
uv run testflinger-cli --server https://testflinger-staging.canonical.com login
Successfully authenticated as user 'rene_stg'
```
```
uv run testflinger-cli --server https://testflinger-staging.canonical.com secret write new/path 'test'
Secret 'new/path' written successfully
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-1019]: https://warthogs.atlassian.net/browse/CERTTF-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ