### PR TITLE
feat(oem_autoinstall): support 26.04 racoon provisioning

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/default-user-data
@@ -16,6 +16,8 @@ autoinstall:
   late-commands:
     - "bash /cdrom/sideloads/hook.sh late-commands"
     - "mount -o rw,remount /cdrom"
+    # Installer generated config lacks dhcp because network was disabled. Let 01-*.yaml to handle network
+    - "curtin in-target --target=/target -- rm /etc/netplan/00-installer-config.yaml || true"
 
     # Rename factory reset EFI directory so firmware won't show it. Ignore
     # errors on the way.

--- a/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/provision-image.sh
+++ b/device-connectors/src/testflinger_device_connectors/data/oem_autoinstall/provision-image.sh
@@ -57,12 +57,12 @@ fi
 
 menuentry "Start redeployment" {
         set gfxpayload=keep
-        linux   /casper/vmlinuz layerfs-path=minimal.standard.live.hotfix.squashfs nopersistent ds=nocloud\;s=/cdrom/cloud-configs/redeploy --- quiet splash nomodeset modprobe.blacklist=nouveau nouveau.modeset=0 autoinstall rp-partuuid=RP_PARTUUID
+        linux   /casper/vmlinuz layerfs-path=minimal.standard.live.hotfix.squashfs nopersistent ds=nocloud\;s=/cdrom/cloud-configs/redeploy nomodeset modprobe.blacklist=nouveau nouveau.modeset=0 autoinstall rp-partuuid=RP_PARTUUID --- quiet splash
         initrd  /casper/initrd
 }
 menuentry "Start normal reset installation" {
         set gfxpayload=keep
-        linux   /casper/vmlinuz layerfs-path=minimal.standard.live.hotfix.squashfs nopersistent ds=nocloud\;s=/cdrom/cloud-configs/reset-media --- quiet splash nomodeset modprobe.blacklist=nouveau nouveau.modeset=0
+        linux   /casper/vmlinuz layerfs-path=minimal.standard.live.hotfix.squashfs nopersistent ds=nocloud\;s=/cdrom/cloud-configs/reset-media nomodeset modprobe.blacklist=nouveau nouveau.modeset=0 --- quiet splash
         initrd  /casper/initrd
 }
 grub_platform


### PR DESCRIPTION
## Description
26.04 resolute image is available for POC.
This change updates oem_autoinstall default user-data by
1. updating the cmd in grub.cfg for racoon parser compatibility
2. adding step in user-data to remove /etc/netplan/00-installer-config.yaml generated by subiquity. Since installer's network was disabled the generated file did not enable dhcp and provisioned OS doesn't pick the IP. By removing this config, we let provisioned OS to consume default /etc/netplan/01-network-manager-all.yaml and setup network correctly.

Above changes won't affect the noble provisioning, which still works.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Closes https://warthogs.atlassian.net/browse/OEX86-962
Closes https://warthogs.atlassian.net/browse/RUSI-67
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
n/a
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
n/a
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Run provision-image.sh script with new user data
1. Provision racoon 26.04 - OK
4. Provision noble 24.04 to verify no regression - OK

Job outputs are in related jira ticket


<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
