### PR TITLE
fix(submit): be sure we call the snap yq command

### DIFF
--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -101,7 +101,7 @@ runs:
         echo "::group::Determine which phases to run for this job"
         for phase in provision test reserve; do
           export KEY="${phase}_data"
-          if yq -e 'has(strenv(KEY))' "${JOB}" > /dev/null 2>&1; then
+          if /snap/bin/yq -e 'has(strenv(KEY))' "${JOB}" > /dev/null 2>&1; then
             echo "${phase}=true" | tee -a "$GITHUB_OUTPUT"
           else
             echo "${phase}=false" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
There is two different yq commands. The one from snap, and the one from apt. The submit action expects that yq is the one from the snap. To be sure to call the correct one, use a full path.