### PR TITLE
fix(cli/auth): resolve mypy errors in cli/testflinger_cli/auth.py (#1028)

### DIFF
--- a/cli/testflinger_cli/auth.py
+++ b/cli/testflinger_cli/auth.py
@@ -76,7 +76,7 @@ class TestflingerCliAuth:
 
         return None
 
-    def _authenticate_with_credentials(self) -> str:
+    def _authenticate_with_credentials(self) -> str | None:
         """Authenticate using client_id and secret_key."""
         try:
             response = self.client.authenticate(
@@ -86,9 +86,13 @@ class TestflingerCliAuth:
             self.store_refresh_token(response["refresh_token"])
             return response["access_token"]
         except client.HTTPError as exc:
+            # _handle_auth_error raises for 401/403 and returns None for
+            # any other HTTP error, so the caller may legitimately
+            # observe None on unexpected statuses.
             self._handle_auth_error(exc)
+            return None
 
-    def _authenticate_with_refresh_token(self, refresh_token: str) -> str:
+    def _authenticate_with_refresh_token(self, refresh_token: str) -> str | None:
         """Authenticate using stored refresh token."""
         try:
             response = self.client.refresh_authentication(refresh_token)
@@ -98,6 +102,7 @@ class TestflingerCliAuth:
                 self.clear_refresh_token()
                 raise InvalidTokenError(exc.msg) from exc
             self._handle_auth_error(exc)
+            return None
 
     def _handle_auth_error(self, exc: client.HTTPError) -> None:
         """Handle authentication HTTP errors."""
@@ -123,8 +128,8 @@ class TestflingerCliAuth:
             return None
 
         # Set client_id from config file to keep token owner
-        self.client_id = config_file.get("AUTH", "client_id", fallback=None)
-        return config_file.get("AUTH", "refresh_token", fallback=None)
+        self.client_id = config_file.get("AUTH", "client_id", fallback="")
+        return config_file.get("AUTH", "refresh_token", fallback="")
 
     def store_refresh_token(self, refresh_token: str) -> None:
         """Store refresh token for persistent login.
@@ -176,8 +181,11 @@ class TestflingerCliAuth:
             return None
 
         try:
+            # is_authenticated guarantees jwt_token is not None here, but
+            # mypy can't see through that so coerce to str for jwt.decode
+            # which expects str | bytes.
             decoded_jwt = jwt.decode(
-                self.jwt_token, options={"verify_signature": False}
+                self.jwt_token or "", options={"verify_signature": False}
             )
             return decoded_jwt
         except jwt.exceptions.DecodeError:


### PR DESCRIPTION
Fixes #1028. mypy flagged 4 type errors in `cli/testflinger_cli/auth.py`; the maintainer (`ajzobro`) gave the green light to submit a PR.

## Changes

1. **`_authenticate_with_credentials` (line 79)** — return type was `-> str` but the `except` branch falls off without returning when `_handle_auth_error` doesn't raise (e.g. an HTTPError with status not in {401, 403}). Widened return to `-> str | None` and added an explicit `return None` after `_handle_auth_error`.

2. **`_authenticate_with_refresh_token` (line 91)** — same shape, same fix.

3. **`get_stored_refresh_token` (line 126)** — `config_file.get(..., fallback=None)` is the wrong shape per stubs (`fallback` is `str`, not `None`). Changed to `fallback=""`. Behaviour is preserved: empty string is falsy in the surrounding `if refresh_token:` / `if self.client_id and self.secret_key:` checks, exactly like `None` was.

4. **`decode_jwt_token` (line 180/184)** — `jwt.decode(self.jwt_token, ...)` passed `str | None` where `str | bytes` was expected. `is_authenticated()` already guarantees `jwt_token is not None` here but mypy can't see that; switched to `self.jwt_token or ""` to satisfy the signature without behaviour change.

## Test plan

- [x] AST parse on `cli/testflinger_cli/auth.py` is clean
- [x] `mypy cli/testflinger_cli/auth.py --ignore-missing-imports` — no errors in `auth.py` (other files in the cli have unrelated mypy errors that are out of scope for this issue)
- [x] All four `fallback=None` and `jwt.decode` call paths preserve runtime behaviour (None vs "" are both falsy in the surrounding checks)