### PR TITLE
fix: correct occured typo in agent install error log

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -87,7 +87,7 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         try:
             charm_utils.install_agent_packages()
         except (apt.PackageNotFoundError, apt.PackageError):
-            self.logger.error("An error occured while installing dependencies")
+            self.logger.error("An error occurred while installing dependencies")
             self._block("Failed to install dependencies")
             return
         run_with_logged_errors(["pipx", "install", "uv"])


### PR DESCRIPTION
## Description

Fixes 'occured' -> 'occurred' typo in the agent install error log message inside `agent/charms/testflinger-agent-host-charm/src/charm.py`.

## Resolved issues

N/A.

## Documentation

No documentation changes required (operator-visible log message string only).

## Web service API changes

None.

## Tests

String-only change inside an error-path log call; no behavioral test added. Existing tests remain unchanged.
