### PR TITLE
change: keep the DUT off while the control_host is being rebooted

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -151,16 +151,24 @@ class DefaultControlHost:
     Attributes:
         host: The hostname or IP of the control host.
         reboot_script: Ordered list of shell commands to trigger a reboot.
+        poweroff_script: Ordered list of shell commands to power off the DUT.
+        poweron_script: Ordered list of shell commands to power on the DUT.
     """
 
     REST_PORT = 8000
     POWEROFF_ENDPOINT = "/api/v1/system/poweroff"
 
     def __init__(
-        self, host: str, reboot_script: Optional[list[str]] = None
+        self,
+        host: str,
+        reboot_script: Optional[list[str]] = None,
+        poweroff_script: Optional[list[str]] = None,
+        poweron_script: Optional[list[str]] = None,
     ) -> None:
         self.host = host
         self.reboot_script = reboot_script or []
+        self.poweroff_script = poweroff_script or []
+        self.poweron_script = poweron_script or []
 
     def _check_ssh(self) -> None:
         """Check whether the control host has an active SSH server.
@@ -252,10 +260,10 @@ class DefaultControlHost:
         logger.info("Waiting for the REST API on control host %s", self.host)
         self.wait_online(self._check_rest_api, timeout)
 
-    def reboot(self) -> None:
-        """Run the configured reboot script."""
-        logger.info("Running control host reboot script")
-        for cmd in self.reboot_script:
+    def _run_script(self, script: list[str], description: str) -> None:
+        """Run the configured shell commands for an operation."""
+        logger.info("Running %s script", description)
+        for cmd in script:
             try:
                 logger.info("Executing: %s", cmd)
                 subprocess.run(
@@ -280,6 +288,18 @@ class DefaultControlHost:
                 logger.error(
                     "Unexpected error running command %s: %s", cmd, str(e)
                 )
+
+    def reboot(self) -> None:
+        """Run the configured reboot script."""
+        self._run_script(self.reboot_script, "control host reboot")
+
+    def poweroff_dut(self) -> None:
+        """Run the configured DUT power-off script."""
+        self._run_script(self.poweroff_script, "DUT power-off")
+
+    def poweron_dut(self) -> None:
+        """Run the configured DUT power-on script."""
+        self._run_script(self.poweron_script, "DUT power-on")
 
     def ssh_fallback(self) -> None:
         """Reboot if SSH is unreachable, then wait for SSH to come back."""
@@ -315,6 +335,7 @@ class DefaultControlHost:
         API is not available.
         """
         try:
+            self.poweroff_dut()
             logger.info("Attempt to power cycle the control host.")
             url = (
                 f"http://{self.host}:{self.REST_PORT}{self.POWEROFF_ENDPOINT}"
@@ -332,6 +353,8 @@ class DefaultControlHost:
                 self.host,
             )
             self.ssh_fallback()
+        finally:
+            self.poweron_dut()
 
 
 class DefaultDevice:
@@ -631,7 +654,19 @@ class DefaultDevice:
             )
             return
 
-        DefaultControlHost(control_host, reboot_script).power_cycle()
+        poweroff_script: list[str] = [
+            str(cmd) for cmd in self.config.get("poweroff_script", [])
+        ]
+        poweron_script: list[str] = [
+            str(cmd) for cmd in self.config.get("poweron_script", [])
+        ]
+
+        DefaultControlHost(
+            control_host,
+            reboot_script,
+            poweroff_script=poweroff_script,
+            poweron_script=poweron_script,
+        ).power_cycle()
 
     def provision(self, args):
         """Run pre-provision hook."""

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -642,7 +642,8 @@ class DefaultDevice:
 
     def _config_script(self, key: str) -> list[str]:
         """Return the list of shell commands configured under ``key``."""
-        return [str(cmd) for cmd in self.config.get(key, [])]
+        value = self.config.get(key) or []
+        return [str(cmd) for cmd in value]
 
     def pre_provision_hook(self):
         """Power cycle the control host before provisioning."""

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -636,6 +636,10 @@ class DefaultDevice:
         )
         time.sleep(int(timeout))
 
+    def _config_script(self, key: str) -> list[str]:
+        """Return the list of shell commands configured under ``key``."""
+        return [str(cmd) for cmd in self.config.get(key, [])]
+
     def pre_provision_hook(self):
         """Power cycle the control host before provisioning."""
         if os.environ.get("DISABLE_CONTROL_HOST_POWERCYCLE"):
@@ -650,10 +654,7 @@ class DefaultDevice:
             logger.debug("No control host configured for this agent.")
             return
 
-        reboot_script: list[str] = [
-            str(cmd)
-            for cmd in self.config.get("control_host_reboot_script", [])
-        ]
+        reboot_script = self._config_script("control_host_reboot_script")
         if not reboot_script:
             logger.warning(
                 "No control_host_reboot_script configured, cannot reboot."
@@ -665,12 +666,14 @@ class DefaultDevice:
         poweroff_script: list[str] = []
         poweron_script: list[str] = []
         if self.MANAGE_DUT_POWER_DURING_REBOOT:
-            poweroff_script = [
-                str(cmd) for cmd in self.config.get("poweroff_script", [])
-            ]
-            poweron_script = [
-                str(cmd) for cmd in self.config.get("poweron_script", [])
-            ]
+            poweroff_script = self._config_script("poweroff_script")
+            poweron_script = self._config_script("poweron_script")
+            if not (poweroff_script and poweron_script):
+                logger.warning(
+                    "poweroff_script/poweron_script not configured: "
+                    "the DUT may stay powered while the control host "
+                    "reboots."
+                )
 
         DefaultControlHost(
             control_host,

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -364,6 +364,12 @@ class DefaultDevice:
         config: Configuration with all the information of the device.
     """
 
+    # Whether the DUT should be powered off while the control host is being
+    # rebooted (and powered back on afterwards). Only connectors that opt in
+    # run the configured poweroff_script/poweron_script during the control
+    # host power cycle.
+    MANAGE_DUT_POWER_DURING_REBOOT = False
+
     def __init__(self, config: dict) -> None:
         """Initialize class with device config and writing data to JSON file.
 
@@ -654,12 +660,17 @@ class DefaultDevice:
             )
             return
 
-        poweroff_script: list[str] = [
-            str(cmd) for cmd in self.config.get("poweroff_script", [])
-        ]
-        poweron_script: list[str] = [
-            str(cmd) for cmd in self.config.get("poweron_script", [])
-        ]
+        # Only connectors that opt in keep the DUT powered off while the
+        # control host reboots; for the rest these stay empty (no-op).
+        poweroff_script: list[str] = []
+        poweron_script: list[str] = []
+        if self.MANAGE_DUT_POWER_DURING_REBOOT:
+            poweroff_script = [
+                str(cmd) for cmd in self.config.get("poweroff_script", [])
+            ]
+            poweron_script = [
+                str(cmd) for cmd in self.config.get("poweron_script", [])
+            ]
 
         DefaultControlHost(
             control_host,

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -679,7 +679,8 @@ class DefaultDevice:
                     "the DUT may stay powered while the control host "
                     "reboots."
                 )
-
+                poweroff_script = []
+                poweron_script = []
         DefaultControlHost(
             control_host,
             reboot_script,

--- a/device-connectors/src/testflinger_device_connectors/devices/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/__init__.py
@@ -294,11 +294,15 @@ class DefaultControlHost:
         self._run_script(self.reboot_script, "control host reboot")
 
     def poweroff_dut(self) -> None:
-        """Run the configured DUT power-off script."""
+        """Run the configured DUT power-off script, if any."""
+        if not self.poweroff_script:
+            return
         self._run_script(self.poweroff_script, "DUT power-off")
 
     def poweron_dut(self) -> None:
-        """Run the configured DUT power-on script."""
+        """Run the configured DUT power-on script, if any."""
+        if not self.poweron_script:
+            return
         self._run_script(self.poweron_script, "DUT power-on")
 
     def ssh_fallback(self) -> None:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
@@ -30,10 +30,6 @@ logger = logging.getLogger(__name__)
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
-    def pre_provision_hook(self):
-        """Skip control host power cycle for muxpi devices."""
-        pass
-
     def provision(self, args):
         """Provision device when the command is invoked."""
         with open(args.config) as configfile:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/__init__.py
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 class DeviceConnector(DefaultDevice):
     """Tool for provisioning baremetal with a given image."""
 
+    MANAGE_DUT_POWER_DURING_REBOOT = True
+
     def provision(self, args):
         """Provision device when the command is invoked."""
         with open(args.config) as configfile:

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -43,6 +43,13 @@ def test_pre_provision_hook_uses_default_power_cycle(mocker):
     mock_power_cycle.assert_called_once()
 
 
+def test_manages_dut_power_during_reboot():
+    """Test muxpi opts in to keeping the DUT off while the control host
+    reboots.
+    """
+    assert DeviceConnector.MANAGE_DUT_POWER_DURING_REBOOT is True
+
+
 def test_check_ce_oem_iot_image(mocker):
     """Test check_ce_oem_iot_image."""
     series = "2404"

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -26,8 +26,8 @@ from testflinger_device_connectors.devices.muxpi import DeviceConnector
 from testflinger_device_connectors.devices.muxpi.muxpi import MuxPi
 
 
-def test_pre_provision_hook_is_noop(mocker):
-    """Test that muxpi skips the control host power cycle."""
+def test_pre_provision_hook_uses_default_power_cycle(mocker):
+    """Test that muxpi uses the default control host power cycle."""
     mocker.patch("builtins.open", mocker.mock_open())
     mock_power_cycle = mocker.patch.object(DefaultControlHost, "power_cycle")
     device = DeviceConnector(
@@ -40,7 +40,7 @@ def test_pre_provision_hook_is_noop(mocker):
 
     device.pre_provision_hook()
 
-    mock_power_cycle.assert_not_called()
+    mock_power_cycle.assert_called_once()
 
 
 def test_check_ce_oem_iot_image(mocker):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -44,6 +44,7 @@ class ZapperConnector(ABC, DefaultDevice):
     device connectors.
     """
 
+    MANAGE_DUT_POWER_DURING_REBOOT = True
     PROVISION_METHOD = ""  # to be defined in the implementation
     ZAPPER_CONNECTION_TIMEOUT = 30
     ZAPPER_READ_TIMEOUT = 60 * 90

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -44,7 +44,6 @@ class ZapperConnector(ABC, DefaultDevice):
     device connectors.
     """
 
-    MANAGE_DUT_POWER_DURING_REBOOT = True
     PROVISION_METHOD = ""  # to be defined in the implementation
     ZAPPER_CONNECTION_TIMEOUT = 30
     ZAPPER_READ_TIMEOUT = 60 * 90

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -39,11 +39,12 @@ class MockConnector(ZapperConnector):
         pass
 
 
-def test_manages_dut_power_during_reboot():
-    """Test the base Zapper connector opts in to keeping the DUT off while
-    the control host reboots (inherited by all Zapper variants).
+def test_does_not_manage_dut_power_during_reboot_by_default():
+    """The base Zapper connector does NOT keep the DUT off while the control
+    host reboots; individual variants (e.g. zapper_iot) opt in explicitly so
+    that variants like zapper_kvm are unaffected.
     """
-    assert ZapperConnector.MANAGE_DUT_POWER_DURING_REBOOT is True
+    assert ZapperConnector.MANAGE_DUT_POWER_DURING_REBOOT is False
 
 
 class ZapperConnectorTests(unittest.TestCase):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -39,6 +39,13 @@ class MockConnector(ZapperConnector):
         pass
 
 
+def test_manages_dut_power_during_reboot():
+    """Test the base Zapper connector opts in to keeping the DUT off while
+    the control host reboots (inherited by all Zapper variants).
+    """
+    assert ZapperConnector.MANAGE_DUT_POWER_DURING_REBOOT is True
+
+
 class ZapperConnectorTests(unittest.TestCase):
     """Unit tests for ZapperConnector class."""
 

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 class DeviceConnector(ZapperConnector):
     """Tool for provisioning baremetal with a given image."""
 
+    MANAGE_DUT_POWER_DURING_REBOOT = True
     PROVISION_METHOD = "ProvisioningIoT"
 
     def _validate_configuration(

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -8,6 +8,12 @@ from testflinger_device_connectors.devices.zapper_iot import DeviceConnector
 class ZapperIoTTests(unittest.TestCase):
     """Test Cases for the Zapper IoT class."""
 
+    def test_manages_dut_power_during_reboot(self):
+        """zapper_iot opts in to keeping the DUT off while the control host
+        reboots, unlike the base connector and other Zapper variants.
+        """
+        self.assertTrue(DeviceConnector.MANAGE_DUT_POWER_DURING_REBOOT)
+
     def test_validate_configuration(self):
         """Test the function creates a proper provision_data
         dictionary when valid data are provided.

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -28,6 +28,12 @@ from testflinger_device_connectors.devices.zapper_kvm import DeviceConnector
 class ZapperKVMConnectorTests(unittest.TestCase):
     """Unit tests for ZapperConnector KVM class."""
 
+    def test_does_not_manage_dut_power_during_reboot(self) -> None:
+        """zapper_kvm must NOT power cycle the DUT while the control host
+        reboots; only zapper_iot (and muxpi) opt in.
+        """
+        self.assertFalse(DeviceConnector.MANAGE_DUT_POWER_DURING_REBOOT)
+
     def test_get_credentials(self) -> None:
         connector = DeviceConnector({"control_host": "zapper-host"})
         connector.job_data = {}

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -222,13 +222,47 @@ class TestPreProvisionHook:
 
         mock_power_cycle.assert_called_once()
 
-    def test_passes_dut_power_scripts(self, mocker):
-        """Test hook passes DUT power scripts to DefaultControlHost."""
+    def test_ignores_dut_power_scripts_when_not_opted_in(self, mocker):
+        """Test hook does not pass DUT power scripts for connectors that
+        do not set MANAGE_DUT_POWER_DURING_REBOOT, even when configured.
+        """
         mocker.patch("builtins.open", mocker.mock_open())
         mock_control_host = mocker.patch(
             "testflinger_device_connectors.devices.DefaultControlHost"
         )
         device = DefaultDevice(
+            {
+                "device_ip": "1.1.1.1",
+                "control_host": "control-host",
+                "control_host_reboot_script": ["reboot-cmd"],
+                "poweroff_script": ["poweroff-cmd"],
+                "poweron_script": ["poweron-cmd"],
+            }
+        )
+
+        device.pre_provision_hook()
+
+        mock_control_host.assert_called_once_with(
+            "control-host",
+            ["reboot-cmd"],
+            poweroff_script=[],
+            poweron_script=[],
+        )
+        mock_control_host.return_value.power_cycle.assert_called_once()
+
+    def test_passes_dut_power_scripts_when_opted_in(self, mocker):
+        """Test hook passes DUT power scripts to DefaultControlHost for
+        connectors that set MANAGE_DUT_POWER_DURING_REBOOT.
+        """
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_control_host = mocker.patch(
+            "testflinger_device_connectors.devices.DefaultControlHost"
+        )
+
+        class _PowerManagingDevice(DefaultDevice):
+            MANAGE_DUT_POWER_DURING_REBOOT = True
+
+        device = _PowerManagingDevice(
             {
                 "device_ip": "1.1.1.1",
                 "control_host": "control-host",

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -13,6 +13,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 """Tests for the devices module."""
 
+import logging
 import subprocess
 import time
 from importlib import import_module
@@ -280,6 +281,34 @@ class TestPreProvisionHook:
             poweroff_script=["poweroff-cmd"],
             poweron_script=["poweron-cmd"],
         )
+        mock_control_host.return_value.power_cycle.assert_called_once()
+
+    def test_warns_when_opted_in_without_dut_power_scripts(
+        self, mocker, caplog
+    ):
+        """Test hook warns when a connector that manages DUT power has no
+        DUT power scripts configured, and still power cycles.
+        """
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_control_host = mocker.patch(
+            "testflinger_device_connectors.devices.DefaultControlHost"
+        )
+
+        class _PowerManagingDevice(DefaultDevice):
+            MANAGE_DUT_POWER_DURING_REBOOT = True
+
+        device = _PowerManagingDevice(
+            {
+                "device_ip": "1.1.1.1",
+                "control_host": "control-host",
+                "control_host_reboot_script": ["reboot-cmd"],
+            }
+        )
+
+        with caplog.at_level(logging.WARNING):
+            device.pre_provision_hook()
+
+        assert "DUT may stay powered" in caplog.text
         mock_control_host.return_value.power_cycle.assert_called_once()
 
     def test_skipped_when_env_var_set(self, mocker, monkeypatch):

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -148,6 +148,19 @@ class TestRebootControlHost:
 
         assert mock_subprocess.call_count == 2
 
+    def test_dut_power_noop_without_scripts(self, mocker, caplog):
+        """Without DUT power scripts (connector not opted in), poweroff_dut/
+        poweron_dut neither run commands nor log that they're running.
+        """
+        mock_subprocess = mocker.patch("subprocess.run")
+
+        with caplog.at_level(logging.INFO):
+            DefaultControlHost("host").poweroff_dut()
+            DefaultControlHost("host").poweron_dut()
+
+        mock_subprocess.assert_not_called()
+        assert "Running" not in caplog.text
+
     def test_reboot_control_host_called_process_error(self, mocker):
         """Test reboot handles CalledProcessError gracefully."""
         error = subprocess.CalledProcessError(1, "cmd1")

--- a/device-connectors/tests/test_devices.py
+++ b/device-connectors/tests/test_devices.py
@@ -222,6 +222,32 @@ class TestPreProvisionHook:
 
         mock_power_cycle.assert_called_once()
 
+    def test_passes_dut_power_scripts(self, mocker):
+        """Test hook passes DUT power scripts to DefaultControlHost."""
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_control_host = mocker.patch(
+            "testflinger_device_connectors.devices.DefaultControlHost"
+        )
+        device = DefaultDevice(
+            {
+                "device_ip": "1.1.1.1",
+                "control_host": "control-host",
+                "control_host_reboot_script": ["reboot-cmd"],
+                "poweroff_script": ["poweroff-cmd"],
+                "poweron_script": ["poweron-cmd"],
+            }
+        )
+
+        device.pre_provision_hook()
+
+        mock_control_host.assert_called_once_with(
+            "control-host",
+            ["reboot-cmd"],
+            poweroff_script=["poweroff-cmd"],
+            poweron_script=["poweron-cmd"],
+        )
+        mock_control_host.return_value.power_cycle.assert_called_once()
+
     def test_skipped_when_env_var_set(self, mocker, monkeypatch):
         """Test hook skips power cycle when env var is set."""
         monkeypatch.setenv("DISABLE_CONTROL_HOST_POWERCYCLE", "1")
@@ -265,6 +291,31 @@ class TestDefaultControlHostPowerCycle:
         mock_wait_offline.assert_called_once_with(host._check_ping, 30)
         mock_reboot.assert_called_once()
         mock_wait_ready.assert_called_once_with(timeout=300)
+
+    def test_power_cycle_runs_dut_power_scripts_around_reboot(self, mocker):
+        """Test DUT stays off while the control host is rebooted."""
+        mocker.patch.object(time, "sleep")
+        mock_post = mocker.patch.object(requests, "post")
+        mock_post.return_value.raise_for_status = Mock()
+        mocker.patch.object(DefaultControlHost, "wait_offline")
+        mocker.patch.object(DefaultControlHost, "wait_ready")
+        mock_run_script = mocker.patch.object(
+            DefaultControlHost, "_run_script"
+        )
+        host = DefaultControlHost(
+            "control-host",
+            ["reboot-cmd"],
+            poweroff_script=["poweroff-cmd"],
+            poweron_script=["poweron-cmd"],
+        )
+
+        host.power_cycle()
+
+        assert mock_run_script.call_args_list == [
+            mocker.call(["poweroff-cmd"], "DUT power-off"),
+            mocker.call(["reboot-cmd"], "control host reboot"),
+            mocker.call(["poweron-cmd"], "DUT power-on"),
+        ]
 
     def test_ssh_fallback_host_already_up(self, mocker):
         """Test ssh_fallback skips reboot when host is reachable."""

--- a/docs/reference/device-connector-conf.rst
+++ b/docs/reference/device-connector-conf.rst
@@ -24,10 +24,10 @@ The configuration options listed below are available for all device connectors u
      - List of commands that can be executed to hard reboot the device
    * - ``poweroff_script``
      - all
-     - (optional) List of commands that can be executed to power off the device
+     - (optional) List of commands to power off the DUT; only used together with ``poweron_script`` by connectors that manage DUT power during control-host reboot
    * - ``poweron_script``
      - all
-     - (optional) List of commands that can be executed to power on the device
+     - (optional) List of commands to power on the DUT; only used together with ``poweroff_script`` by connectors that manage DUT power during control-host reboot
    * - ``serial_host``
      - all 
      - (optional) ``ser2net`` host for capturing serial output

--- a/docs/reference/device-connector-conf.rst
+++ b/docs/reference/device-connector-conf.rst
@@ -22,6 +22,12 @@ The configuration options listed below are available for all device connectors u
    * - ``reboot_script``
      - all 
      - List of commands that can be executed to hard reboot the device
+   * - ``poweroff_script``
+     - all
+     - (optional) List of commands that can be executed to power off the device
+   * - ``poweron_script``
+     - all
+     - (optional) List of commands that can be executed to power on the device
    * - ``serial_host``
      - all 
      - (optional) ``ser2net`` host for capturing serial output

--- a/docs/reference/device-connector-types.rst
+++ b/docs/reference/device-connector-types.rst
@@ -97,12 +97,12 @@ The ``maas2`` device connector supports the following ``provision_data`` keys:
      - Specify a kernel to use during deployment. This is the name of the
        kernel as it appears in the MAAS web UI and must already be imported into MAAS.
        For more information, see
-       `MAAS documentation: Set a specific kernel <https://maas.io/docs/about-machine-customization#p-17465-custom-ubuntu-kernels>`_.
+       `MAAS documentation: Set a specific kernel <https://maas.io/docs/about-machine-customization#kernel-choices>`_.
        on this topic
    * - ``user_data``
      - A string containing base64 encoded cloud-init user data to be used for provisioning.
        For more information, see
-       `MAAS documentation: Pre-seed cloud-init <https://maas.io/docs/about-machine-customization#p-17465-pre-seeding>`_.
+       `MAAS documentation: Pre-seed cloud-init <https://maas.io/docs/about-machine-customization#preseeding>`_.
        on this topic
    * - ``disks``
      - Specify a custom disk configuration for the machine. For more information, see the
@@ -112,7 +112,7 @@ The ``maas2`` device connector supports the following ``provision_data`` keys:
        is supported only with MAAS 3.5.0 and later; on older MAAS versions this
        setting is ignored. For more information, see `MAAS documentation:
        Ephemeral deployment
-       <https://canonical.com/maas/docs/about-deploying-machines#p-17464-ephemeral-os-deployments-maas-35>`_.
+       <https://canonical.com/maas/docs/about-deploying-machines#ephemeral-os-deployments>`_.
 
 
 .. _muxpi:


### PR DESCRIPTION
## Description

We identified issues with provisioning if the control_host is rebooted while the DUT is off. Mostly IoT devices.

This is pending a change in the configuration file, introducing poweroff_ and poweron_ scripts.

## Resolved issues

Some connectors are not happy with the control-host reboot.

## Documentation

N/A

## Web service API changes

No

## Tests

oem_autoinstall (no dut reboot)
```
uv run testflinger-device-connector oem_autoinstall provision -c ./rpi5b8g002-remote.yaml local.json                       
2026-06-10 13:01:56,722 rpi5b8g-002 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-06-10 13:01:56,722 rpi5b8g-002 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-06-10 13:02:28,313 rpi5b8g-002 INFO: DEVICE CONNECTOR: Running control host reboot script
2026-06-10 13:02:28,313 rpi5b8g-002 INFO: DEVICE CONNECTOR: Executing: ssh JumpHostL1 ssh agent6 'snmpset -c private -v 2c <redacted> i 2'
2026-06-10 13:02:33,505 rpi5b8g-002 INFO: DEVICE CONNECTOR: Executing: sleep 5
2026-06-10 13:02:38,511 rpi5b8g-002 INFO: DEVICE CONNECTOR: Executing: ssh JumpHostL1 ssh agent6 'snmpset -c private -v 2c <redacted> i 1'
2026-06-10 13:02:43,718 rpi5b8g-002 INFO: DEVICE CONNECTOR: Waiting for the REST API on control host  <redacted> 
```

muxpi (dut kept off)
```
uv run testflinger-device-connector muxpi provision -c ./rpi5b8g002-remote.yaml l
ocal.json                                                                                                                            
2026-06-10 12:51:16,182 rpi5b8g-002 INFO: DEVICE CONNECTOR: Running pre-provision hook                                               
2026-06-10 12:51:16,182 rpi5b8g-002 INFO: DEVICE CONNECTOR: Running DUT power-off script                                             
2026-06-10 12:51:16,182 rpi5b8g-002 INFO: DEVICE CONNECTOR: Executing: ssh JumpHostL1 ssh agent6 'snmpset -c private -v2c  <redacted> i 0'                                                                                          
2026-06-10 12:51:21,011 rpi5b8g-002 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.                                 
2026-06-10 12:51:52,399 rpi5b8g-002 INFO: DEVICE CONNECTOR: Running control host reboot script                                       
2026-06-10 12:51:52,399 rpi5b8g-002 INFO: DEVICE CONNECTOR: Executing: ssh JumpHostL1 ssh agent6 'snmpset -c private -v 2c  <redacted> i 2'                                                                                                
2026-06-10 12:51:57,444 rpi5b8g-002 INFO: DEVICE CONNECTOR: Executing: sleep 5                                                       
2026-06-10 12:52:02,450 rpi5b8g-002 INFO: DEVICE CONNECTOR: Executing: ssh JumpHostL1 ssh agent6 'snmpset -c private -v 2c  <redacted> i 1'                                                                                                
2026-06-10 12:52:08,013 rpi5b8g-002 INFO: DEVICE CONNECTOR: Waiting for the REST API on control host  <redacted>                 
2026-06-10 12:53:16,929 rpi5b8g-002 INFO: DEVICE CONNECTOR: Running DUT power-on script                                              
2026-06-10 12:53:16,929 rpi5b8g-002 INFO: DEVICE CONNECTOR: Executing: ssh JumpHostL1 ssh agent6 'snmpset -c private -v2c <redacted>  i 1'  
```

