### PR TITLE
feat(cli): add ephemeral to reserve command

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -352,6 +352,11 @@ class TestflingerCli:
             help="Reservation timeout in seconds (default "
             f"{DEFAULT_RESERVE_TIMEOUT})",
         )
+        parser.add_argument(
+            "--ephemeral",
+            action="store_true",
+            help="MAAS ephemeral (in-memory) deployment.",
+        )
 
     def _add_status_args(self, subparsers):
         """Command line arguments for status."""
@@ -1398,7 +1403,14 @@ class TestflingerCli:
         # Handle distro if provided
         provision_data = {}
         if self.args.distro:
-            provision_data = {"provision_data": {"distro": self.args.distro}}
+            # If distro is provided, we can assume this is a MAAS deployment
+            # Setting ephemeral based on user input.
+            provision_data = {
+                "provision_data": {
+                    "distro": self.args.distro,
+                    "ephemeral": self.args.ephemeral,
+                }
+            }
         else:
             try:
                 images = self.client.get_images(queue)

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -1400,16 +1400,21 @@ class TestflingerCli:
             self.do_list_queues()
         )
 
+        # Ephemeral only supported for MAAS deployments via distro argument
+        if self.args.ephemeral and not self.args.distro:
+            sys.exit(
+                "Error: --ephemeral option requires --distro to be specified."
+            )
+
         # Handle distro if provided
         provision_data = {}
         if self.args.distro:
-            # If distro is provided, we can assume this is a MAAS deployment
-            # Setting ephemeral based on user input.
+            # Only include ephemeral in provision_data if it's set
             provision_data = {
                 "provision_data": {
                     "distro": self.args.distro,
-                    "ephemeral": self.args.ephemeral,
                 }
+                | ({"ephemeral": True} if self.args.ephemeral else {})
             }
         else:
             try:

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -920,6 +920,30 @@ def test_reserve_with_distro(capsys, requests_mock):
     assert '"ssh_keys"' in std.out
 
 
+def test_reserve_with_ephemeral(capsys, requests_mock):
+    """Test reserve with --ephemeral flag submits correct provision_data."""
+    requests_mock.get(rmock.ANY, status_code=HTTPStatus.OK)
+    requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "--distro",
+        "noble",
+        "-k",
+        "lp:fakeuser",
+        "--ephemeral",
+        "-d",  # dry-run to skip polling
+    ]
+    testflinger_cli.TestflingerCli().run()
+    std = capsys.readouterr()
+    assert '"distro": "noble"' in std.out
+    assert '"job_queue": "fake"' in std.out
+    assert '"ssh_keys"' in std.out
+    assert '"ephemeral": true' in std.out
+
+
 def test_reserve_distro_with_image_fails(requests_mock, capsys):
     """Test that --distro and --image cannot be used together.
 

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -938,10 +938,51 @@ def test_reserve_with_ephemeral(capsys, requests_mock):
     ]
     testflinger_cli.TestflingerCli().run()
     std = capsys.readouterr()
-    assert '"distro": "noble"' in std.out
-    assert '"job_queue": "fake"' in std.out
-    assert '"ssh_keys"' in std.out
     assert '"ephemeral": true' in std.out
+
+
+def test_reserve_with_ephemeral_and_image_fails(requests_mock):
+    """Test that --ephemeral and --image cannot be used together."""
+    requests_mock.get(URL + "/v1/agents/queues", json={})
+    requests_mock.get(URL + "/v1/agents/images/fake", json={})
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "-i",
+        "http://face_image.xz",
+        "-k",
+        "lp:fakeuser",
+        "--ephemeral",
+        "-d",
+    ]
+    with pytest.raises(SystemExit) as exc_info:
+        testflinger_cli.TestflingerCli().run()
+    # Verify that the error message mentions the conflict
+    assert "--ephemeral option requires --distro to be specified" in str(
+        exc_info.value
+    )
+
+
+def test_reserve_without_ephemeral(capsys, requests_mock):
+    """Test reserve without ephemeral flag does not add ephemeral key."""
+    requests_mock.get(rmock.ANY, status_code=HTTPStatus.OK)
+    requests_mock.post(rmock.ANY, status_code=HTTPStatus.OK)
+    sys.argv = [
+        "",
+        "reserve",
+        "-q",
+        "fake",
+        "--distro",
+        "noble",
+        "-k",
+        "lp:fakeuser",
+        "-d",  # dry-run to skip polling
+    ]
+    testflinger_cli.TestflingerCli().run()
+    std = capsys.readouterr()
+    assert "ephemeral" not in std.out
 
 
 def test_reserve_distro_with_image_fails(requests_mock, capsys):

--- a/docs/how-to/reserve-job.rst
+++ b/docs/how-to/reserve-job.rst
@@ -52,10 +52,13 @@ For a ``maas2`` device type, this requires the ``--distro`` parameter:
 
 .. tip::
 
-  For MAAS devices, you can use ephemeral (in-memory) deployments by using the ``--ephemeral`` flag.
-  This makes an in-memory deployment which is faster to provision and can be useful for simple validation jobs.
+  For MAAS devices, you can use ephemeral (in-memory) deployments by using the
+  ``--ephemeral`` flag when MAAS 3.5.0 or later is available.
+  This makes an in-memory deployment which is faster to provision and can be useful 
+  for simple validation jobs. On older MAAS versions, the ``--ephemeral`` flag is 
+  ignored and the deployment proceeds without ephemeral provisioning.
 
-For most other device types, the ``--image`` parameter corresponds to the ``url:`` key in ``reserve_data``:
+For most other device types, the ``--image`` parameter corresponds to the ``url:`` key in ``provision_data``:
 
 .. code-block:: shell
 

--- a/docs/how-to/reserve-job.rst
+++ b/docs/how-to/reserve-job.rst
@@ -50,6 +50,11 @@ For a ``maas2`` device type, this requires the ``--distro`` parameter:
 
   $ testflinger-cli reserve --distro noble --key lp:user --key gh:user --timeout 7200 --queue maas_devices
 
+.. tip::
+
+  For MAAS devices, you can use ephemeral (in-memory) deployments by using the ``--ephemeral`` flag.
+  This makes an in-memory deployment which is faster to provision and can be useful for simple validation jobs.
+
 For most other device types, the ``--image`` parameter corresponds to the ``url:`` key in ``reserve_data``:
 
 .. code-block:: shell

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -108,8 +108,10 @@ The ``maas2`` device connector supports the following ``provision_data`` keys:
      - Specify a custom disk configuration for the machine. For more information, see the
        :doc:`maas_storage`.
    * - ``ephemeral``
-     - Set to ``true`` to deploy in-memory rather than to disk.
-       For more information, see `MAAS documentation: Ephemeral deployment
+     - Set to ``true`` to deploy in-memory rather than to disk. Ephemeral deployment
+       is supported only with MAAS 3.5.0 and later; on older MAAS versions this
+       setting is ignored. For more information, see `MAAS documentation:
+       Ephemeral deployment
        <https://canonical.com/maas/docs/about-deploying-machines#p-17464-ephemeral-os-deployments-maas-35>`_.
 
 

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -107,6 +107,10 @@ The ``maas2`` device connector supports the following ``provision_data`` keys:
    * - ``disks``
      - Specify a custom disk configuration for the machine. For more information, see the
        :doc:`maas_storage`.
+   * - ``ephemeral``
+     - Set to ``true`` to deploy in-memory rather than to disk.
+       For more information, see `MAAS documentation: Ephemeral deployment
+       <https://canonical.com/maas/docs/about-deploying-machines#p-17464-ephemeral-os-deployments-maas-35>`_.
 
 
 .. _muxpi:


### PR DESCRIPTION
## Description
With ephemeral now supported server side. Adding support for this type of deployments via `reserve` command.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-965](https://warthogs.atlassian.net/browse/CERTTF-965)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
Updated reserve docs with a tip for maas deployments and ephemeral flag. 
Also added doc for ephemeral support in maas device connector reference
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
NA
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests and tested in staging:
```
uv run testflinger-cli --server https://testflinger-staging.canonical.com reserve --distro noble --key lp:rene-orozco --timeout 60 --queue audino --ephemeral

The following job will be submitted:
{
...
  "provision_data": {
    "distro": "noble",
    "ephemeral": true
  }
}
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-965]: https://warthogs.atlassian.net/browse/CERTTF-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ