### PR TITLE
feat(server): add "Copy job YAML" button to dashboard job detail

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,107 @@
+# Handoff: dashboard "Copy job YAML" feature
+
+Context dump for another agent/session to continue from. Working dir:
+`/home/mz2/Developer/testflinger` (server subproject under `server/`).
+
+## Goal
+
+Add a copy-to-clipboard button to the Testflinger dashboard job detail page
+that copies a submittable job-definition YAML matching the provisioning/test
+data being viewed.
+
+## Status: DONE + pushed + draft PR open
+
+- Branch: `feat/dashboard-copy-job-yaml`
+- Commit: `1a7acca` `feat(server): add "Copy job YAML" button to dashboard job detail`
+  - Authored solely by Matias Piipari (no Claude attribution, by request).
+  - **Unsigned** — repo has GPG signing on, but pinentry timed out
+    non-interactively. Re-sign if CI enforces it:
+    `git commit --amend -S --no-edit && git push -f fork feat/dashboard-copy-job-yaml`
+- Remotes: `origin` = `canonical/testflinger` (no write access for this user);
+  `fork` = `git@github.com:mz2/testflinger.git` (created during this work).
+  Branch pushed to `fork`.
+- Draft PR: https://github.com/canonical/testflinger/pull/1141
+  (`mz2:feat/dashboard-copy-job-yaml` -> `canonical:main`).
+
+## What changed
+
+Feature:
+- `server/src/testflinger/views.py` — `build_job_yaml(job_data)` reconstructs a
+  submittable job def from the stored `job_data` (only the `Job` schema
+  top-level fields: `job_queue`, timeouts, `provision_data`,
+  `firmware_update_data`, `test_data`, `allocate_data`, `reserve_data`), dumped
+  with a `yaml.SafeDumper` subclass whose str representer renders multiline
+  strings (e.g. `test_cmds`) as literal `|` blocks. `job_detail` passes
+  `job_yaml=` to the template.
+- `server/src/testflinger/templates/job_detail.html` — "Copy job YAML" button
+  (`p-button--base has-icon`, `data-copy-target="#job-yaml-content"`) in a
+  `.section-heading-bar` flex row next to the "Job Definition" heading; plus a
+  hidden `<div id="job-yaml-content" hidden>{{- job_yaml -}}</div>` payload.
+- `server/src/testflinger/static/assets/js/clipboard.js` (NEW) — generic
+  handler: any `[data-copy-target]` copies the referenced element's
+  `textContent` via `navigator.clipboard.writeText`, flips label to "Copied!"
+  for 2s. Reading `textContent` un-escapes the autoescaped YAML (no XSS).
+- `server/src/testflinger/templates/base.html` — loads `clipboard.js`.
+- `server/src/testflinger/static/assets/css/testflinger.css` —
+  `.section-heading-bar` (flex, space-between).
+- `server/tests/test_views.py` — `test_build_job_yaml` and
+  `test_job_detail_has_copy_button`.
+
+Local-dev conveniences (so the change is testable without rebuilds):
+- `server/docker-compose.yml` — bind-mount `./src:/srv/testflinger/src`
+  (project is installed editable via `uv sync`, so this makes edits live; only
+  `src/` is mounted so the image `.venv` is untouched) and env
+  `TEMPLATES_AUTO_RELOAD: "true"`.
+- `server/src/testflinger/application.py` — env-guarded (default off)
+  `tf_app.config["TEMPLATES_AUTO_RELOAD"]` for Jinja template auto-reload.
+- `server/devel/create_sample_data.py` — seeded jobs now include
+  `provision_data` (module const `SAMPLE_PROVISION_DATA`) so the copied YAML is
+  representative. All three sample values validated against the real `Job`
+  schema.
+
+## How to test
+
+Unit (no backend):
+```
+cd server && tox -e unit          # or: pytest tests/test_views.py -k "build_job_yaml or copy_button"
+```
+All `test_views.py` pass (10/10 at handoff).
+
+End-to-end:
+```
+cd server
+docker compose up --build         # FIRST run needs --build to bake in application.py + mount
+# seed jobs (script only needs `requests`):
+uv run --no-project --with requests devel/create_sample_data.py
+#   or inside the container: docker compose exec testflinger python devel/create_sample_data.py
+```
+Then open http://localhost:5000/jobs -> a job -> click "Copy job YAML", paste,
+confirm YAML matches the Provision/Test tabs. Button flips to "Copied!".
+
+Notes/gotchas:
+- After the first `--build`, view/template/JS/CSS edits hot-reload (refresh;
+  `.py` triggers gunicorn `--reload` in a couple seconds). No more rebuilds.
+- `navigator.clipboard` needs a secure context; `http://localhost` qualifies.
+- `docker compose` here is backed by podman-compose (works; file validated).
+
+## Environment quirks (this dev box)
+
+- Host is NixOS. `uv`-downloaded CPython and prebuilt binaries (ruff, uv-build)
+  fail with "Could not start dynamically linked executable". Use the nix python
+  (`/home/mz2/.nix-profile/bin/python3`). `uv pip install -e .` fails (uv_build
+  backend can't run); a throwaway venv at `/tmp/tfvenv` was used for tests with
+  `PYTHONPATH="src:../common/src"` and deps installed individually
+  (note: pin `marshmallow<4`, the codebase uses the removed `default=` field
+  kwarg). `ruff` could NOT be run here — Python lint was checked manually
+  (79-char limit, docstrings, `yaml.safe_*`); CI will run ruff.
+- Templates were checked with `djlint` (format + lint clean).
+
+## Open follow-ups
+
+- PR "Resolved issues" is "None" — add a Jira (CERTTF-…)/GitHub issue if one
+  exists.
+- Decide whether the local-dev changes (compose mount, TEMPLATES_AUTO_RELOAD,
+  sample-data provision_data) belong in this PR or a separate one.
+- Re-sign the commit if signed commits are required.
+- This HANDOFF.md is committed on the branch by request; remove before merge if
+  it shouldn't land in canonical.

--- a/server/devel/create_sample_data.py
+++ b/server/devel/create_sample_data.py
@@ -126,6 +126,15 @@ class AgentDataGenerator:  # pylint: disable=too-few-public-methods
             yield (f"{self.prefix}{agent_num}", agent_data)
 
 
+# Representative provision_data sections so generated jobs exercise the
+# "Copy job YAML" view with a realistic image reference.
+SAMPLE_PROVISION_DATA = (
+    {"url": "http://cdimage.example/ubuntu-22.04-arm64.img.xz"},
+    {"url": "http://cdimage.example/ubuntu-24.04-amd64.img.xz"},
+    {"distro": "jammy"},
+)
+
+
 class JobDataGenerator:  # pylint: disable=too-few-public-methods
     """Job data generator"""
 
@@ -149,6 +158,7 @@ class JobDataGenerator:  # pylint: disable=too-few-public-methods
         for _ in range(self.num_jobs):
             yield {
                 "job_queue": random.choice(self.queue_list),
+                "provision_data": random.choice(SAMPLE_PROVISION_DATA),
                 "test_data": {"test_cmds": "echo test"},
             }
 

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -28,7 +28,16 @@ services:
       OIDC_CLIENT_ID: testflinger-client
       OIDC_CLIENT_SECRET: my-oidc-secret
       OIDC_PROVIDER_ISSUER: http://dex:5556/dex
+      # Reload Jinja templates on every request for local development so
+      # template edits show up without restarting/rebuilding.
+      TEMPLATES_AUTO_RELOAD: "true"
     command: --reload
+    # Mount the source over the image copy so edits to views/templates/static
+    # are picked up live (gunicorn --reload restarts on .py changes; static
+    # files and auto-reloaded templates are served straight from disk).
+    # Only src/ is mounted, so the image's .venv is left untouched.
+    volumes:
+      - ./src:/srv/testflinger/src
     ports:
       - 5000:5000
     depends_on:

--- a/server/src/testflinger/application.py
+++ b/server/src/testflinger/application.py
@@ -62,6 +62,10 @@ def create_flask_app(config=None, secrets_store=None):
 
     tf_app.config["PROPAGATE_EXCEPTIONS"] = True
 
+    # Opt-in (off by default) Jinja template auto-reload for local development.
+    if os.environ.get("TEMPLATES_AUTO_RELOAD", "false").lower() == "true":
+        tf_app.config["TEMPLATES_AUTO_RELOAD"] = True
+
     # Return datetime objects as RFC3339/ISO8601 strings
     tf_app.json = ISODatetimeProvider(tf_app)
 

--- a/server/src/testflinger/static/assets/css/testflinger.css
+++ b/server/src/testflinger/static/assets/css/testflinger.css
@@ -103,3 +103,10 @@ main {
 .p-navigation__nav {
     overflow: visible !important;
 }
+
+/* Heading row with a trailing action button (e.g. copy job YAML) */
+.section-heading-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}

--- a/server/src/testflinger/static/assets/js/clipboard.js
+++ b/server/src/testflinger/static/assets/js/clipboard.js
@@ -1,0 +1,52 @@
+/**
+ * Copy-to-clipboard buttons.
+ *
+ * Any element carrying a `data-copy-target` attribute copies the textContent
+ * of the element matched by that selector to the clipboard when clicked, and
+ * briefly shows confirmation feedback.
+ */
+
+/**
+  Provide brief "Copied!" feedback on a button before restoring its label
+  @param {HTMLElement} button the button that was clicked
+*/
+function showCopyFeedback(button) {
+  const label = button.querySelector('span');
+  if (!label) {
+    return;
+  }
+  const original = label.textContent;
+  label.textContent = 'Copied!';
+  button.disabled = true;
+  setTimeout(function() {
+    label.textContent = original;
+    button.disabled = false;
+  }, 2000);
+}
+
+/**
+  Attach click handlers to all copy-to-clipboard buttons on the page
+*/
+function initCopyButtons() {
+  const buttons = [].slice.call(
+    document.querySelectorAll('[data-copy-target]')
+  );
+
+  buttons.forEach(function(button) {
+    button.addEventListener('click', function() {
+      const target = document.querySelector(
+        button.getAttribute('data-copy-target')
+      );
+      if (!target || !navigator.clipboard) {
+        return;
+      }
+      navigator.clipboard.writeText(target.textContent).then(function() {
+        showCopyFeedback(button);
+      });
+    });
+  });
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', initCopyButtons);
+}

--- a/server/src/testflinger/templates/base.html
+++ b/server/src/testflinger/templates/base.html
@@ -41,5 +41,7 @@
             src="{{ url_for('static', filename='assets/js/navigation.js') }}"></script>
     <script type="text/javascript"
             src="{{ url_for('static', filename='assets/js/tabs.js') }}"></script>
+    <script type="text/javascript"
+            src="{{ url_for('static', filename='assets/js/clipboard.js') }}"></script>
   </body>
 </html>

--- a/server/src/testflinger/templates/job_detail.html
+++ b/server/src/testflinger/templates/job_detail.html
@@ -25,11 +25,21 @@
       </tr>
     </tbody>
   </table>
-  <h2 class="p-muted-heading" id="job-definition">
-    <a href="#job-definition"
-       class="p-link--anchor-heading"
-       aria-label="Link to Job Definition section">Job Definition</a>
-  </h2>
+  <div class="section-heading-bar">
+    <h2 class="p-muted-heading" id="job-definition">
+      <a href="#job-definition"
+         class="p-link--anchor-heading"
+         aria-label="Link to Job Definition section">Job Definition</a>
+    </h2>
+    <button class="p-button--base has-icon"
+            type="button"
+            data-copy-target="#job-yaml-content"
+            aria-label="Copy job YAML to clipboard">
+      <i class="p-icon--copy"></i>
+      <span>Copy job YAML</span>
+    </button>
+  </div>
+  <div id="job-yaml-content" hidden>{{- job_yaml -}}</div>
   <div class="p-tabs">
     <div class="p-tabs__list" role="tablist" aria-label="Job Definition tabs">
       <div class="p-tabs__item">

--- a/server/src/testflinger/views.py
+++ b/server/src/testflinger/views.py
@@ -18,6 +18,7 @@
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
+import yaml
 from flask import (
     Blueprint,
     make_response,
@@ -31,6 +32,51 @@ from testflinger.database import mongo
 from testflinger.logs import MongoLogHandler
 
 views = Blueprint("testflinger", __name__)
+
+# Top-level fields that make up a submittable job definition, in the order
+# they should appear in the generated YAML (mirrors api.schemas.Job).
+JOB_DEFINITION_FIELDS = (
+    "job_queue",
+    "global_timeout",
+    "output_timeout",
+    "allocation_timeout",
+    "provision_data",
+    "firmware_update_data",
+    "test_data",
+    "allocate_data",
+    "reserve_data",
+)
+
+
+class _JobYamlDumper(yaml.SafeDumper):
+    """YAML dumper that renders multiline strings as literal blocks."""
+
+
+def _str_representer(dumper, data):
+    """Represent multiline strings (e.g. test_cmds) as literal blocks."""
+    if "\n" in data:
+        return dumper.represent_scalar(
+            "tag:yaml.org,2002:str", data, style="|"
+        )
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_JobYamlDumper.add_representer(str, _str_representer)
+
+
+def build_job_yaml(job_data):
+    """Build a submittable job-definition YAML from stored job data."""
+    definition = {
+        field: job_data[field]
+        for field in JOB_DEFINITION_FIELDS
+        if field in job_data
+    }
+    return yaml.dump(
+        definition,
+        Dumper=_JobYamlDumper,
+        default_flow_style=False,
+        sort_keys=False,
+    )
 
 
 @views.route("/")
@@ -157,7 +203,8 @@ def job_detail(job_id):
         ):
             log_handler = MongoLogHandler(mongo)
             log_handler.format_logs_as_results(job_id, result_data)
-    return render_template("job_detail.html", job=job_data)
+    job_yaml = build_job_yaml(job_data.get("job_data", {}))
+    return render_template("job_detail.html", job=job_data, job_yaml=job_yaml)
 
 
 @views.route("/queues")

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -21,9 +21,15 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 import mongomock
+import yaml
 from testflinger_common.enums import LogType, TestPhase
 
-from testflinger.views import agent_detail, job_detail, queues_data
+from testflinger.views import (
+    agent_detail,
+    build_job_yaml,
+    job_detail,
+    queues_data,
+)
 
 
 def test_queues():
@@ -307,3 +313,52 @@ def test_job_results_mongo_logs(testapp):
     # Check that phase statuses are present
     assert "Exit Status:</span> 0" in html
     assert "Exit Status:</span> 1" in html
+
+
+def test_build_job_yaml():
+    """build_job_yaml produces a submittable, ordered job definition."""
+    job_data = {
+        "job_queue": "queue1",
+        "provision_data": {"distro": "jammy"},
+        "test_data": {"test_cmds": "echo hello\nlsb_release -a\n"},
+        # Runtime-only keys must not leak into the definition
+        "job_id": "should-not-appear",
+    }
+
+    job_yaml = build_job_yaml(job_data)
+
+    parsed = yaml.safe_load(job_yaml)
+    assert parsed == {
+        "job_queue": "queue1",
+        "provision_data": {"distro": "jammy"},
+        "test_data": {"test_cmds": "echo hello\nlsb_release -a\n"},
+    }
+    # job_queue is rendered first, multiline test_cmds use a literal block
+    assert job_yaml.startswith("job_queue: queue1")
+    assert "test_cmds: |" in job_yaml
+    assert "should-not-appear" not in job_yaml
+
+
+def test_job_detail_has_copy_button(testapp):
+    """The job detail view exposes a copy-job-YAML button and payload."""
+    mongo = mongomock.MongoClient()
+    job_id = str(uuid.uuid4())
+    mongo.db.jobs.insert_one(
+        {
+            "job_id": job_id,
+            "created_at": datetime.now(timezone.utc),
+            "job_data": {
+                "job_queue": "queue1",
+                "provision_data": {"distro": "jammy"},
+            },
+            "result_data": {"job_state": "complete"},
+        }
+    )
+    with patch("testflinger.views.mongo", mongo):
+        with testapp.test_request_context():
+            response = job_detail(job_id)
+
+    html = str(response)
+    assert 'data-copy-target="#job-yaml-content"' in html
+    assert 'id="job-yaml-content"' in html
+    assert "job_queue: queue1" in html


### PR DESCRIPTION
## Description

Adds a **Copy job YAML** button to the job detail page that copies a submittable job-definition YAML (`job_queue`, `provision_data`, `firmware_update_data`, `test_data`, …) for the job being viewed. The YAML is reconstructed server-side by `build_job_yaml()` (multiline values such as `test_cmds` rendered as literal blocks) and copied by a small generic `clipboard.js` via `[data-copy-target]`.

Also includes local-dev conveniences for testing the change:
- bind-mount `src/` in `docker-compose.yml` + env-guarded `TEMPLATES_AUTO_RELOAD` so view/template/static edits are picked up without rebuilding the image (default off, prod unaffected).
- `create_sample_data.py` now seeds jobs with `provision_data` so the copied YAML is representative.

## Resolved issues

None.

## Documentation

No public documentation impacted. Unit tests added in `tests/test_views.py` (`build_job_yaml` output + button/payload rendering).

## Web service API changes

None — no new/changed endpoints, no DB queries, no migrations. The new `TEMPLATES_AUTO_RELOAD` env var is local-development only and defaults off.

## Tests

- `tox -e unit` (server).
- Manual: `cd server && docker compose up --build`, then `python devel/create_sample_data.py`, open `http://localhost:5000/jobs`, pick a job, click **Copy job YAML**, and paste to confirm the YAML matches the displayed provision/test data.