### PR TITLE
Fix: IoT provisioning must define test_data issue

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -41,11 +41,22 @@ class DeviceConnector(ZapperConnector):
         """Validate the job config and data and prepare the arguments
         for the Zapper `provision` API.
         """
+        # We prefer using username/password in provision_plan
+        # while username/password are not defined in test_data
+        provision_plan = self.job_data.get("provision_data", {}).get(
+            "provision_plan", {}
+        )
+
+        config = provision_plan.get("config", {})
+
+        default_uname = config.get("username", "ubuntu")
+        default_password = config.get("password", "ubuntu")
+
         username = self.job_data.get("test_data", {}).get(
-            "test_username", "ubuntu"
+            "test_username", default_uname
         )
         password = self.job_data.get("test_data", {}).get(
-            "test_password", "ubuntu"
+            "test_password", default_password
         )
         ubuntu_sso_email = self.job_data["provision_data"].get(
             "ubuntu_sso_email"

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -61,6 +61,18 @@ class DeviceConnector(ZapperConnector):
         ubuntu_sso_email = self.job_data["provision_data"].get(
             "ubuntu_sso_email"
         )
+        test_username = self.job_data.get("test_data", {}).get(
+            "test_username", "ubuntu"
+        )
+        test_password = self.job_data.get("test_data", {}).get(
+            "test_password", "ubuntu"
+        )
+        if username != test_username or password != test_password:
+            logger.warning(
+                "Provisioning is using a username different from"
+                " what the test phase expects, which may prevent it"
+                " from accessing the DUT later on."
+            )
 
         # If ubuntu_sso_email is provided, use it instead of the test_username
         provisioning_data = {

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -83,7 +83,7 @@ class ZapperIoTTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
-    def test_validate_configuration_provision_plan(self):
+    def test_validate_configuration_provision_plan_without_test_data(self):
         """Test the function validates a custom test plan
         when provided.
         """
@@ -106,6 +106,63 @@ class ZapperIoTTests(unittest.TestCase):
                     ],
                 },
             }
+        }
+
+        args, kwargs = device._validate_configuration()
+
+        expected = {
+            "username": "admin",
+            "password": "admin",
+            "custom_provision_plan": {
+                "config": {
+                    "project_name": "name",
+                    "username": "admin",  # this gets overridden
+                    "password": "admin",
+                    "serial_console": {
+                        "port": "/dev/ttySanity1",
+                        "baud_rate": 115200,
+                    },
+                    "network": "eth0",
+                },
+                "run_stage": [
+                    {"initial_login": {"method": "system-user"}},
+                ],
+            },
+            "urls": [],
+            "preset": None,
+            "preset_kwargs": None,
+        }
+        self.maxDiff = None
+        self.assertEqual(args, ())
+        self.assertDictEqual(expected, kwargs)
+
+    def test_validate_configuration_provision_plan_with_test_data(self):
+        """Test the function validates a custom test plan
+        when provided.
+        """
+        device = DeviceConnector({})
+        device.job_data = {
+            "provision_data": {
+                "provision_plan": {
+                    "config": {
+                        "project_name": "name",
+                        "username": "admin",
+                        "password": "admin",
+                        "serial_console": {
+                            "port": "/dev/ttySanity1",
+                            "baud_rate": 115200,
+                        },
+                        "network": "eth0",
+                    },
+                    "run_stage": [
+                        {"initial_login": {"method": "system-user"}},
+                    ],
+                }
+            },
+            "test_data": {
+                "test_username": "ubuntu",
+                "test_password": "ubuntu",
+            },
         }
 
         args, kwargs = device._validate_configuration()


### PR DESCRIPTION
## Description
We default use test_data username/password, while test_data is not defined, fallback to use provision_data username/password not just "ubunut"/"ubuntu"

## Resolved issues
Solving wrong userame/password while test_data is not defined.

## Documentation
## Web service API changes
## Tests
1. provision imx8mp-pdk with test_data is defined and verified username/password is correct
2. provision imx8mp-pdk without test_data and verified that we fallback to use username/password in provision_data
