### PR TITLE
ci: allow unit tests to run on github-hosted runners

### DIFF
--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -71,7 +71,7 @@ jobs:
     defaults:
       run:
         working-directory: agent
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1

--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -29,7 +29,7 @@ jobs:
     defaults:
       run:
         working-directory: agent
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     permissions:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     steps:

--- a/.github/workflows/cli-tox.yml
+++ b/.github/workflows/cli-tox.yml
@@ -25,7 +25,7 @@ jobs:
     defaults:
       run:
         working-directory: cli
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     permissions:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     steps:

--- a/.github/workflows/common-tox.yml
+++ b/.github/workflows/common-tox.yml
@@ -25,7 +25,7 @@ jobs:
     defaults:
       run:
         working-directory: common
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     permissions:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     steps:

--- a/.github/workflows/device-tox.yml
+++ b/.github/workflows/device-tox.yml
@@ -25,7 +25,7 @@ jobs:
     defaults:
       run:
         working-directory: device-connectors
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     permissions:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     steps:

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -25,7 +25,7 @@ jobs:
     defaults:
       run:
         working-directory: server
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     permissions:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     steps:

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -69,7 +69,7 @@ jobs:
     defaults:
       run:
         working-directory: server/charm
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1


### PR DESCRIPTION
## Description
This modifies the runners where the unit tests for all components are executed. Instead of self hosted this will now run on github hosted runners as there is no special consideration needed for running unit tests. 
This can allow external collaborators contributions to execute unit tests without failing due insufficient authorization:
https://github.com/canonical/testflinger/actions/runs/25013731460/job/73280011666?pr=1030

> [!NOTE]
> Charm integration tests are on purpose left on self hosted runners as they require charmcraft, juju and/or microk8s to be installed which can potentially be slower or not supported in Github runners which are essentially VMs. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
NA
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
NA
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
NA
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
No major change made, tests should continue to pass
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
