### PR TITLE
fix(cli): drop trailing blank line from `jobs` output

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -1721,7 +1721,6 @@ class TestflingerCli:
             )
             queue = jobdata["queue"]
             print(f"{job_id} {job_state:9} {timestamp:%a %b %d %H:%M} {queue}")
-        print()
 
     def list_queues(self):
         """List the advertised queues on the current Testflinger server."""

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -2678,3 +2678,44 @@ def test_jobs_with_get_status_scenarios(mock_get_status, capsys):
     # job_ids[4]: successful get_status returns "active"
     assert job_ids[4] in captured.out
     assert "active" in captured.out.split(job_ids[4])[1].split("\n")[0]
+
+
+def test_jobs_no_trailing_blank_line(capsys):
+    """Output of `jobs` must not end with an empty line.
+
+    Regression test for the issue where ``testflinger jobs | tail -1``
+    returned the empty trailing line instead of the most recent job.
+    """
+    job_ids = [str(uuid.uuid1()) for _ in range(2)]
+    submission_time = time.time()
+    history_data = {
+        job_ids[0]: {
+            "submission_time": submission_time,
+            "queue": "queue-a",
+            "job_state": "complete",
+        },
+        job_ids[1]: {
+            "submission_time": submission_time + 1,
+            "queue": "queue-b",
+            "job_state": "complete",
+        },
+    }
+
+    sys.argv = ["", "jobs"]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.args.status = False
+    tfcli.history.history = history_data
+
+    tfcli.jobs()
+
+    captured = capsys.readouterr()
+    lines = captured.out.split("\n")
+    # `print` always appends one newline; the meaningful "no trailing blank"
+    # invariant is that there is no SECOND newline after the last job row.
+    assert lines[-1] == "", "expected trailing newline from final print"
+    assert lines[-2] != "", (
+        "jobs output ended with a blank line; "
+        "`testflinger jobs | tail -1` would return empty"
+    )
+    # The last meaningful line should contain the most recently submitted job.
+    assert job_ids[1] in lines[-2]


### PR DESCRIPTION
## Description

`testflinger jobs` ends with an empty line, which makes shell pipelines awkward: `testflinger jobs | tail -1` returns the blank line instead of the most recently submitted job, as issue #1042 demonstrates. The cause is the trailing `print()` at the bottom of `Cli.jobs` in `cli/testflinger_cli/__init__.py`, which served only as cosmetic spacing for interactive use. Removing it lets `tail -1` and friends do what users expect; the interactive output loses one blank line at the end, which is the change every shell-pipe user is implicitly asking for.

The "consider adding single column mode" half of the issue is intentionally not addressed here -- it is a separate, opt-in CLI surface change and the maintainer's "consider" framing suggests the design isn't pinned down yet. This PR keeps the diff to the actively-broken behavior.

## Resolved issues

- Resolves #1042

## Documentation

No public documentation references the trailing blank line; nothing in `docs/` describes the `jobs` command output shape. The new test (`cli/tests/test_cli.py::test_jobs_no_trailing_blank_line`) is the regression guard for this behavior.

## Web service API changes

None. This change is local to the CLI and does not touch the testflinger server, the device-connectors, or the agent.

## Tests

`cli/tests/test_cli.py` adds `test_jobs_no_trailing_blank_line`. It seeds two jobs into a `TestflingerCli().history`, calls `tfcli.jobs()`, and asserts that the captured stdout does NOT end with two consecutive newlines (i.e. `lines[-2]` is not an empty string). The final meaningful line must contain the most recently submitted job ID. With the old trailing `print()` in place this test fails; with the fix it passes.

```
$ python3 -m pytest cli/tests/test_cli.py
======================= 94 passed, 13 warnings in 8.72s ========================
```

The existing `test_jobs_with_get_status_scenarios` test still passes; it only asserted that each job ID appeared in the output, not anything about trailing whitespace.

Closes #1042
