### PR TITLE
fix: Jammy OEM preset doesn't handle alloem properly

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -35,6 +35,8 @@ from testflinger_device_connectors.devices.zapper import ZapperConnector
 
 logger = logging.getLogger(__name__)
 
+JAMMY_OEM_PRESET = "desktop-jammy-oem"
+
 
 class DeviceConnector(ZapperConnector):
     """Tool for provisioning baremetal with a given image."""
@@ -108,7 +110,7 @@ class DeviceConnector(ZapperConnector):
         )
 
     def _get_credentials(self, target: str | None = None) -> tuple[str, str]:
-        if target == "jammy-oem":
+        if target == JAMMY_OEM_PRESET:
             return "ubuntu", "u"
         else:
             return (
@@ -127,7 +129,7 @@ class DeviceConnector(ZapperConnector):
         for the Zapper `provision` API.
         """
         provision_data = {}
-        if "preset" in self.job_data["provision_data"]:
+        if preset := self.job_data["provision_data"].get("preset"):
             has_autoinstall = False
             for key, value in self.job_data["provision_data"].items():
                 if key.startswith("autoinstall"):
@@ -136,7 +138,7 @@ class DeviceConnector(ZapperConnector):
                     provision_data[key] = value
 
             provision_data["username"], provision_data["password"] = (
-                self._get_credentials("preset")
+                self._get_credentials(preset)
             )
 
             if has_autoinstall:
@@ -144,12 +146,22 @@ class DeviceConnector(ZapperConnector):
                     self._get_autoinstall_conf()
                 )
 
+            if preset == JAMMY_OEM_PRESET:
+                # control host only does recovery
+                provision_data.pop("url", None)
+
+                if alloem_url := self.job_data["provision_data"].get(
+                    "alloem_url"
+                ):
+                    provision_data["url"] = alloem_url
+                    provision_data.pop("alloem_url", None)
+
         elif "alloem_url" in self.job_data["provision_data"]:
             provision_data["url"] = self.job_data["provision_data"][
                 "alloem_url"
             ]
             provision_data["username"], provision_data["password"] = (
-                self._get_credentials("jammy-oem")
+                self._get_credentials(JAMMY_OEM_PRESET)
             )
             provision_data["autoinstall_conf"] = self._get_autoinstall_conf()
             provision_data["robot_tasks"] = self.job_data["provision_data"][
@@ -190,7 +202,11 @@ class DeviceConnector(ZapperConnector):
     def _post_run_actions(self, args):
         super()._post_run_actions(args)
 
-        if "alloem_url" in self.job_data["provision_data"]:
+        provision_data = self.job_data["provision_data"]
+        used_alloem = "alloem_url" in provision_data
+        is_jammy_oem_preset = provision_data.get("preset") == JAMMY_OEM_PRESET
+
+        if used_alloem or is_jammy_oem_preset:
             self._post_run_actions_oem(args)
 
     def _post_run_actions_oem(self, args):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -122,82 +122,91 @@ class DeviceConnector(ZapperConnector):
                 ),
             )
 
+    OPTIONAL_KEYS = (
+        "cmdline_append",
+        "skip_download",
+        "wait_until_ssh",
+        "live_image",
+        "ubuntu_sso_email",
+        "robot_retries",
+    )
+
     def _validate_configuration(
         self,
     ) -> Tuple[Tuple, Dict[str, Any]]:
         """Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.
         """
-        provision_data = {}
-        if preset := self.job_data["provision_data"].get("preset"):
-            has_autoinstall = False
-            for key, value in self.job_data["provision_data"].items():
-                if key.startswith("autoinstall"):
-                    has_autoinstall = True
-                else:
-                    provision_data[key] = value
+        job_provision = self.job_data["provision_data"]
 
-            provision_data["username"], provision_data["password"] = (
-                self._get_credentials(preset)
-            )
-
-            if has_autoinstall:
-                provision_data["autoinstall_conf"] = (
-                    self._get_autoinstall_conf()
-                )
-
-            if preset == JAMMY_OEM_PRESET:
-                # control host only does recovery
-                provision_data.pop("url", None)
-
-                if alloem_url := self.job_data["provision_data"].get(
-                    "alloem_url"
-                ):
-                    provision_data["url"] = alloem_url
-                    provision_data.pop("alloem_url", None)
-
-        elif "alloem_url" in self.job_data["provision_data"]:
-            provision_data["url"] = self.job_data["provision_data"][
-                "alloem_url"
-            ]
-            provision_data["username"], provision_data["password"] = (
-                self._get_credentials(JAMMY_OEM_PRESET)
-            )
-            provision_data["autoinstall_conf"] = self._get_autoinstall_conf()
-            provision_data["robot_tasks"] = self.job_data["provision_data"][
-                "robot_tasks"
-            ]
+        if "preset" in job_provision:
+            provision_data = self._build_preset_payload()
+        elif "alloem_url" in job_provision:
+            provision_data = self._build_alloem_payload()
         else:
-            provision_data["url"] = self.job_data["provision_data"]["url"]
-            provision_data["username"], provision_data["password"] = (
-                self._get_credentials()
-            )
-            provision_data["autoinstall_conf"] = self._get_autoinstall_conf()
-            provision_data["robot_tasks"] = self.job_data["provision_data"][
-                "robot_tasks"
-            ]
+            provision_data = self._build_default_payload()
 
         provision_data["authorized_keys"] = [self._read_ssh_key()]
-
-        # Let's handle defaults on the Zapper side adding only the explicitly
-        # specified keys to the `provision_data` dict.
-        optionals = [
-            "cmdline_append",
-            "skip_download",
-            "wait_until_ssh",
-            "live_image",
-            "ubuntu_sso_email",
-            "robot_retries",
-        ]
+        # Let Zapper handle defaults — only forward explicitly-set keys.
         provision_data.update(
             {
-                opt: self.job_data["provision_data"][opt]
-                for opt in optionals
-                if opt in self.job_data["provision_data"]
+                opt: job_provision[opt]
+                for opt in self.OPTIONAL_KEYS
+                if opt in job_provision
             }
         )
 
         return ((), provision_data)
+
+    def _build_preset_payload(self) -> Dict[str, Any]:
+        job_provision = self.job_data["provision_data"]
+        preset = job_provision["preset"]
+
+        provision_data = {
+            key: value
+            for key, value in job_provision.items()
+            if not key.startswith("autoinstall")
+        }
+        has_autoinstall = any(
+            key.startswith("autoinstall") for key in job_provision
+        )
+
+        provision_data["username"], provision_data["password"] = (
+            self._get_credentials(preset)
+        )
+        if has_autoinstall:
+            provision_data["autoinstall_conf"] = self._get_autoinstall_conf()
+
+        if preset == JAMMY_OEM_PRESET:
+            # control host only does recovery
+            provision_data.pop("url", None)
+            if alloem_url := job_provision.get("alloem_url"):
+                provision_data["url"] = alloem_url
+                provision_data.pop("alloem_url", None)
+
+        return provision_data
+
+    def _build_alloem_payload(self) -> Dict[str, Any]:
+        job_provision = self.job_data["provision_data"]
+        username, password = self._get_credentials(JAMMY_OEM_PRESET)
+        return {
+            "url": job_provision["alloem_url"],
+            "username": username,
+            "password": password,
+            "autoinstall_conf": self._get_autoinstall_conf(),
+            "robot_tasks": job_provision["robot_tasks"],
+        }
+
+    def _build_default_payload(self) -> Dict[str, Any]:
+        job_provision = self.job_data["provision_data"]
+        username, password = self._get_credentials()
+        return {
+            "url": job_provision["url"],
+            "username": username,
+            "password": password,
+            "autoinstall_conf": self._get_autoinstall_conf(),
+            "robot_tasks": job_provision["robot_tasks"],
+        }
 
     def _post_run_actions(self, args):
         super()._post_run_actions(args)

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -31,7 +31,10 @@ class ZapperKVMConnectorTests(unittest.TestCase):
     def test_get_credentials(self) -> None:
         connector = DeviceConnector({"control_host": "zapper-host"})
         connector.job_data = {}
-        assert connector._get_credentials("jammy-oem") == ("ubuntu", "u")
+        assert connector._get_credentials("desktop-jammy-oem") == (
+            "ubuntu",
+            "u",
+        )
         assert connector._get_credentials("preset") == ("ubuntu", "ubuntu")
         assert connector._get_credentials() == ("ubuntu", "ubuntu")
 
@@ -122,6 +125,70 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         }
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
+
+    def test_validate_configuration_jammy_oem_preset(self):
+        """Test that `desktop-jammy-oem` preset strips `url` from the
+        provision data since the control host only does recovery.
+        """
+        connector = DeviceConnector({"control_host": "zapper-host"})
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "preset": "desktop-jammy-oem",
+            },
+        }
+
+        connector._get_autoinstall_conf = Mock()
+        connector._read_ssh_key = Mock(return_value="mykey")
+        args, kwargs = connector._validate_configuration()
+
+        self.assertNotIn("url", kwargs)
+        self.assertEqual(kwargs["preset"], "desktop-jammy-oem")
+        self.assertEqual(kwargs["username"], "ubuntu")
+        self.assertEqual(kwargs["password"], "u")
+
+    def test_validate_configuration_jammy_oem_preset_with_alloem_url(self):
+        """Test `desktop-jammy-oem` preset combined with `alloem_url`:
+        the original `url` is replaced by `alloem_url`, `alloem_url` is
+        removed from the payload, and jammy-oem credentials are used.
+        """
+        connector = DeviceConnector({"control_host": "zapper-host"})
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "alloem_url": "http://example.com/alloem.iso",
+                "preset": "desktop-jammy-oem",
+            },
+        }
+
+        connector._get_autoinstall_conf = Mock()
+        connector._read_ssh_key = Mock(return_value="mykey")
+        args, kwargs = connector._validate_configuration()
+
+        self.assertEqual(kwargs["url"], "http://example.com/alloem.iso")
+        self.assertNotIn("alloem_url", kwargs)
+        self.assertEqual(kwargs["username"], "ubuntu")
+        self.assertEqual(kwargs["password"], "u")
+
+    def test_validate_configuration_jammy_oem_preset_no_url(self):
+        """Test `desktop-jammy-oem` preset does not raise when `url`
+        is already absent from provision data.
+        """
+        connector = DeviceConnector({"control_host": "zapper-host"})
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "preset": "desktop-jammy-oem",
+            },
+        }
+
+        connector._get_autoinstall_conf = Mock()
+        connector._read_ssh_key = Mock(return_value="mykey")
+        args, kwargs = connector._validate_configuration()
+
+        self.assertNotIn("url", kwargs)
 
     def test_validate_configuration_w_opt(self):
         """Test whether the validate_configuration function returns
@@ -515,6 +582,25 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         connector = DeviceConnector(fake_config)
         connector.job_data = {
             "provision_data": {"alloem_url": "file://image.iso"}
+        }
+        connector._copy_ssh_id = Mock()
+        connector._change_password = Mock()
+        connector._run_oem_script = Mock()
+
+        connector._post_run_actions("args")
+
+        connector._change_password.assert_called_with("ubuntu", "u")
+        connector._run_oem_script.assert_called_with("args")
+        connector._copy_ssh_id.assert_called()
+
+    def test_post_run_actions_jammy_oem_preset(self):
+        """Test the function updates the password and runs the OEM script
+        when the `desktop-jammy-oem` preset is in scope.
+        """
+        fake_config = {"device_ip": "localhost", "control_host": "zapper-host"}
+        connector = DeviceConnector(fake_config)
+        connector.job_data = {
+            "provision_data": {"preset": "desktop-jammy-oem"}
         }
         connector._copy_ssh_id = Mock()
         connector._change_password = Mock()


### PR DESCRIPTION
## Description

When using the Jammy OEM presets that are things to adjust manually, like username, or the alloem URL, when provided.

## Resolved issues

Cannot provision Jammy OEM preset

## Documentation

N/A

## Web service API changes

No

## Tests

Updated test cases
