### PR TITLE
Add always to the job completion waiting

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -239,7 +239,7 @@ runs:
         exit $EXIT_STATUS
 
     - name: Wait for job completion
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.reserve == 'false'
+      if: always() && !cancelled() && inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.reserve == 'false'
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}


### PR DESCRIPTION
## Description

When using the testflinger submit GH action, if the provision or test step fail, the whole action is ended. This can lead to following actions not being able to fetch the status since testflinger results are not yet available.

In our case this leads to false messages in steps after the submit (pinging people etc).
In this [CI run](https://github.com/canonical/cypress-image-definitions/actions/runs/24711551479/job/72277224149) you see that no polling is happening and another action in this workflow now reports "Test job still running or results unavailable".
The [same workflow](https://github.com/canonical/cypress-image-definitions/actions/runs/24716551232/job/72294379117) but running with an `always` added to the completion waiting reports a failure correctly.

## Resolved issues

No issue has been created.

## Documentation

Only addition is a `always()` to the wait for completion step.

## Web service API changes

None.

## Tests

Fork has been executed, see above.