### PR TITLE
feat(server-charm): add configuration options to set OIDC

### DIFF
--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -112,12 +112,12 @@ config:
       type: string
       default: "localhost,127.0.0.1,::1"
       description: Resources that we should be able to access bypassing proxy
-    behind_proxy:
+    enable_proxyfix:
       type: boolean
       default: false
       description: |
-        Whether the application is running behind a proxy. 
-        Required if OIDC is enabled and the application is running behind a proxy,
+        Enable Flask's ProxyFix middleware.
+        Required when the application is behind a reverse proxy and OIDC is enabled,
         so that redirects from the OIDC provider can be properly handled.
     webhook_url:
       type: string

--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -120,6 +120,22 @@ config:
       type: string
       default: ""
       description: Optional bearer token for authenticating with the webhook endpoint
+    web_secret_key:
+      type: string
+      default: ""
+      description: The secret key used for signing web sessions and cookies
+    oidc_client_id:
+      type: string
+      default: ""
+      description: The OIDC client ID used for authenticating with the OIDC provider
+    oidc_client_secret:
+      type: string
+      default: ""
+      description: The OIDC client secret used for authenticating with the OIDC provider
+    oidc_provider_issuer:
+      type: string
+      default: ""
+      description: The OIDC provider issuer URL for authenticating users
 
 
 parts:

--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -112,6 +112,13 @@ config:
       type: string
       default: "localhost,127.0.0.1,::1"
       description: Resources that we should be able to access bypassing proxy
+    behind_proxy:
+      type: boolean
+      default: false
+      description: |
+        Whether the application is running behind a proxy. 
+        Required if OIDC is enabled and the application is running behind a proxy,
+        so that redirects from the OIDC provider can be properly handled.
     webhook_url:
       type: string
       default: "http://test-observer-api.local/"

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -496,6 +496,10 @@ class TestflingerCharm(ops.CharmBase):
             "NO_PROXY": self.typed_config.no_proxy,
             "WEBHOOK_URL": self.typed_config.webhook_url,
             "WEBHOOK_AUTH": self.typed_config.webhook_auth,
+            "WEB_SECRET_KEY": self.typed_config.web_secret_key,
+            "OIDC_CLIENT_ID": self.typed_config.oidc_client_id,
+            "OIDC_CLIENT_SECRET": self.typed_config.oidc_client_secret,
+            "OIDC_PROVIDER_ISSUER": self.typed_config.oidc_provider_issuer,
         }
         return env
 

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -494,7 +494,7 @@ class TestflingerCharm(ops.CharmBase):
             "HTTP_PROXY": self.typed_config.http_proxy,
             "HTTPS_PROXY": self.typed_config.https_proxy,
             "NO_PROXY": self.typed_config.no_proxy,
-            "BEHIND_PROXY": str(self.typed_config.behind_proxy),
+            "ENABLE_PROXYFIX": str(self.typed_config.enable_proxyfix),
             "WEBHOOK_URL": self.typed_config.webhook_url,
             "WEBHOOK_AUTH": self.typed_config.webhook_auth,
             "WEB_SECRET_KEY": self.typed_config.web_secret_key,

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -494,6 +494,7 @@ class TestflingerCharm(ops.CharmBase):
             "HTTP_PROXY": self.typed_config.http_proxy,
             "HTTPS_PROXY": self.typed_config.https_proxy,
             "NO_PROXY": self.typed_config.no_proxy,
+            "BEHIND_PROXY": str(self.typed_config.behind_proxy),
             "WEBHOOK_URL": self.typed_config.webhook_url,
             "WEBHOOK_AUTH": self.typed_config.webhook_auth,
             "WEB_SECRET_KEY": self.typed_config.web_secret_key,

--- a/server/charm/src/config.py
+++ b/server/charm/src/config.py
@@ -20,6 +20,10 @@ class TestflingerServerConfig(pydantic.BaseModel):
     no_proxy: str = "localhost,127.0.0.1,::1"
     webhook_url: str = "http://test-observer-api.local/"
     webhook_auth: str = ""
+    web_secret_key: str = ""
+    oidc_client_id: str = ""
+    oidc_client_secret: str = ""
+    oidc_provider_issuer: str = ""
 
     @pydantic.field_validator("external_hostname")
     @classmethod
@@ -47,3 +51,36 @@ class TestflingerServerConfig(pydantic.BaseModel):
             raise ValueError("webhook_url must include a host")
 
         return value
+
+    @pydantic.field_validator("oidc_provider_issuer")
+    @classmethod
+    def validate_oidc_provider_issuer(cls, value):
+        """Validate oidc_provider_issuer includes a protocol and no paths."""
+        if not value:
+            return value
+
+        parsed_oidc = urlparse(value)
+        if parsed_oidc.scheme not in {"http", "https"}:
+            raise ValueError(
+                "oidc_provider_issuer must include protocol (http:// or https://)"
+            )
+        if not parsed_oidc.netloc:
+            raise ValueError("oidc_provider_issuer must include a host")
+        if parsed_oidc.path != "":
+            raise ValueError("oidc_provider_issuer must not include a path")
+        return value
+
+    @pydantic.model_validator(mode="after")
+    def validate_oidc_config(self):
+        """Validate that all OIDC parameters are set if any are configured."""
+        oidc_params = [
+            self.oidc_client_id,
+            self.oidc_client_secret,
+            self.oidc_provider_issuer,
+            self.web_secret_key,
+        ]
+        if any(oidc_params) and not all(oidc_params):
+            raise ValueError(
+                "All OIDC parameters must be set if any are configured"
+            )
+        return self

--- a/server/charm/src/config.py
+++ b/server/charm/src/config.py
@@ -18,6 +18,7 @@ class TestflingerServerConfig(pydantic.BaseModel):
     http_proxy: str = ""
     https_proxy: str = ""
     no_proxy: str = "localhost,127.0.0.1,::1"
+    behind_proxy: bool = False
     webhook_url: str = "http://test-observer-api.local/"
     webhook_auth: str = ""
     web_secret_key: str = ""

--- a/server/charm/src/config.py
+++ b/server/charm/src/config.py
@@ -18,7 +18,7 @@ class TestflingerServerConfig(pydantic.BaseModel):
     http_proxy: str = ""
     https_proxy: str = ""
     no_proxy: str = "localhost,127.0.0.1,::1"
-    behind_proxy: bool = False
+    enable_proxyfix: bool = False
     webhook_url: str = "http://test-observer-api.local/"
     webhook_auth: str = ""
     web_secret_key: str = ""

--- a/server/charm/src/config.py
+++ b/server/charm/src/config.py
@@ -56,7 +56,7 @@ class TestflingerServerConfig(pydantic.BaseModel):
     @pydantic.field_validator("oidc_provider_issuer")
     @classmethod
     def validate_oidc_provider_issuer(cls, value):
-        """Validate oidc_provider_issuer includes a protocol and no paths."""
+        """Validate oidc_provider_issuer includes a scheme and host."""
         if not value:
             return value
 
@@ -67,9 +67,7 @@ class TestflingerServerConfig(pydantic.BaseModel):
             )
         if not parsed_oidc.netloc:
             raise ValueError("oidc_provider_issuer must include a host")
-        if parsed_oidc.path != "":
-            raise ValueError("oidc_provider_issuer must not include a path")
-        return value
+        return value.rstrip("/")
 
     @pydantic.model_validator(mode="after")
     def validate_oidc_config(self):

--- a/server/charm/tests/unit/test_charm.py
+++ b/server/charm/tests/unit/test_charm.py
@@ -531,3 +531,30 @@ def test_retry_key_rotation_action_exec_error(_, ctx, make_state):
 
     with pytest.raises(testing.ActionFailed):
         ctx.run(ctx.on.action("retry-key-rotation"), state_in)
+
+
+def test_oidc_config_set_on_charm(ctx, make_state):
+    """Test charm is active when OIDC config is set and valid."""
+    oidc_config = {
+        "oidc_client_id": "client-id",
+        "oidc_client_secret": "client-secret",
+        "oidc_provider_issuer": "https://oidc-provider.local",
+        "web_secret_key": "web-secret-key",
+    }
+    state_in = make_state(config=oidc_config)
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+    assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_oidc_config_invalid_on_charm(ctx, make_state):
+    """Test charm is blocked when OIDC config is invalid."""
+    oidc_config = {
+        "oidc_client_id": "client-id",
+        "oidc_client_secret": "client-secret",
+    }
+    state_in = make_state(config=oidc_config)
+
+    # Pydantic validation runs in __init__ via load_config(errors="blocked"),
+    # which sets BlockedStatus and raises _Abort before the hook handler runs.
+    with pytest.raises(testing.errors.UncaughtCharmError):
+        _ = ctx.run(ctx.on.config_changed(), state_in)

--- a/server/charm/tests/unit/test_config.py
+++ b/server/charm/tests/unit/test_config.py
@@ -86,7 +86,7 @@ def test_invalid_oidc_configuration():
             web_secret_key="web-secret-key",  # noqa: S106
         )
 
-    # Missing oidc_secret_key
+    # Missing oidc_client_secret
     with pytest.raises(ValueError):
         TestflingerServerConfig(
             oidc_client_id="client-id",
@@ -114,14 +114,21 @@ def test_invalid_oidc_provider_issuer():
             web_secret_key="web-secret-key",  # noqa: S106
         )
 
-    # Reject oidc_provider_issuer that include path
-    with pytest.raises(ValueError):
-        TestflingerServerConfig(
-            oidc_client_id="client-id",
-            oidc_client_secret="client-secret",  # noqa: S106
-            oidc_provider_issuer="https://oidc-provider.local/issuer",
-            web_secret_key="web-secret-key",  # noqa: S106
-        )
+    config = TestflingerServerConfig(
+        oidc_client_id="client-id",
+        oidc_client_secret="client-secret",  # noqa: S106
+        oidc_provider_issuer="https://keycloak.example.com/realms/myrealm",
+        web_secret_key="web-secret-key",  # noqa: S106
+    )
+    assert config.oidc_provider_issuer == "https://keycloak.example.com/realms/myrealm"
+
+    config = TestflingerServerConfig(
+        oidc_client_id="client-id",
+        oidc_client_secret="client-secret",  # noqa: S106
+        oidc_provider_issuer="https://oidc-provider.local/",
+        web_secret_key="web-secret-key",  # noqa: S106
+    )
+    assert config.oidc_provider_issuer == "https://oidc-provider.local"
 
     # Reject oidc_provider_issuer that does not include hostname
     with pytest.raises(ValueError):

--- a/server/charm/tests/unit/test_config.py
+++ b/server/charm/tests/unit/test_config.py
@@ -114,6 +114,7 @@ def test_invalid_oidc_provider_issuer():
             web_secret_key="web-secret-key",  # noqa: S106
         )
 
+    # Test valid OIDC provider with path
     config = TestflingerServerConfig(
         oidc_client_id="client-id",
         oidc_client_secret="client-secret",  # noqa: S106
@@ -125,6 +126,7 @@ def test_invalid_oidc_provider_issuer():
         == "https://keycloak.example.com/realms/myrealm"
     )
 
+    # Test valid OIDC provider with no path, ending in slash
     config = TestflingerServerConfig(
         oidc_client_id="client-id",
         oidc_client_secret="client-secret",  # noqa: S106

--- a/server/charm/tests/unit/test_config.py
+++ b/server/charm/tests/unit/test_config.py
@@ -51,3 +51,83 @@ def test_invalid_webhook_url():
     # Reject webhook url that does not include hostname
     with pytest.raises(ValueError):
         TestflingerServerConfig(webhook_url="https:///v1/test-executions/")
+
+
+def test_valid_oidc_configuration():
+    """Test that OIDC configuration is validated correctly."""
+    # Valid OIDC config with all parameters set
+    config = TestflingerServerConfig(
+        oidc_client_id="client-id",
+        oidc_client_secret="client-secret",  # noqa: S106
+        oidc_provider_issuer="https://oidc-provider.local",
+        web_secret_key="web-secret-key",  # noqa: S106
+    )
+    assert config.oidc_client_id == "client-id"
+    assert config.oidc_client_secret == "client-secret"  # noqa: S105
+    assert config.oidc_provider_issuer == "https://oidc-provider.local"
+    assert config.web_secret_key == "web-secret-key"  # noqa: S105
+
+
+def test_invalid_oidc_configuration():
+    """Test that invalid OIDC configuration raises validation error."""
+    # Missing web_secret_key
+    with pytest.raises(ValueError):
+        TestflingerServerConfig(
+            oidc_client_id="client-id",
+            oidc_client_secret="client-secret",  # noqa: S106
+            oidc_provider_issuer="https://oidc-provider.local",
+        )
+
+    # Missing oidc_provider_issuer
+    with pytest.raises(ValueError):
+        TestflingerServerConfig(
+            oidc_client_id="client-id",
+            oidc_client_secret="client-secret",  # noqa: S106
+            web_secret_key="web-secret-key",  # noqa: S106
+        )
+
+    # Missing oidc_secret_key
+    with pytest.raises(ValueError):
+        TestflingerServerConfig(
+            oidc_client_id="client-id",
+            oidc_provider_issuer="https://oidc-provider.local",
+            web_secret_key="web-secret-key",  # noqa: S106
+        )
+
+    # Missing oidc_client_id
+    with pytest.raises(ValueError):
+        TestflingerServerConfig(
+            oidc_client_secret="client-secret",  # noqa: S106
+            oidc_provider_issuer="https://oidc-provider.local",
+            web_secret_key="web-secret-key",  # noqa: S106
+        )
+
+
+def test_invalid_oidc_provider_issuer():
+    """Test that invalid OIDC provider issuer raises validation error."""
+    # Reject oidc_provider_issuer that do not include protocol
+    with pytest.raises(ValueError):
+        TestflingerServerConfig(
+            oidc_client_id="client-id",
+            oidc_client_secret="client-secret",  # noqa: S106
+            oidc_provider_issuer="oidc-provider.local",
+            web_secret_key="web-secret-key",  # noqa: S106
+        )
+
+    # Reject oidc_provider_issuer that include path
+    with pytest.raises(ValueError):
+        TestflingerServerConfig(
+            oidc_client_id="client-id",
+            oidc_client_secret="client-secret",  # noqa: S106
+            oidc_provider_issuer="https://oidc-provider.local/issuer",
+            web_secret_key="web-secret-key",  # noqa: S106
+        )
+
+    # Reject oidc_provider_issuer that does not include hostname
+    with pytest.raises(ValueError):
+        TestflingerServerConfig(
+            oidc_client_id="client-id",
+            oidc_client_secret="client-secret",  # noqa: S106
+            oidc_provider_issuer="https:///issuer",
+            web_secret_key="web-secret-key",  # noqa: S106
+        )

--- a/server/charm/tests/unit/test_config.py
+++ b/server/charm/tests/unit/test_config.py
@@ -120,7 +120,10 @@ def test_invalid_oidc_provider_issuer():
         oidc_provider_issuer="https://keycloak.example.com/realms/myrealm",
         web_secret_key="web-secret-key",  # noqa: S106
     )
-    assert config.oidc_provider_issuer == "https://keycloak.example.com/realms/myrealm"
+    assert (
+        config.oidc_provider_issuer
+        == "https://keycloak.example.com/realms/myrealm"
+    )
 
     config = TestflingerServerConfig(
         oidc_client_id="client-id",

--- a/server/src/testflinger/application.py
+++ b/server/src/testflinger/application.py
@@ -106,6 +106,10 @@ def create_flask_app(config=None, secrets_store=None):
         return {"vanilla_framework_version": VANILLA_FRAMEWORK_VERSION}
 
     # Tell Flask it's behind a proxy so it can properly handle redirects
+    # This middleware should only be used if the application is actually
+    # behind such a proxy, and should be configured with the number of
+    # proxies that are chained in front of it. Not all proxies set all
+    # the headers.
     if os.environ.get("BEHIND_PROXY", "false").lower() == "true":
         tf_app.wsgi_app = ProxyFix(
             tf_app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1

--- a/server/src/testflinger/application.py
+++ b/server/src/testflinger/application.py
@@ -16,6 +16,7 @@
 """Setup the Testflinger web application."""
 
 import logging
+import os
 
 from apiflask import APIFlask
 from flask import request
@@ -105,9 +106,10 @@ def create_flask_app(config=None, secrets_store=None):
         return {"vanilla_framework_version": VANILLA_FRAMEWORK_VERSION}
 
     # Tell Flask it's behind a proxy so it can properly handle redirects
-    tf_app.wsgi_app = ProxyFix(
-        tf_app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1
-    )
+    if os.environ.get("BEHIND_PROXY", "false").lower() == "true":
+        tf_app.wsgi_app = ProxyFix(
+            tf_app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1
+        )
 
     tf_app.register_blueprint(views)
     tf_app.register_blueprint(v1, url_prefix="/v1")

--- a/server/src/testflinger/application.py
+++ b/server/src/testflinger/application.py
@@ -21,6 +21,7 @@ from apiflask import APIFlask
 from flask import request
 from pymongo.errors import ConnectionFailure
 from werkzeug.exceptions import NotFound
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from testflinger.api.v1 import LogTypeConverter, v1
 from testflinger.database import setup_mongodb
@@ -102,6 +103,11 @@ def create_flask_app(config=None, secrets_store=None):
     @tf_app.context_processor
     def inject_vanilla_framework_version():
         return {"vanilla_framework_version": VANILLA_FRAMEWORK_VERSION}
+
+    # Tell Flask it's behind a proxy so it can properly handle redirects
+    tf_app.wsgi_app = ProxyFix(
+        tf_app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1
+    )
 
     tf_app.register_blueprint(views)
     tf_app.register_blueprint(v1, url_prefix="/v1")

--- a/server/src/testflinger/application.py
+++ b/server/src/testflinger/application.py
@@ -110,7 +110,7 @@ def create_flask_app(config=None, secrets_store=None):
     # behind such a proxy, and should be configured with the number of
     # proxies that are chained in front of it. Not all proxies set all
     # the headers.
-    if os.environ.get("BEHIND_PROXY", "false").lower() == "true":
+    if os.environ.get("ENABLE_PROXYFIX", "false").lower() == "true":
         tf_app.wsgi_app = ProxyFix(
             tf_app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1
         )

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -35,12 +35,12 @@ def test_setup_mongo_fails_without_config():
 
 
 def test_proxyfix_enabled(monkeypatch):
-    """Ensure ProxyFix is enabled when BEHIND_PROXY is true."""
-    monkeypatch.setenv("BEHIND_PROXY", "true")
+    """Ensure ProxyFix is enabled when ENABLE_PROXYFIX is true."""
+    monkeypatch.setenv("ENABLE_PROXYFIX", "true")
     app = create_flask_app(type("", (), {"TESTING": True})())
     assert isinstance(app.wsgi_app, ProxyFix)
 
 
 def test_proxyfix_disabled(testapp):
-    """Ensure ProxyFix is disabled when BEHIND_PROXY is not set."""
+    """Ensure ProxyFix is disabled when ENABLE_PROXYFIX is not set."""
     assert not isinstance(testapp.wsgi_app, ProxyFix)

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -16,6 +16,7 @@
 """Unit tests for Testflinger flask app."""
 
 import pytest
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from testflinger.application import create_flask_app
 
@@ -31,3 +32,15 @@ def test_setup_mongo_fails_without_config():
     with pytest.raises(SystemExit) as exc:
         create_flask_app()
     assert exc.value.code == "No MongoDB URI configured!"
+
+
+def test_proxyfix_enabled(monkeypatch):
+    """Ensure ProxyFix is enabled when BEHIND_PROXY is true."""
+    monkeypatch.setenv("BEHIND_PROXY", "true")
+    app = create_flask_app(type("", (), {"TESTING": True})())
+    assert isinstance(app.wsgi_app, ProxyFix)
+
+
+def test_proxyfix_disabled(testapp):
+    """Ensure ProxyFix is disabled when BEHIND_PROXY is not set."""
+    assert not isinstance(testapp.wsgi_app, ProxyFix)


### PR DESCRIPTION
## Description
This PR adds the required configuration options so it can enable OIDC. The ground work was already made so this only adds the configuration at the charm level. 

It also adds `ProxyFix` conditionally based on if the application is running behind a proxy, this is different than the HTTP_PROXY and NO_PROXY as those are used for outbound and this is required for inbound requests. Without ProxyFix, the OIDC provider is unable to redirect back to the application. 

~Finally, this also "sneaks" a hotfix needed with PyMongo > 4.9 e.g. db["fs.<collection>"] otherwise the application is unable to start~ I moved pymongo fix to #1118 to also include some unit tests as they were missing entirely for GridFS

> [!NOTE]
> Integration tests are failing because of this MongoDB issue, the tests uses the image that is available on `main` until this fix is landed, expect failures as the application will never start (it crashes with the above traceback)

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-714](https://warthogs.atlassian.net/browse/CERTTF-714)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests for charm configuration and also tested on staging:
<img width="2488" height="1022" alt="Screenshot from 2026-05-21 14-23-28" src="https://github.com/user-attachments/assets/c0b68185-418e-485d-a119-d5b61eff4504" />

<!--


- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-714]: https://warthogs.atlassian.net/browse/CERTTF-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ