### PR TITLE
fix(agent): tf-test modify bind mounts in container

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -28,6 +28,7 @@ if [ -d "$VIRTUAL_ENV_PATH" ]; then
         -v $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id:$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id \
         $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \
         bash -c "(cd /srv/testflinger/device-connectors && sudo uv pip install . --system &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json"
+    exit_code=$?
     docker cp "$agent_id:/home/ubuntu/artifacts" "$PWD/" 2>/dev/null || true
 else
     docker run -t --name $AGENT \
@@ -39,5 +40,7 @@ else
         -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT \
         $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \
         bash -c "(cd /srv/testflinger-agent/$AGENT/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json"
+    exit_code=$?
     docker cp "$AGENT:/home/ubuntu/artifacts" "$PWD/" 2>/dev/null || true
 fi
+exit $exit_code

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -14,9 +14,15 @@ AGENT_CONFIGS_PATH={{ agent_configs_path }}
 CONFIG_DIR="{{ config_dir }}"
 VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
+# create artifacts directory to allow mounting in container
+mkdir -p "$PWD/artifacts"
+
 if [ -d "$VIRTUAL_ENV_PATH" ]; then
     docker run -t --name $agent_id \
-        -v $PWD:/home/ubuntu \
+        --workdir /home/ubuntu \
+        -v "$PWD/testflinger.json:/home/ubuntu/testflinger.json:ro" \
+        -v "$PWD/device-connector-error.json:/home/ubuntu/device-connector-error.json" \
+        -v "$PWD/artifacts:/home/ubuntu/artifacts" \
         -v ~/.ssh:/home/ubuntu/.ssh:ro \
         -v /srv/testflinger:/srv/testflinger \
         -v $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id:$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id \
@@ -24,7 +30,10 @@ if [ -d "$VIRTUAL_ENV_PATH" ]; then
         bash -c "(cd /srv/testflinger/device-connectors && sudo uv pip install . --system &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json"
 else
     docker run -t --name $AGENT \
-        -v $PWD:/home/ubuntu \
+        --workdir /home/ubuntu \
+        -v "$PWD/testflinger.json:/home/ubuntu/testflinger.json:ro" \
+        -v "$PWD/device-connector-error.json:/home/ubuntu/device-connector-error.json" \
+        -v "$PWD/artifacts:/home/ubuntu/artifacts" \
         -v ~/.ssh:/home/ubuntu/.ssh:ro \
         -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT \
         $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -14,28 +14,25 @@ AGENT_CONFIGS_PATH={{ agent_configs_path }}
 CONFIG_DIR="{{ config_dir }}"
 VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
-# create artifacts directory to allow mounting in container
-mkdir -p "$PWD/artifacts"
-
 if [ -d "$VIRTUAL_ENV_PATH" ]; then
     docker run -t --name $agent_id \
         --workdir /home/ubuntu \
         -v "$PWD/testflinger.json:/home/ubuntu/testflinger.json:ro" \
         -v "$PWD/device-connector-error.json:/home/ubuntu/device-connector-error.json" \
-        -v "$PWD/artifacts:/home/ubuntu/artifacts" \
         -v ~/.ssh:/home/ubuntu/.ssh:ro \
         -v /srv/testflinger:/srv/testflinger \
         -v $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id:$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id \
         $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \
         bash -c "(cd /srv/testflinger/device-connectors && sudo uv pip install . --system &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id/default.yaml testflinger.json"
+    docker cp "$agent_id:/home/ubuntu/artifacts" "$PWD/" 2>/dev/null || true
 else
     docker run -t --name $AGENT \
         --workdir /home/ubuntu \
         -v "$PWD/testflinger.json:/home/ubuntu/testflinger.json:ro" \
         -v "$PWD/device-connector-error.json:/home/ubuntu/device-connector-error.json" \
-        -v "$PWD/artifacts:/home/ubuntu/artifacts" \
         -v ~/.ssh:/home/ubuntu/.ssh:ro \
         -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT \
         $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \
         bash -c "(cd /srv/testflinger-agent/$AGENT/testflinger/device-connectors && sudo pip install . &> /dev/null) && PYTHONUNBUFFERED=1 testflinger-device-connector $PROVISION_TYPE runtest -c /srv/testflinger-agent/$AGENT/default.yaml testflinger.json"
+    docker cp "$AGENT:/home/ubuntu/artifacts" "$PWD/" 2>/dev/null || true
 fi

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -14,11 +14,15 @@ AGENT_CONFIGS_PATH={{ agent_configs_path }}
 CONFIG_DIR="{{ config_dir }}"
 VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
+# pre-create attachments directory so it can be bind-mounted read-only
+mkdir -p "$PWD/attachments"
+
 if [ -d "$VIRTUAL_ENV_PATH" ]; then
     docker run -t --name $agent_id \
         --workdir /home/ubuntu \
         -v "$PWD/testflinger.json:/home/ubuntu/testflinger.json:ro" \
         -v "$PWD/device-connector-error.json:/home/ubuntu/device-connector-error.json" \
+        -v "$PWD/attachments:/home/ubuntu/attachments" \
         -v ~/.ssh:/home/ubuntu/.ssh:ro \
         -v /srv/testflinger:/srv/testflinger \
         -v $AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id:$AGENT_CONFIGS_PATH/$CONFIG_DIR/$agent_id \
@@ -30,6 +34,7 @@ else
         --workdir /home/ubuntu \
         -v "$PWD/testflinger.json:/home/ubuntu/testflinger.json:ro" \
         -v "$PWD/device-connector-error.json:/home/ubuntu/device-connector-error.json" \
+        -v "$PWD/attachments:/home/ubuntu/attachments" \
         -v ~/.ssh:/home/ubuntu/.ssh:ro \
         -v /srv/testflinger-agent/$AGENT:/srv/testflinger-agent/$AGENT \
         $REGISTRY/$NAMESPACE/$IMAGE:$IMAGE_TAG \

--- a/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
+++ b/agent/charms/testflinger-agent-host-charm/src/tf-cmd-scripts/tf-test
@@ -14,7 +14,7 @@ AGENT_CONFIGS_PATH={{ agent_configs_path }}
 CONFIG_DIR="{{ config_dir }}"
 VIRTUAL_ENV_PATH="{{ virtual_env_path }}"
 
-# pre-create attachments directory so it can be bind-mounted read-only
+# pre-create attachments directory so it can be bind-mounted
 mkdir -p "$PWD/attachments"
 
 if [ -d "$VIRTUAL_ENV_PATH" ]; then

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -311,7 +311,7 @@ class TestflingerClient:
             id for the job
         """
         artifacts_dir = os.path.join(rundir, "artifacts")
-        if not os.path.isdir(artifacts_dir):
+        if not os.path.isdir(artifacts_dir) or not os.listdir(artifacts_dir):
             return
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/agent/tests/test_client.py
+++ b/agent/tests/test_client.py
@@ -230,7 +230,7 @@ class TestClient:
         artifacts_dir = tmp_path / "artifacts"
         artifacts_dir.mkdir()
 
-        # For transmiting artifacts, directory should not be empty
+        # For transmitting artifacts, directory should not be empty
         (artifacts_dir / "test.txt").write_text("test")
         job_id = str(uuid.uuid1())
         testflinger_data = {"job_id": job_id}
@@ -243,35 +243,32 @@ class TestClient:
         client.transmit_job_outcome(tmp_path)
         assert requests_mock.called
 
-        def test_save_artifacts_missing_artifacts_dir(
-            self, client, requests_mock, tmp_path
-        ):
-            """Test save_artifacts handles artifacts directory is missing."""
-            job_id = str(uuid.uuid1())
-            testflinger_data = {"job_id": job_id}
-            testflinger_json = tmp_path / "testflinger.json"
-            testflinger_json.write_text(json.dumps(testflinger_data))
-            client.save_artifacts(tmp_path)
+    def test_save_artifacts_missing_artifacts_dir(
+        self, client, requests_mock, tmp_path
+    ):
+        """Test save_artifacts handles artifacts directory is missing."""
+        job_id = str(uuid.uuid1())
+        testflinger_data = {"job_id": job_id}
+        testflinger_json = tmp_path / "testflinger.json"
+        testflinger_json.write_text(json.dumps(testflinger_data))
+        client.save_artifacts(tmp_path, job_id)
+        # No requests should be made to server since there are no artifacts
+        assert requests_mock.called is False
 
-            # No requests should be made to server since there are no artifacts
-            assert requests_mock.called is False
-
-        def test_save_artifacts_empty_artifacts_dir(
-            self, client, requests_mock, tmp_path
-        ):
-            """Test save_artifacts handles artifacts directory is empty."""
-            job_id = str(uuid.uuid1())
-            testflinger_data = {"job_id": job_id}
-            testflinger_json = tmp_path / "testflinger.json"
-            testflinger_json.write_text(json.dumps(testflinger_data))
-
-            # Create an empty artifacts directory
-            artifacts_dir = tmp_path / "artifacts"
-            artifacts_dir.mkdir()
-            client.save_artifacts(tmp_path)
-
-            # No requests should be made to server since there are no artifacts
-            assert requests_mock.called is False
+    def test_save_artifacts_empty_artifacts_dir(
+        self, client, requests_mock, tmp_path
+    ):
+        """Test save_artifacts handles artifacts directory is empty."""
+        job_id = str(uuid.uuid1())
+        testflinger_data = {"job_id": job_id}
+        testflinger_json = tmp_path / "testflinger.json"
+        testflinger_json.write_text(json.dumps(testflinger_data))
+        # Create an empty artifacts directory
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        client.save_artifacts(tmp_path, job_id)
+        # No requests should be made to server since there are no artifacts
+        assert requests_mock.called is False
 
     def test_transmit_job_outcome_missing_json(self, client, tmp_path, caplog):
         """

--- a/agent/tests/test_client.py
+++ b/agent/tests/test_client.py
@@ -246,19 +246,19 @@ class TestClient:
     def test_save_artifacts_missing_artifacts_dir(
         self, client, requests_mock, tmp_path
     ):
-        """Test save_artifacts handles artifacts directory is missing."""
+        """Test no request is made if artifacts directory is missing."""
         job_id = str(uuid.uuid1())
         testflinger_data = {"job_id": job_id}
         testflinger_json = tmp_path / "testflinger.json"
         testflinger_json.write_text(json.dumps(testflinger_data))
         client.save_artifacts(tmp_path, job_id)
-        # No requests should be made to server since there are no artifacts
+        # No requests should be made to server as there is nothing to submit
         assert requests_mock.called is False
 
     def test_save_artifacts_empty_artifacts_dir(
         self, client, requests_mock, tmp_path
     ):
-        """Test save_artifacts handles artifacts directory is empty."""
+        """Test no request is made if artifacts directory is empty."""
         job_id = str(uuid.uuid1())
         testflinger_data = {"job_id": job_id}
         testflinger_json = tmp_path / "testflinger.json"
@@ -267,7 +267,7 @@ class TestClient:
         artifacts_dir = tmp_path / "artifacts"
         artifacts_dir.mkdir()
         client.save_artifacts(tmp_path, job_id)
-        # No requests should be made to server since there are no artifacts
+        # No requests should be made to server as there is nothing to submit
         assert requests_mock.called is False
 
     def test_transmit_job_outcome_missing_json(self, client, tmp_path, caplog):

--- a/agent/tests/test_client.py
+++ b/agent/tests/test_client.py
@@ -229,6 +229,9 @@ class TestClient:
         """Test that transmit_job_outcome sends artifacts if they exist."""
         artifacts_dir = tmp_path / "artifacts"
         artifacts_dir.mkdir()
+
+        # For transmiting artifacts, directory should not be empty
+        (artifacts_dir / "test.txt").write_text("test")
         job_id = str(uuid.uuid1())
         testflinger_data = {"job_id": job_id}
         testflinger_json = tmp_path / "testflinger.json"
@@ -239,6 +242,36 @@ class TestClient:
         )
         client.transmit_job_outcome(tmp_path)
         assert requests_mock.called
+
+        def test_save_artifacts_missing_artifacts_dir(
+            self, client, requests_mock, tmp_path
+        ):
+            """Test save_artifacts handles artifacts directory is missing."""
+            job_id = str(uuid.uuid1())
+            testflinger_data = {"job_id": job_id}
+            testflinger_json = tmp_path / "testflinger.json"
+            testflinger_json.write_text(json.dumps(testflinger_data))
+            client.save_artifacts(tmp_path)
+
+            # No requests should be made to server since there are no artifacts
+            assert requests_mock.called is False
+
+        def test_save_artifacts_empty_artifacts_dir(
+            self, client, requests_mock, tmp_path
+        ):
+            """Test save_artifacts handles artifacts directory is empty."""
+            job_id = str(uuid.uuid1())
+            testflinger_data = {"job_id": job_id}
+            testflinger_json = tmp_path / "testflinger.json"
+            testflinger_json.write_text(json.dumps(testflinger_data))
+
+            # Create an empty artifacts directory
+            artifacts_dir = tmp_path / "artifacts"
+            artifacts_dir.mkdir()
+            client.save_artifacts(tmp_path)
+
+            # No requests should be made to server since there are no artifacts
+            assert requests_mock.called is False
 
     def test_transmit_job_outcome_missing_json(self, client, tmp_path, caplog):
         """


### PR DESCRIPTION
## Description
This PR modifies the container bind mounts. Previously, it mounted the whole $PWD (`testflinger/<agent>/run/<job_id>/`) to /home/ubuntu and potentially root owned files or files with incorrect permissions (e.g. 444 read only) are "leaking" to the  the charm unit, resulting on those unable to be removed. As an example, go files after build:
```
ls -l testflinger/petilil/results/d5e50ec8-085b-4983-b77d-c82efe11e72a/go/pkg/mod/gopkg.in/yaml.v3@v3.0.1/limit_test.go
-r--r--r-- 1 ubuntu ubuntu 3875 Apr 27 21:00 testflinger/petilil/results/d5e50ec8-085b-4983-b77d-c82efe11e72a/go/pkg/mod/gopkg.in/yaml.v3@v3.0.1/limit_test.go
```

The above file is read only by all users so the agent is unable to remove it

This PR:
1. Mounts `testflinger.json` as RO
2. Mounts `device-connector-error.json` to allow writing errors from device-connectors
3. Mounts `attachments` directory to allow using user submitted attachments
4. Copies the artifact directory from container to $PWD if any
5. Only save artifacts if artifacts directory exists and not empty. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves #538
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

Recreated issue
1. submit [job](https://testflinger-staging.canonical.com/jobs/d5e50ec8-085b-4983-b77d-c82efe11e72a) with a go compile example
2. Validate files are present in charm unit:
```
ls -l testflinger/petilil/run/d5e50ec8-085b-4983-b77d-c82efe11e72a/
total 40
-rw-r--r-- 1 ubuntu ubuntu    0 Apr 27 20:50 device-connector-error.json
-rw-r--r-- 1 ubuntu ubuntu   70 Apr 27 21:00 device-info.json
drwxr-xr-x 3 ubuntu ubuntu 4096 Apr 27 21:00 go <==== Shouldn't be here
drwxr-xr-x 9 ubuntu ubuntu 4096 Apr 27 21:00 inference-snaps-cli <==== Shouldn't be here
-rw-r--r-- 1 ubuntu ubuntu 2300 Apr 27 21:00 provision.log
-rw-r--r-- 1 ubuntu ubuntu  182 Apr 27 20:50 setup.log
-rw-r--r-- 1 ubuntu ubuntu 8106 Apr 27 21:00 test.log
-rw-r--r-- 1 ubuntu ubuntu   40 Apr 27 21:00 testflinger-outcome.json
-rw-r--r-- 1 ubuntu ubuntu 2742 Apr 27 20:50 testflinger.json
-rwxrwxr-x 1 ubuntu ubuntu 2311 Apr 27 21:00 tf_cmd_script
```
3. After job completion, the agent will crash:
```
[26-04-27 21:02:42]    INFO: (agent.py:501)| Attempting to send result: /home/ubuntu/testflinger/petilil/results/d5e50ec8-085b-4983-b77d-c82efe11e72a
[26-04-27 21:02:42]   ERROR: (cmd.py:32)| [Errno 13] Permission denied: 'limit_test.go'
Traceback (most recent call last):
  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/cmd.py", line 27, in main
    start_agent()
  File "/srv/testflinger-venv/lib/python3.10/site-packages/testflinger_agent/__init__.py", line 148, in start_agent
    agent.process_jobs()
...
    os.unlink(entry.name, dir_fd=topfd)
PermissionError: [Errno 13] Permission denied: 'limit_test.go'
```

```
sudo supervisorctl status petilil
petilil                          EXITED    Apr 27 09:02 PM
```

After fix:
1. Submit the same [job](https://testflinger-staging.canonical.com/jobs/a3544e6e-4408-4ae3-ab4c-176e09139b05) example with go compile
2. During test phase, charm unit does not have any container-only files:
```
ls -l testflinger/petilil/run/a3544e6e-4408-4ae3-ab4c-176e09139b05/
total 32
drwxr-xr-x 3 ubuntu ubuntu 4096 Apr 27 22:07 attachments
-rw-r--r-- 1 ubuntu ubuntu    0 Apr 27 22:07 device-connector-error.json
-rw-r--r-- 1 ubuntu ubuntu   70 Apr 27 22:07 device-info.json
-rw-r--r-- 1 ubuntu ubuntu 2207 Apr 27 22:17 provision.log
-rw-r--r-- 1 ubuntu ubuntu  182 Apr 27 22:07 setup.log
-rw-r--r-- 1 ubuntu ubuntu 7501 Apr 27 22:17 test.log
-rw-r--r-- 1 ubuntu ubuntu   40 Apr 27 22:17 testflinger-outcome.json
-rw-r--r-- 1 ubuntu ubuntu 2993 Apr 27 22:07 testflinger.json
```
3. During test phase, files are only located inside the container, from job output:
```
+ pwd
/home/ubuntu
+ ls -la
total 60
drwxr-x---  1 ubuntu ubuntu 4096 Apr 27 22:18 .
drwxr-xr-x  1 root   root   4096 Jun  5  2025 ..
-rw-r--r--  1 ubuntu ubuntu  220 Jun  5  2025 .bash_logout
-rw-r--r--  1 ubuntu ubuntu 3771 Jun  5  2025 .bashrc
drwxr-xr-x  3 ubuntu ubuntu 4096 Apr 27 22:17 .cache
drwxr-xr-x  3 ubuntu ubuntu 4096 Apr 27 22:17 .config
...
-rw-r--r--  1 ubuntu ubuntu   70 Apr 27 22:17 device-info.json
drwxr-xr-x  3 ubuntu ubuntu 4096 Apr 27 22:17 go <=== This is now only available inside the container
drwxr-xr-x  9 ubuntu ubuntu 4096 Apr 27 22:18 inference-snaps-cli  <=== This is now only available inside the container
-rw-r--r--  1 ubuntu ubuntu 2993 Apr 27 22:07 testflinger.json
-rwxrwxr-x  1 ubuntu ubuntu 2477 Apr 27 22:17 tf_cmd_script
```

4. Attachments are still able to be used as executables:
```
+ chmod u+x attachments/test/script.sh
+ attachments/test/script.sh
Running from script
```

5. After job completion, artifacts are available to download:
```
testflinger-cli --server https://testflinger-staging.canonical.com artifacts a3544e6e-4408-4ae3-ab4c-176e09139b05 
Downloading artifacts tarball...
Artifacts downloaded to artifacts.tgz
```

```
cat artifacts/system_info.txt 
Linux petilil 5.15.0-176-generic #186-Ubuntu SMP Fri Mar 13 11:01:42 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
```

6. Agent did not crashed:
```
[26-04-27 22:18:21]    INFO: (job.py:129)| Running reserve_command: tf-reserve
[26-04-27 22:19:19]    INFO: (job.py:129)| Running cleanup_command: tf-cleanup
[26-04-27 22:19:36]    INFO: (client.py:292)| Submitting job outcome for job: a3544e6e-4408-4ae3-ab4c-176e09139b05
[26-04-27 22:19:38]    INFO: (__init__.py:149)| Sleeping for 10
[26-04-27 22:19:48]    INFO: (__init__.py:147)| Checking jobs
[26-04-27 22:19:49]    INFO: (__init__.py:149)| Sleeping for 10
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
