### PR TITLE
Fix: TF Agent host charm rebuilds COS scrape jobs based on supervisor config.

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -51,10 +51,14 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
             self.on.update_testflinger_action,
             self.on_update_testflinger_action,
         )
-        self.scrape_jobs = []
         self._grafana_agent = COSAgentProvider(
             self,
             scrape_configs=self.get_scrape_jobs,
+            refresh_events=[
+                self.on.config_changed,
+                self.on.update_configs_action,
+                self.on.upgrade_charm,
+            ],
         )
         self.framework.observe(self.on.secret_changed, self._on_secret_changed)
         self.framework.observe(self.on.update_status, self._on_update_status)
@@ -142,7 +146,6 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         ) as service_template:
             template = Template(service_template.read())
 
-        self.scrape_jobs = []
         for agent_dir in agent_dirs:
             agent_config_path = agent_dir
             agent_name = agent_dir.name
@@ -162,15 +165,6 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
                 agent_config_path=agent_config_path,
                 virtual_env_path=VIRTUAL_ENV_PATH,
                 metric_endpoint_port=metric_endpoint_port,
-            )
-            self.scrape_jobs.append(
-                {
-                    "job_name": agent_name,
-                    "metrics_path": "/metrics",
-                    "static_configs": [
-                        {"targets": [f"localhost:{metric_endpoint_port}"]}
-                    ],
-                }
             )
 
             with open(
@@ -324,7 +318,7 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         self.unit.status = ops.ActiveStatus()
 
     def get_scrape_jobs(self):
-        return self.scrape_jobs
+        return supervisord.get_supervisor_scrape_jobs()
 
 
 if __name__ == "__main__":

--- a/agent/charms/testflinger-agent-host-charm/src/supervisord.py
+++ b/agent/charms/testflinger-agent-host-charm/src/supervisord.py
@@ -64,6 +64,24 @@ def get_supervisor_agents_port_mapping() -> dict[str, int]:
     return agent_port_mapping
 
 
+def get_supervisor_scrape_jobs() -> list[dict]:
+    """Build scrape jobs from persisted supervisor configs.
+
+    Returns:
+        list[dict]: COS-compatible scrape jobs for each configured agent.
+    """
+    return [
+        {
+            "job_name": agent_name,
+            "metrics_path": "/metrics",
+            "static_configs": [{"targets": [f"localhost:{port}"]}],
+        }
+        for agent_name, port in sorted(
+            get_supervisor_agents_port_mapping().items()
+        )
+    ]
+
+
 def parse_supervisor_config_file(
     conf_path: str,
 ) -> Tuple[Optional[str], Optional[int]]:

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -50,6 +50,47 @@ def test_update_tf_cmd_scripts_on_config_changed(
     mock_update_scripts.assert_called_once()
 
 
+@patch("charm.COSAgentProvider")
+@patch("charm.supervisord.get_supervisor_scrape_jobs")
+def test_cos_provider_reads_scrape_jobs_from_supervisor_configs(
+    mock_get_scrape_jobs,
+    mock_cos_provider,
+    ctx,
+    state_in,
+):
+    """Test scrape job publication uses persisted supervisor configs."""
+    expected_scrape_jobs = [
+        {
+            "job_name": "agent1",
+            "metrics_path": "/metrics",
+            "static_configs": [{"targets": ["localhost:8000"]}],
+        }
+    ]
+    mock_get_scrape_jobs.return_value = expected_scrape_jobs
+
+    ctx.run(ctx.on.start(), state=state_in())
+
+    scrape_configs = mock_cos_provider.call_args.kwargs["scrape_configs"]
+    assert scrape_configs() == expected_scrape_jobs
+
+
+@patch("charm.COSAgentProvider")
+def test_cos_provider_refreshes_on_update_configs_action(
+    mock_cos_provider,
+    ctx,
+    state_in,
+):
+    """Test COS refresh is wired to the expected charm events."""
+    ctx.run(ctx.on.start(), state=state_in())
+
+    refresh_events = mock_cos_provider.call_args.kwargs["refresh_events"]
+    assert [event.event_kind for event in refresh_events] == [
+        "config_changed",
+        "update_configs_action",
+        "upgrade_charm",
+    ]
+
+
 def test_blocked_on_no_secret(ctx, state_in, caplog):
     """Test blocked status when credentials-secret config is not set."""
     state_out = ctx.run(ctx.on.start(), state=state_in())

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_supervisord.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_supervisord.py
@@ -62,6 +62,27 @@ def test_get_supervisor_agents_port_mapping(mock_exists, mock_iterdir):
     assert mapping == expected
 
 
+@patch("supervisord.get_supervisor_agents_port_mapping")
+def test_get_supervisor_scrape_jobs(mock_get_mapping):
+    """Test scrape jobs are rebuilt from persisted supervisor state."""
+    mock_get_mapping.return_value = {"agent2": 8001, "agent1": 8000}
+
+    scrape_jobs = supervisord.get_supervisor_scrape_jobs()
+
+    assert scrape_jobs == [
+        {
+            "job_name": "agent1",
+            "metrics_path": "/metrics",
+            "static_configs": [{"targets": ["localhost:8000"]}],
+        },
+        {
+            "job_name": "agent2",
+            "metrics_path": "/metrics",
+            "static_configs": [{"targets": ["localhost:8001"]}],
+        },
+    ]
+
+
 def test_parse_supervisor_config_file_invalid():
     """Test parsing invalid supervisor config file."""
     config_content = """


### PR DESCRIPTION
## Description

After deploying the Grafana Agent hosts in TEL, the `/etc/grafana-agent.yaml` config was not properly populated with scrape endpoints.

Following investigation, the suspicion is that since `charm.py` is instantiated on every Juju event, the in-memory `self.scrape_endpoints` variable is not consistently populated.

To address this, `COSAgentProvider.scrape_configs` are now sourced directly from the `supervisord` configuration.

## Resolved issues

[CERTTF-1038](https://warthogs.atlassian.net/browse/CERTTF-1038)

## Documentation

Charm unit tests.

## Web service API changes

N/A

## Tests

Charm unit tests.


[CERTTF-1038]: https://warthogs.atlassian.net/browse/CERTTF-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ