### PR TITLE
CLI: fix broken URL in the 401 error message resolves #1022 (BugFix)

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -1299,7 +1299,7 @@ class TestflingerCli:
                             "that requires client authorisation "
                             "without using client credentials. \n"
                             "See https://testflinger.readthedocs.io/en/latest"
-                            "/how-to/authentication.html for more details"
+                            "/how-to/authentication/ for more details"
                         )
                 else:
                     # This shouldn't happen, so let's get more information


### PR DESCRIPTION
## Description
update the url in the 401 error message in the CLI to point to the right location on RTD

## Resolved issues

fixes #1022

## Documentation

NA, just fixes a broken URL

## Web service API changes

NA

## Tests
NA
