### PR TITLE
fix(server): pymongo gridfs attribute error

### DIFF
--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -95,10 +95,10 @@ def create_indexes():
     )
 
     # Remove artifacts after 7 days
-    mongo.db.fs.chunks.create_index(
+    mongo.db["fs.chunks"].create_index(
         "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
     )
-    mongo.db.fs.files.create_index(
+    mongo.db["fs.files"].create_index(
         "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
     )
 
@@ -134,8 +134,8 @@ def save_file(data: Any, filename: str):
     storage = GridFS(mongo.db)
     file_id = storage.put(data, filename=filename)
     # Add a timestamp to the chunks - do this so we can set a TTL for them
-    timestamp = mongo.db.fs.files.find_one({"_id": file_id})["uploadDate"]
-    mongo.db.fs.chunks.update_many(
+    timestamp = mongo.db["fs.files"].find_one({"_id": file_id})["uploadDate"]
+    mongo.db["fs.chunks"].update_many(
         {"files_id": file_id}, {"$set": {"uploadDate": timestamp}}
     )
 

--- a/server/tests/test_database.py
+++ b/server/tests/test_database.py
@@ -21,9 +21,12 @@ import mongomock
 import pytest
 from mongomock.gridfs import enable_gridfs_integration
 
-from testflinger.database import retrieve_file, save_file
-
-DEFAULT_EXPIRATION = 60 * 60 * 24 * 7  # 7 days in seconds
+from testflinger.database import (
+    DEFAULT_EXPIRATION,
+    create_indexes,
+    retrieve_file,
+    save_file,
+)
 
 # Enable GridFS support once for all tests in this module.
 enable_gridfs_integration()
@@ -47,6 +50,7 @@ def test_save_file_as_chunks(mock_mongo):
 
     file_id = file_doc["_id"]
     chunks = list(mock_mongo.db["fs.chunks"].find({"files_id": file_id}))
+    assert chunks, "Expected at least one GridFS chunk document"
     for chunk in chunks:
         assert "uploadDate" in chunk
         assert chunk["uploadDate"] == file_doc["uploadDate"]
@@ -71,16 +75,35 @@ def test_retrieve_file_raises_for_missing_file(mock_mongo):
 @patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
 def test_create_indexes_gridfs_collections(mock_mongo):
     """Test TTL indexes are created on fs.chunks and fs.files collections."""
-    mock_mongo.db["fs.chunks"].create_index(
-        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
-    )
-    mock_mongo.db["fs.files"].create_index(
-        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
-    )
+    # exclude compound indexes that are not relevant for gridFS
+    # as those are not supported by mongomock
+    with (
+        patch.object(mock_mongo.db.jobs, "create_index"),
+        patch.object(mock_mongo.db.logs, "create_index"),
+    ):
+        create_indexes()
 
     chunks_indexes = mock_mongo.db["fs.chunks"].index_information()
     files_indexes = mock_mongo.db["fs.files"].index_information()
 
-    # We expect at least the default _id index plus the TTL index on uploadDate
-    assert len(chunks_indexes) > 1
-    assert len(files_indexes) > 1
+    # Validate TTL index exists and has the expected expiry.
+    chunks_ttl = next(
+        (
+            info
+            for info in chunks_indexes.values()
+            if info.get("key") == [("uploadDate", 1)]
+        ),
+        None,
+    )
+    files_ttl = next(
+        (
+            info
+            for info in files_indexes.values()
+            if info.get("key") == [("uploadDate", 1)]
+        ),
+        None,
+    )
+    assert chunks_ttl is not None
+    assert chunks_ttl.get("expireAfterSeconds") == DEFAULT_EXPIRATION
+    assert files_ttl is not None
+    assert files_ttl.get("expireAfterSeconds") == DEFAULT_EXPIRATION

--- a/server/tests/test_database.py
+++ b/server/tests/test_database.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""Unit tests for testflinger database functions."""
+
+from unittest.mock import patch
+
+import mongomock
+import pytest
+from mongomock.gridfs import enable_gridfs_integration
+
+from testflinger.database import retrieve_file, save_file
+
+DEFAULT_EXPIRATION = 60 * 60 * 24 * 7  # 7 days in seconds
+
+# Enable GridFS support once for all tests in this module.
+enable_gridfs_integration()
+
+
+@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
+def test_save_file_stored_filename(mock_mongo):
+    """Test save_file references the filename in the fs.files collection."""
+    save_file(b"hello world", "hello.txt")
+
+    stored = mock_mongo.db["fs.files"].find_one({"filename": "hello.txt"})
+    assert stored is not None
+
+
+@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
+def test_save_file_as_chunks(mock_mongo):
+    """Test save_file stores data as chunks with same uploadDate as file."""
+    save_file(b"hello world", "hello.txt")
+
+    file_doc = mock_mongo.db["fs.files"].find_one({"filename": "hello.txt"})
+
+    file_id = file_doc["_id"]
+    chunks = list(mock_mongo.db["fs.chunks"].find({"files_id": file_id}))
+    for chunk in chunks:
+        assert "uploadDate" in chunk
+        assert chunk["uploadDate"] == file_doc["uploadDate"]
+
+
+@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
+def test_retrieve_file_returns_stored_content(mock_mongo):
+    """Test retrieve_file returns the content stored with save_file."""
+    content = b"hello world"
+    save_file(content, "hello.txt")
+    result = retrieve_file("hello.txt")
+    assert result.read() == content
+
+
+@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
+def test_retrieve_file_raises_for_missing_file(mock_mongo):
+    """Test retrieve_file raises FileNotFoundError for a non-existent file."""
+    with pytest.raises(FileNotFoundError):
+        retrieve_file("fake.txt")
+
+
+@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
+def test_create_indexes_gridfs_collections(mock_mongo):
+    """Test TTL indexes are created on fs.chunks and fs.files collections."""
+    mock_mongo.db["fs.chunks"].create_index(
+        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
+    mock_mongo.db["fs.files"].create_index(
+        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
+
+    chunks_indexes = mock_mongo.db["fs.chunks"].index_information()
+    files_indexes = mock_mongo.db["fs.files"].index_information()
+
+    # We expect at least the default _id index plus the TTL index on uploadDate
+    assert len(chunks_indexes) > 1
+    assert len(files_indexes) > 1


### PR DESCRIPTION
## Description
This fixes a bug introduced in #1057 by pymongo<4.17. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves #1117
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
NA
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
NA
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests as the GridFS was completely missing. For testing this fix, the integration test is the actually relevant as currently, integration tests are failing as the application is unable to start. Unforntunately, the integration tests will fail until after this is merged as the integration tests uses the container image from `main`
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
