### PR TITLE
feat(dev): introduce just to monorepo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,20 @@ You can install `uv` with snap:
 sudo snap install --classic astral-uv
 ```
 
+Additionally, this project uses [just] as a task runner, you can install it with:
+
+```shell
+uv tool install rust-just
+```
+
+Then run `just` from anywhere in the repository for usage.
+
 ### Development Environment
+
+[just] provides an alternative way to run formatting, linting and unit tests without needing to be located in each subproject.
+All `just` recipes in this repository use `uv` underneath.
+
+If you prefer using `uv` directly, you'll need to set up your virtual environments manually.
 
 Within a subproject, you can set up the virtual environment with the following
 command:
@@ -40,11 +53,25 @@ To learn more about `uv`, refer to the [`uv` documentation][uv].
 
 #### Add a Dependency
 
-To add a new dependency to a subproject, please use `uv`, as
-it will automatically add it to both the `pyproject.toml` and `uv.lock` files:
+To add a new dependency to a component, please use `just`, as
+it will automatically add it to both the `pyproject.toml` and `uv.lock` files
+for the specified component.
 
 ```shell
-uv add ...
+just add <component> <flags> <package>
+```
+
+e.g.
+
+```shell
+just add server 'urllib>=2.6.3'
+```
+
+Alternatively, you can also use `uv` within each component subproject:
+
+```shell
+cd <component>
+uv add <package>
 ```
 
 If the dependency is only a development dependency, please add it to the `dev`
@@ -55,12 +82,17 @@ To learn more about the `uv add` command, refer to the
 
 ### Remove a Dependency
 
-To remove a dependency from a subproject, please use `uv`, as
+To remove a dependency from a subproject, please use `just`, as
 it will automatically remove it from both the `pyproject.toml` and `uv.lock`
 files:
 
 ```shell
-uv remove ...
+just remove <component> <package>
+```
+
+Alternatively, you can also use `uv` within each component subproject:
+```shell
+uv remove <package>
 ```
 
 If the dependency is only a development dependency, please remove it from the
@@ -75,6 +107,12 @@ If there is a discrepancy between a subproject's `pyproject.toml` and lock file,
 you can generate the lock file (`uv.lock`) with:
 
 ```shell
+just lock <component>
+```
+
+Or alternatively, within each subproject directory:
+
+```shell
 uv lock
 ```
 
@@ -84,8 +122,32 @@ To learn more about the `uv lock` command, refer to the
 ## Testing
 
 All of the linters, format checkers, and unit tests can be run automatically.
-Before pushing anything, it's a good idea to run `tox` from the root of the
-subproject where you made changes.
+Before pushing anything, it's a good idea to run tests for the specified component:
+
+```shell
+just check <component>
+```
+
+This will run all available checks for the specified component. You can also run them individually:
+
+
+- `just lint <component>` (Check code against coding style standards)
+- `just format <component>` (Apply coding style standards to code)
+- `just unit <component>` (Run unit tests)
+
+Or run checks for all components at the same time:
+
+```shell
+just check-all
+```
+
+Or run linting for all components at the same time:
+
+```shell
+just lint-all
+```
+
+If using `uv`, you can run `tox` from the root of the subproject where you made changes.
 
 To run tox with `uv`, use:
 
@@ -110,10 +172,22 @@ same pull request. The CI check will fail if the spec is out of sync.
 To check if the specification is up-to-date, run:
 
 ```shell
+just check-schema
+```
+
+Alternatively, within the `server/` directory:
+
+```shell
 uvx --with tox-uv tox run -e check-schema
 ```
 
-If the check fails, regenerate the spec from the `server/` directory:
+If the check fails, regenerate the spec:
+
+```shell
+just schema
+```
+
+Or alternatively, within the `server/` directory:
 
 ```shell
 uvx --with tox-uv tox run -e schema
@@ -164,6 +238,7 @@ Testflinger documentation is maintained under the [`docs/`](./docs/) subdirector
 To submit changes to the documentation, please read the [documentation contributing guide](./docs/CONTRIBUTING.md).
 
 [uv]: https://docs.astral.sh/uv
+[just]: https://github.com/casey/just
 [uv-add]: https://docs.astral.sh/uv/reference/cli/#uv-add
 [uv-remove]: https://docs.astral.sh/uv/reference/cli/#uv-remove
 [uv-lock]: https://docs.astral.sh/uv/reference/cli/#uv-lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,6 @@ just check <component>
 
 This will run all available checks for the specified component. You can also run them individually:
 
-
 - `just lint <component>` (Check code against coding style standards)
 - `just format <component>` (Apply coding style standards to code)
 - `just unit <component>` (Run unit tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ Within a subproject, you can set up the virtual environment with the following
 command:
 
 ```shell
+cd <component>
 uv sync
 ```
 
@@ -64,7 +65,7 @@ just add <component> <flags> <package>
 e.g.
 
 ```shell
-just add server 'urllib>=2.6.3'
+just add server 'requests>=2.32.3'
 ```
 
 Alternatively, you can also use `uv` within each component subproject:
@@ -92,6 +93,7 @@ just remove <component> <package>
 
 Alternatively, you can also use `uv` within each component subproject:
 ```shell
+cd <component>
 uv remove <package>
 ```
 
@@ -113,6 +115,7 @@ just lock <component>
 Or alternatively, within each subproject directory:
 
 ```shell
+cd <component>
 uv lock
 ```
 
@@ -152,6 +155,7 @@ If using `uv`, you can run `tox` from the root of the subproject where you made 
 To run tox with `uv`, use:
 
 ```shell
+cd <component>
 uvx --with tox-uv tox
 ```
 
@@ -160,6 +164,7 @@ If you have `tox` installed, you can also just run `tox` from the subproject.
 In case of any linting or formatting errors, all solvable fixes can be applied with:
 
 ```shell
+cd <component>
 uvx --with tox-uv tox run -e format
 ```
 
@@ -178,6 +183,7 @@ just check-schema
 Alternatively, within the `server/` directory:
 
 ```shell
+cd server/
 uvx --with tox-uv tox run -e check-schema
 ```
 
@@ -190,6 +196,7 @@ just schema
 Or alternatively, within the `server/` directory:
 
 ```shell
+cd server/
 uvx --with tox-uv tox run -e schema
 ```
 

--- a/docs.just
+++ b/docs.just
@@ -29,7 +29,7 @@ clean-doc:
 clean:
     make clean
 
-[doc('Check links in the documentation.')]
+[doc('Check out Git LFS files used by the documentation.')]
 check-lfs:
     make check-lfs
 

--- a/docs.just
+++ b/docs.just
@@ -1,7 +1,7 @@
 # Docs recipes, continue using Makefile as source of truth
 set working-directory := 'docs'
 
-[doc('Watch, build, and serve the docs.')]
+[doc('Serve, build and auto-rebuild on change')]
 run:
     make run
 

--- a/docs.just
+++ b/docs.just
@@ -1,0 +1,62 @@
+# Docs recipes, continue using Makefile as source of truth
+set working-directory := 'docs'
+
+[doc('Watch, build, and serve the docs.')]
+run:
+    make run
+
+[doc('Show help for the docs recipes.')]
+help:
+    @just --list docs --unsorted
+
+[doc('Only remake demo tapes with vh.')]
+vhs:
+    make vhs
+
+[doc('Build the HTML documentation.')]
+html:
+    make html
+
+[doc('Serve the built documentation.')]
+serve:
+    make serve
+
+[doc('Remove files created by building the docs.')]
+clean-doc:
+    make clean-doc
+
+[doc('Full clean including venv and node modules.')]
+clean:
+    make clean
+
+[doc('Check links in the documentation.')]
+check-lfs:
+    make check-lfs
+
+[doc('Check links in the documentation.')]
+linkcheck:
+    make linkcheck
+
+[doc('Lint markdown files.')]
+lint-md:
+    make lint-md
+
+[doc('Check spelling using vale.')]
+spelling:
+    make spelling
+
+[doc('Check inclusive language (woke) using vale.')]
+woke:
+    make woke
+
+[doc('Check accessibility using pa11y.')]
+pa11y:
+    make pa11y
+
+[doc('Check style guide compliance using vale.')]
+vale:
+    make vale
+
+[doc('Build PDF documentation.')]
+pdf:
+    make pdf

--- a/docs.just
+++ b/docs.just
@@ -9,7 +9,7 @@ run:
 help:
     @just --list docs --unsorted
 
-[doc('Only remake demo tapes with vh.')]
+[doc('Only remake demo tapes with vhs.')]
 vhs:
     make vhs
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,153 @@
+mod docs  # load docs module to expose docs subcommands
+
+set ignore-comments  # don't print comment lines in recipes
+
+# this is the first recipe in the file, so it will run if just is called without a recipe
+_short_help:
+    @echo '{{BOLD}}Canonical Testflinger Monorepo{{NORMAL}}'
+    @echo ''
+    @echo '{{BOLD}}List available components in this monorepo with {{CYAN}}just list-components{{NORMAL}}'
+    @echo ''
+    @echo '{{BOLD}}List all commands with {{CYAN}}just help{{NORMAL}}{{BOLD}}, or:{{NORMAL}}'
+    @echo '- Run all checks for all components: {{CYAN}}just check-all{{NORMAL}}'
+    @echo '- Run {{CYAN}}ruff format{{NORMAL}} for all components: {{CYAN}}just format-all{{NORMAL}}'
+    @echo '- Run {{CYAN}}ruff{{NORMAL}} for all components: {{CYAN}}just lint-all{{NORMAL}}'
+    @echo ''
+    @echo '{{BOLD}}Run individual checks for a component:{{NORMAL}}'
+    @echo '- {{CYAN}}just check <component>{{NORMAL}} (Run all checks: lint, format, unit tests)'
+    @echo '- {{CYAN}}just lint <component>{{NORMAL}} (Check linting issues)'
+    @echo '- {{CYAN}}just format <component>{{NORMAL}} (Solves all fixable lint and formatting issues)'
+    @echo '- {{CYAN}}just unit <component>{{NORMAL}} (Run unit tests)'
+    @echo '- {{CYAN}}just check-schema{{NORMAL}} (Check server schema is up to date)'
+    @echo '- {{CYAN}}just schema{{NORMAL}} (Generate server schema)'
+    @echo ''
+    @echo '{{BOLD}}Build the docs: {{CYAN}}just docs{{NORMAL}}'
+
+# === COMPONENT DEFINITIONS ===
+
+# Testflinger main components
+tf_components := 'agent cli common device-connectors server'
+
+# Testflinger Charm components
+charm_components := 'agent-charm server-charm'
+
+# All components
+all_components := tf_components + ' ' + charm_components
+
+# Resolves a component name to its directory path
+_path component:
+    @case '{{component}}' in \
+        agent-charm) echo 'agent/charms/testflinger-agent-host-charm' ;; \
+        server-charm) echo 'server/charm' ;; \
+        *) echo '{{component}}' ;; \
+    esac
+
+# === RECIPE DEFINITIONS ===
+
+[doc('Describe usage and list the available recipes.')]
+help:
+    @echo 'All recipes require {{CYAN}}`uv`{{NORMAL}} to be available.'
+    @just --list --unsorted --list-submodules
+
+[doc('List available components in monorepo.')]
+list-components:
+    @echo '{{all_components}}'
+
+# --- All-components recipes ---
+
+[doc('Run all checks (format, lint, unit tests) for all components.')]
+check-all:
+    #!/usr/bin/env -S bash -e
+    FAILURES=0
+    for component in {{all_components}}; do
+        echo "=== Checking $component ==="
+        just check "$component" || ((FAILURES+=1))
+    done
+    echo "$FAILURES component(s) failed."
+    exit $FAILURES
+
+[doc('Run `ruff format` for all components, failing afterwards if any errors are found.')]
+format-all:
+    #!/usr/bin/env -S bash -e
+    FAILURES=0
+    for component in {{all_components}}; do
+        echo "=== Formatting $component ==="
+        just format "$component" || ((FAILURES+=1))
+    done
+    echo "$FAILURES component(s) failed."
+    exit $FAILURES
+
+[doc('Run `lint` for all components, failing afterwards if any errors are found.')]
+lint-all:
+    #!/usr/bin/env -S bash -e
+    FAILURES=0
+    for component in {{all_components}}; do
+        echo "=== Linting $component ==="
+        just lint "$component" || ((FAILURES+=1))
+    done
+    echo "$FAILURES component(s) failed."
+    exit $FAILURES
+
+# --- Per-component recipes ---
+
+[doc('Run all checks (format, lint, unit tests) for a component.')]
+check component:
+    #!/usr/bin/env -S bash -e
+    cd "$(just _path '{{component}}')"
+    uvx --with tox-uv tox
+
+[doc('Run `ruff format --check` for a component.')]
+format component:
+    #!/usr/bin/env -S bash -e
+    cd "$(just _path '{{component}}')"
+    uvx --with tox-uv tox run -e format
+
+[doc('Run `ruff check` for a component.')]
+lint component:
+    #!/usr/bin/env -S bash -e
+    cd "$(just _path '{{component}}')"
+    uvx --with tox-uv tox run -e lint
+
+[doc('Run unit tests for a component.')]
+unit component:
+    #!/usr/bin/env -S bash -e
+    cd "$(just _path '{{component}}')"
+    uvx --with tox-uv tox run -e unit
+
+# --- Server schema recipes ---
+
+[doc('Validate server schema is up to date.')]
+check-schema:
+    #!/usr/bin/env -S bash -e
+    cd 'server'
+    uvx --with tox-uv tox run -e check-schema
+
+[doc('Generate server schema.')]
+schema:
+    #!/usr/bin/env -S bash -e
+    cd 'server'
+    uvx --with tox-uv tox run -e schema
+
+# --- Package management recipes ---
+
+[doc("Run `uv add` for component, respecting repo-level version constraints, e.g. `just add agent 'pydantic>=2'`.")]
+[positional-arguments]  # pass recipe args to recipe script positionally
+add component +args:
+    #!/usr/bin/env -S bash -e
+    shift 1  # drop $1 (component) from $@ it's just +args
+    cd "$(just _path '{{component}}')"
+    uv add "${@}"
+
+[doc("Run `uv remove` for component, e.g. `just remove agent pydantic`.")]
+[positional-arguments]
+remove component +args:
+    #!/usr/bin/env -S bash -e
+    shift 1  # drop $1 (component) from $@
+    cd "$(just _path '{{component}}')"
+    uv remove "${@}"
+
+[doc("Run `uv lock` for component to update its lockfile.")]
+lock component:
+    #!/usr/bin/env -S bash -e
+    cd "$(just _path '{{component}}')"
+    uv lock

--- a/justfile
+++ b/justfile
@@ -21,6 +21,7 @@ _short_help:
     @echo '- {{CYAN}}just check-schema{{NORMAL}} (Check server schema is up to date)'
     @echo '- {{CYAN}}just schema{{NORMAL}} (Generate server schema)'
     @echo ''
+    @echo '{{BOLD}}Show help for the docs recipes: {{CYAN}}just docs help{{NORMAL}}'
     @echo '{{BOLD}}Build the docs: {{CYAN}}just docs{{NORMAL}}'
 
 # === COMPONENT DEFINITIONS ===

--- a/justfile
+++ b/justfile
@@ -12,6 +12,7 @@ _short_help:
     @echo '- Run all checks for all components: {{CYAN}}just check-all{{NORMAL}}'
     @echo '- Run {{CYAN}}ruff format{{NORMAL}} for all components: {{CYAN}}just format-all{{NORMAL}}'
     @echo '- Run {{CYAN}}ruff{{NORMAL}} for all components: {{CYAN}}just lint-all{{NORMAL}}'
+    @echo '- Run unit tests for all components: {{CYAN}}just unit-all{{NORMAL}}'
     @echo ''
     @echo '{{BOLD}}Run individual checks for a component:{{NORMAL}}'
     @echo '- {{CYAN}}just check <component>{{NORMAL}} (Run all checks: lint, format, unit tests)'
@@ -85,6 +86,17 @@ lint-all:
     for component in {{all_components}}; do
         echo "=== Linting $component ==="
         just lint "$component" || ((FAILURES+=1))
+    done
+    echo "$FAILURES component(s) failed."
+    exit $FAILURES
+
+[doc('Run `unit` for all components, failing afterwards if any errors are found.')]
+unit-all:
+    #!/usr/bin/env -S bash -e
+    FAILURES=0
+    for component in {{all_components}}; do
+        echo "=== Running unit tests for $component ==="
+        just unit "$component" || ((FAILURES+=1))
     done
     echo "$FAILURES component(s) failed."
     exit $FAILURES


### PR DESCRIPTION
## Description
This PR takes inspiration on how other Canonical projects are managing monorepos e.g. [charmlibs](https://github.com/canonical/charmlibs) by using [just](https://github.com/casey/just)

Just is essentially a command runner which in our case can be leveraged to improve developer experience while working locally. The proposed approach is not breaking and does not add complexity by reusing the `tox.ini` file and the environments/commands defined there. 

This introduces "recipes" that are easy to remember and that can be executed from any directory inside the repository: 

1. `justfile`: main file where recipes are located and where just usage is defined, it is defined per Testflinger component or with the suffix "all" to execute on all components. 
2. `docs.just`: recipes that are documentation only. 

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
NA
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
Updated the `CONTRIBUTING.md` making just as the preferred approach given the benefits but also kept the old reference to run using `uvx` directly. 
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Demo'ed and tested locally:

1. List general info
```
$ just
Canonical Testflinger Monorepo

List available components in this monorepo with just list-components

List all commands with just help, or:
- Run all checks for all components: just check-all
- Run ruff format for all components: just format-all
- Run ruff for all components: just lint-all

Run individual checks for a component:
- just check <component> (Run all checks: lint, format, unit tests)
- just lint <component> (Check linting issues)
- just format <component> (Solves all fixable lint and formatting issues)
- just unit <component> (Run unit tests)
- just check-schema (Check server schema is up to date)
- just schema (Generate server schema)

Build the docs: just docs
```

2. Running a recipe inside a component but reference another:
```
~/Documents/Canonical/testflinger/agent/charms/testflinger-agent-host-charm/src$ just format server
...
format: commands[0]> djlint --reformat src

Reformatting 12/12 files ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 00:00    


0 files were updated.

format: commands[1]> ruff format
48 files left unchanged
format: commands[2]> ruff check --fix
All checks passed!
  format: OK (0.31=setup[0.02]+cmd[0.27,0.01,0.01] seconds)
  congratulations :) (0.32 seconds)
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
