### PR TITLE
docs: update tutorial status filter

### DIFF
--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -120,7 +120,7 @@ Run the following command in the terminal to retrieve the available job queues t
 .. code-block:: shell
 
   $ testflinger list-agents \
-  --filter-status=online,^provision,^reserve,^testing \
+  --filter-status=online,^provision,^reserve,^test \
   --filter-provision-type=maas \
   --filter-queue "intel" \
   --fields name,status,queues


### PR DESCRIPTION
## Summary
- Update the tutorial `list-agents` example to use `^test` instead of the outdated `^testing` status filter.

## Tests
- `git diff --check`
- Text check: verified `^testing` is no longer present and the updated filter appears once
- `make -C docs html`

Fixes #1112