### PR TITLE
feat(server): restrict UI views if OIDC is enabled

### DIFF
--- a/server/src/testflinger/oidc/views.py
+++ b/server/src/testflinger/oidc/views.py
@@ -15,12 +15,12 @@
 #
 """OIDC related views for authenticated application."""
 
+from apiflask import APIBlueprint
 from authlib.integrations.base_client.errors import (
     MismatchingStateError,
     OAuthError,
 )
 from flask import (
-    Blueprint,
     current_app,
     redirect,
     request,
@@ -31,7 +31,7 @@ from flask import (
 from testflinger.database import register_web_client
 from testflinger.owasp import OWASPLogger
 
-oidc_views = Blueprint("oidc", __name__)
+oidc_views = APIBlueprint("oidc", __name__, enable_openapi=False)
 
 
 @oidc_views.route("/callback")

--- a/server/src/testflinger/templates/401_unauthorized.html
+++ b/server/src/testflinger/templates/401_unauthorized.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% set title = "Unauthorized" %}
+{% block content %}
+  <div class="row">
+    <h1>401 Unauthorized</h1>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      {% block main %}
+        <p class="large">Sorry, you need to sign in to access this page.</p>
+      {% endblock main %}
+    </div>
+  </div>
+{% endblock content %}

--- a/server/src/testflinger/templates/401_unauthorized.html
+++ b/server/src/testflinger/templates/401_unauthorized.html
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-12">
       {% block main %}
-        <p class="large">Sorry, you need to sign in to access this page.</p>
+        <p class="large">You need to sign in to access this page.</p>
       {% endblock main %}
     </div>
   </div>

--- a/server/src/testflinger/views.py
+++ b/server/src/testflinger/views.py
@@ -18,8 +18,8 @@
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
+from apiflask import APIBlueprint
 from flask import (
-    Blueprint,
     current_app,
     make_response,
     render_template,
@@ -32,7 +32,7 @@ from testflinger import database
 from testflinger.database import mongo
 from testflinger.logs import MongoLogHandler
 
-views = Blueprint("testflinger", __name__)
+views = APIBlueprint("testflinger", __name__, enable_openapi=False)
 
 
 @views.before_request

--- a/server/src/testflinger/views.py
+++ b/server/src/testflinger/views.py
@@ -20,9 +20,11 @@ from http import HTTPStatus
 
 from flask import (
     Blueprint,
+    current_app,
     make_response,
     render_template,
     request,
+    session,
 )
 from prometheus_client import generate_latest
 
@@ -31,6 +33,19 @@ from testflinger.database import mongo
 from testflinger.logs import MongoLogHandler
 
 views = Blueprint("testflinger", __name__)
+
+
+@views.before_request
+def require_login():
+    """Block UI views when OIDC is enabled and no user is logged in."""
+    if current_app.oauth is None or request.endpoint == "testflinger.home":
+        return None
+    if "user" not in session:
+        return make_response(
+            render_template("401_unauthorized.html"),
+            HTTPStatus.UNAUTHORIZED,
+        )
+    return None
 
 
 @views.route("/")

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -18,9 +18,11 @@
 import re
 import uuid
 from datetime import datetime, timezone
+from http import HTTPStatus
 from unittest.mock import patch
 
 import mongomock
+import pytest
 from testflinger_common.enums import LogType, TestPhase
 
 from testflinger.views import agent_detail, job_detail, queues_data
@@ -307,3 +309,35 @@ def test_job_results_mongo_logs(testapp):
     # Check that phase statuses are present
     assert "Exit Status:</span> 0" in html
     assert "Exit Status:</span> 1" in html
+
+
+@pytest.mark.parametrize("endpoint", ["/agents", "/jobs", "/queues"])
+def test_unauthorized_view_access(oidc_app, endpoint):
+    """Test 401 error when OIDC is enabled but user is not authenticated."""
+    app, _ = oidc_app
+    with app.test_client() as client:
+        response = client.get(endpoint)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert "Sorry, you need to sign in to access this page." in str(
+        response.data
+    )
+
+
+@pytest.mark.parametrize("endpoint", ["/agents", "/jobs", "/queues"])
+def test_authorized_view_access(oidc_app, endpoint):
+    """Test views are available when OIDC is enabled and user authenticated."""
+    app, _ = oidc_app
+    mongo = mongomock.MongoClient()
+    with app.test_client() as client, patch("testflinger.views.mongo", mongo):
+        with client.session_transaction() as sess:
+            sess["user"] = "testuser"
+        response = client.get(endpoint)
+    assert response.status_code == HTTPStatus.OK
+
+
+def test_home_accessible_without_auth_when_oidc_enabled(oidc_app):
+    """Test home page is accessible even when OIDC is enabled and no user."""
+    app, _ = oidc_app
+    with app.test_client() as client:
+        response = client.get("/")
+    assert response.status_code == HTTPStatus.OK

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -318,9 +318,7 @@ def test_unauthorized_view_access(oidc_app, endpoint):
     with app.test_client() as client:
         response = client.get(endpoint)
     assert response.status_code == HTTPStatus.UNAUTHORIZED
-    assert "Sorry, you need to sign in to access this page." in str(
-        response.data
-    )
+    assert "You need to sign in to access this page." in str(response.data)
 
 
 @pytest.mark.parametrize("endpoint", ["/agents", "/jobs", "/queues"])


### PR DESCRIPTION
## Description
This restricts the UI views if OIDC is enabled. Users trying to reach any UI endpoint without authentication will be redirected to a generic 401 page. The Log In button will be always in the header. 

Flask's `Blueprint` is also now replaced by APIFlask `APIBlueprint` given the `before_request` had a problem while generating the schema. `APIBlueprint` extends `Blueprint`  so its a 1:1 replacement.

> [!NOTE]
This does not restrict the API endpoint as this is handled separately. A follow up PR should close this gap in order to enable full app restriction. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-1171](https://warthogs.atlassian.net/browse/CERTTF-1171)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests for this behavior

Also, tested locally:

https://github.com/user-attachments/assets/e6442adf-0949-42d9-97f9-c1fcb0a7eac8

API remains accessible as the views are the only ones restricted, e.g.:
```
curl http://localhost:5000/v1/agents/data
[{"name": "agent0", "queues": ["test_queue7", "test_queue6", "test_queue4", "test_queue2", "test_queue9", "test_queue3", "test_queue5"], "state": "waiting", "updated_at": {"$date": "2026-06-09T21:43:28.600Z"}, "provision_streak_count": 1, "provision_streak_type": "fail", "restricted_to": {}}, {"name": "agent1", "queues": ["test_queue4", "test_queue5", "test_queue3", "test_queue2", "test_queue9", "test_queue7", "test_queue8", "test_queue1", "test_queue0"], "state": "provision", "updated_at": {"$date": "2026-06-09T21:43:28.630Z"}, "provision_streak_count": 1, "provision_streak_type": "pass", "restricted_to": {}}, {"name": "agent2", "queues": ["test_queue4", "test_queue2", "test_queue8", "test_queue3", "test_queue5", "test_queue0", "test_queue9", "test_queue6"], "state": "test", "updated_at": {"$date": "2026-06-09T21:43:28.645Z"}, "provision_streak_count": 1, "provision_streak_type": "pass", "restricted_to": {}}, {"name": "agent3", "queues": ["test_queue1", "test_queue2", "test_queue8", "test_queue4"], "state": "waiting", "updated_at": {"$date": "2026-06-09T21:43:28.657Z"}, "provision_streak_count": 1, "provision_streak_type": "fail", "restricted_to": {}}, {"name": "agent4", "queues": ["test_queue6", "test_queue0", "test_queue2", "test_queue9"], "state": "waiting", "updated_at": {"$date": "2026-06-09T21:43:28.675Z"}, "provision_streak_count": 1, "provision_streak_type": "pass", "restricted_to": {}}, {"name": "agent5", "queues": ["test_queue8", "test_queue2"], "state": "test", "updated_at": {"$date": "2026-06-09T21:43:28.697Z"}, "provision_streak_count": 1, "provision_streak_type": "fail", "restricted_to": {}}, {"name": "agent6", "queues": ["test_queue1", "test_queue2", "test_queue6", "test_queue7"], "state": "provision", "updated_at": {"$date": "2026-06-09T21:43:28.715Z"}, "provision_streak_count": 1, "provision_streak_type": "pass", "restricted_to": {}}, {"name": "agent7", "queues": ["test_queue1", "test_queue8", "test_queue9", "test_queue5", "test_queue6", "test_queue7", "test_queue0", "test_queue2"], "state": "waiting", "updated_at": {"$date": "2026-06-09T21:43:28.734Z"}, "provision_streak_count": 1, "provision_streak_type": "fail", "restricted_to": {}}, {"name": "agent8", "queues": ["test_queue6", "test_queue0", "test_queue8", "test_queue4", "test_queue7", "test_queue1", "test_queue3", "test_queue5", "test_queue2", "test_queue9"], "state": "test", "updated_at": {"$date": "2026-06-09T21:43:28.748Z"}, "provision_streak_count": 1, "provision_streak_type": "pass", "restricted_to": {}}, {"name": "agent9", "queues": ["test_queue5", "test_queue9", "test_queue1"], "state": "waiting", "updated_at": {"$date": "2026-06-09T21:43:28.762Z"}, "provision_streak_count": 1, "provision_streak_type": "fail", "restricted_to": {}}]
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-1171]: https://warthogs.atlassian.net/browse/CERTTF-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ