### PR TITLE
action/submit: Retry if provision fails

### DIFF
--- a/.github/actions/submit/README.md
+++ b/.github/actions/submit/README.md
@@ -42,17 +42,17 @@ If you wish to define your job inline, you can use the following step:
 
 ### Inputs
 
-| Key                                | Description                                                                                                            | Required | Default                     |
-|------------------------------------|------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
-| `job`                              | Inline YAML contents of a job file.                                                                                    | [^job]   |                             |
-| `job-path`                         | Path to a job file.                                                                                                    | [^job]   |                             |
-| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                                                                                     |          | `false`                     |
-| `dry-run`                          | Don't submit job.                                                                                                      |          | `false`                     |
-| `server`                           | Testflinger server address.                                                                                            |          | `testflinger.canonical.com` |
-| `attachments-relative-to`          | Reference directory for relative attachment paths.                                                                     |          |                             |
-| `client-id`                        | Client ID for jobs requiring authentication.                                                                           | [^auth]  |                             |
-| `secret-key`                       | Secret key for jobs requiring authentication.                                                                          | [^auth]  |                             |
-| `retries`                          | Number of times to retry submitting the job if it failed before completing the provision phase. Requires `poll: true`. |          | `0`                         |
+| Key                                | Description                                                                                                     | Required | Default                     |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
+| `job`                              | Inline YAML contents of a job file.                                                                             | [^job]   |                             |
+| `job-path`                         | Path to a job file.                                                                                             | [^job]   |                             |
+| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                                                                              |          | `false`                     |
+| `dry-run`                          | Don't submit job.                                                                                               |          | `false`                     |
+| `server`                           | Testflinger server address.                                                                                     |          | `testflinger.canonical.com` |
+| `attachments-relative-to`          | Reference directory for relative attachment paths.                                                              |          |                             |
+| `client-id`                        | Client ID for jobs requiring authentication.                                                                    | [^auth]  |                             |
+| `secret-key`                       | Secret key for jobs requiring authentication.                                                                   | [^auth]  |                             |
+| `retries`                          | Number of times to retry submitting the job if it failed before reaching the test phase. Requires `poll: true`. |          | `0`                         |
 
 ### Outputs
 

--- a/.github/actions/submit/README.md
+++ b/.github/actions/submit/README.md
@@ -42,16 +42,18 @@ If you wish to define your job inline, you can use the following step:
 
 ### Inputs
 
-| Key                                | Description                                        | Required | Default                     |
-| ---------------------------------- | -------------------------------------------------- | -------- | --------------------------- |
-| `job`                              | Inline YAML contents of a job file.                | [^job]   |                             |
-| `job-path`                         | Path to a job file.                                | [^job]   |                             |
-| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                 |          | `false`                     |
-| `dry-run`                          | Don't submit job.                                  |          | `false`                     |
-| `server`                           | Testflinger server address.                        |          | `testflinger.canonical.com` |
-| `attachments-relative-to`          | Reference directory for relative attachment paths. |          |                             |
-| `client-id`                        | Client ID for jobs requiring authentication.       | [^auth]  |                             |
-| `secret-key`                       | Secret key for jobs requiring authentication.      | [^auth]  |                             |
+| Key                                | Description                                                                                                                                                                    | Required | Default                     |
+|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
+| `job`                              | Inline YAML contents of a job file.                                                                                                                                            | [^job]   |                             |
+| `job-path`                         | Path to a job file.                                                                                                                                                            | [^job]   |                             |
+| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                                                                                                                                             |          | `false`                     |
+| `dry-run`                          | Don't submit job.                                                                                                                                                              |          | `false`                     |
+| `server`                           | Testflinger server address.                                                                                                                                                    |          | `testflinger.canonical.com` |
+| `attachments-relative-to`          | Reference directory for relative attachment paths.                                                                                                                             |          |                             |
+| `client-id`                        | Client ID for jobs requiring authentication.                                                                                                                                   | [^auth]  |                             |
+| `secret-key`                       | Secret key for jobs requiring authentication.                                                                                                                                  | [^auth]  |                             |
+| `provision-max-retries`            | Number of times to retry if the provision phase fails (0 = no retry). Requires `poll: true`.                                                                                   |          | `0`                         |
+| `provision-timeout`                | Maximum time to wait for the provision phase before cancelling the job and submitting it again (e.g. `30m`, `1h`, `3600s`). Leave empty to not impose a timeout in the action. |          |                             |
 
 ### Outputs
 

--- a/.github/actions/submit/README.md
+++ b/.github/actions/submit/README.md
@@ -42,17 +42,17 @@ If you wish to define your job inline, you can use the following step:
 
 ### Inputs
 
-| Key                                | Description                                                                                                     | Required | Default                     |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
-| `job`                              | Inline YAML contents of a job file.                                                                             | [^job]   |                             |
-| `job-path`                         | Path to a job file.                                                                                             | [^job]   |                             |
-| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                                                                              |          | `false`                     |
-| `dry-run`                          | Don't submit job.                                                                                               |          | `false`                     |
-| `server`                           | Testflinger server address.                                                                                     |          | `testflinger.canonical.com` |
-| `attachments-relative-to`          | Reference directory for relative attachment paths.                                                              |          |                             |
-| `client-id`                        | Client ID for jobs requiring authentication.                                                                    | [^auth]  |                             |
-| `secret-key`                       | Secret key for jobs requiring authentication.                                                                   | [^auth]  |                             |
-| `retries`                          | Number of times to retry submitting the job if it failed before reaching the test phase. Requires `poll: true`. |          | `0`                         |
+| Key                                | Description                                                                                                            | Required | Default                     |
+|------------------------------------|------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
+| `job`                              | Inline YAML contents of a job file.                                                                                    | [^job]   |                             |
+| `job-path`                         | Path to a job file.                                                                                                    | [^job]   |                             |
+| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                                                                                     |          | `false`                     |
+| `dry-run`                          | Don't submit job.                                                                                                      |          | `false`                     |
+| `server`                           | Testflinger server address.                                                                                            |          | `testflinger.canonical.com` |
+| `attachments-relative-to`          | Reference directory for relative attachment paths.                                                                     |          |                             |
+| `client-id`                        | Client ID for jobs requiring authentication.                                                                           | [^auth]  |                             |
+| `secret-key`                       | Secret key for jobs requiring authentication.                                                                          | [^auth]  |                             |
+| `retries`                          | Number of times to retry submitting the job if it failed before completing the provision phase. Requires `poll: true`. |          | `0`                         |
 
 ### Outputs
 

--- a/.github/actions/submit/README.md
+++ b/.github/actions/submit/README.md
@@ -42,17 +42,17 @@ If you wish to define your job inline, you can use the following step:
 
 ### Inputs
 
-| Key                                | Description                                                                                                                 | Required | Default                     |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
-| `job`                              | Inline YAML contents of a job file.                                                                                         | [^job]   |                             |
-| `job-path`                         | Path to a job file.                                                                                                         | [^job]   |                             |
-| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                                                                                          |          | `false`                     |
-| `dry-run`                          | Don't submit job.                                                                                                           |          | `false`                     |
-| `server`                           | Testflinger server address.                                                                                                 |          | `testflinger.canonical.com` |
-| `attachments-relative-to`          | Reference directory for relative attachment paths.                                                                          |          |                             |
-| `client-id`                        | Client ID for jobs requiring authentication.                                                                                | [^auth]  |                             |
-| `secret-key`                       | Secret key for jobs requiring authentication.                                                                               | [^auth]  |                             |
-| `provision-max-retries`            | Number of times to retry if the provision phase fails (0 = no retry). Requires `poll: true`.                                |          | `0`                         |
+| Key                                | Description                                                                                                     | Required | Default                     |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
+| `job`                              | Inline YAML contents of a job file.                                                                             | [^job]   |                             |
+| `job-path`                         | Path to a job file.                                                                                             | [^job]   |                             |
+| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                                                                              |          | `false`                     |
+| `dry-run`                          | Don't submit job.                                                                                               |          | `false`                     |
+| `server`                           | Testflinger server address.                                                                                     |          | `testflinger.canonical.com` |
+| `attachments-relative-to`          | Reference directory for relative attachment paths.                                                              |          |                             |
+| `client-id`                        | Client ID for jobs requiring authentication.                                                                    | [^auth]  |                             |
+| `secret-key`                       | Secret key for jobs requiring authentication.                                                                   | [^auth]  |                             |
+| `retries`                          | Number of times to retry submitting the job if it failed before reaching the test phase. Requires `poll: true`. |          | `0`                         |
 
 ### Outputs
 

--- a/.github/actions/submit/README.md
+++ b/.github/actions/submit/README.md
@@ -36,7 +36,7 @@ If you wish to define your job inline, you can use the following step:
 ```
 
 > [!TIP]
-> You can also pin the submit action to an specific version e.g submit@submit/v1.3.1
+> You can also pin the submit action to a specific version e.g submit@submit/v1.3.1
 
 ## API
 
@@ -53,7 +53,6 @@ If you wish to define your job inline, you can use the following step:
 | `client-id`                        | Client ID for jobs requiring authentication.                                                                                | [^auth]  |                             |
 | `secret-key`                       | Secret key for jobs requiring authentication.                                                                               | [^auth]  |                             |
 | `provision-max-retries`            | Number of times to retry if the provision phase fails (0 = no retry). Requires `poll: true`.                                |          | `0`                         |
-| `provision-timeout`                | Maximum time to wait for the provision phase before cancelling the job and submitting it again (e.g. `30m`, `1h`, `3600s`). |          |                             |
 
 ### Outputs
 

--- a/.github/actions/submit/README.md
+++ b/.github/actions/submit/README.md
@@ -42,18 +42,18 @@ If you wish to define your job inline, you can use the following step:
 
 ### Inputs
 
-| Key                                | Description                                                                                                                                                                    | Required | Default                     |
-|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
-| `job`                              | Inline YAML contents of a job file.                                                                                                                                            | [^job]   |                             |
-| `job-path`                         | Path to a job file.                                                                                                                                                            | [^job]   |                             |
-| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                                                                                                                                             |          | `false`                     |
-| `dry-run`                          | Don't submit job.                                                                                                                                                              |          | `false`                     |
-| `server`                           | Testflinger server address.                                                                                                                                                    |          | `testflinger.canonical.com` |
-| `attachments-relative-to`          | Reference directory for relative attachment paths.                                                                                                                             |          |                             |
-| `client-id`                        | Client ID for jobs requiring authentication.                                                                                                                                   | [^auth]  |                             |
-| `secret-key`                       | Secret key for jobs requiring authentication.                                                                                                                                  | [^auth]  |                             |
-| `provision-max-retries`            | Number of times to retry if the provision phase fails (0 = no retry). Requires `poll: true`.                                                                                   |          | `0`                         |
-| `provision-timeout`                | Maximum time to wait for the provision phase before cancelling the job and submitting it again (e.g. `30m`, `1h`, `3600s`). Leave empty to not impose a timeout in the action. |          |                             |
+| Key                                | Description                                                                                                                 | Required | Default                     |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------|
+| `job`                              | Inline YAML contents of a job file.                                                                                         | [^job]   |                             |
+| `job-path`                         | Path to a job file.                                                                                                         | [^job]   |                             |
+| `poll`[^reserve_data][^poll-multi] | Track submitted job to completion.                                                                                          |          | `false`                     |
+| `dry-run`                          | Don't submit job.                                                                                                           |          | `false`                     |
+| `server`                           | Testflinger server address.                                                                                                 |          | `testflinger.canonical.com` |
+| `attachments-relative-to`          | Reference directory for relative attachment paths.                                                                          |          |                             |
+| `client-id`                        | Client ID for jobs requiring authentication.                                                                                | [^auth]  |                             |
+| `secret-key`                       | Secret key for jobs requiring authentication.                                                                               | [^auth]  |                             |
+| `provision-max-retries`            | Number of times to retry if the provision phase fails (0 = no retry). Requires `poll: true`.                                |          | `0`                         |
+| `provision-timeout`                | Maximum time to wait for the provision phase before cancelling the job and submitting it again (e.g. `30m`, `1h`, `3600s`). |          |                             |
 
 ### Outputs
 

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -28,8 +28,8 @@ inputs:
   secret-key:
     description: Secret key for jobs requiring authentication
     required: false
-  provision-max-retries:
-    description: Maximum number of times to retry the job when the provision phase fails (0 = no retry)
+  retries:
+    description: Number of times to retry submitting the job if it failed before reaching the test phase (0 = no retry)
     required: false
     default: "0"
 outputs:
@@ -125,7 +125,7 @@ runs:
         JOB: ${{ steps.create-job-file.outputs.job }}
         POLL: ${{ inputs.poll }}
         HAS_PROVISION: ${{ steps.check-phases.outputs.provision }}
-        MAX_RETRIES: ${{ inputs.provision-max-retries }}
+        MAX_RETRIES: ${{ inputs.retries }}
       run: |
         # check that the auth solution has the right number of params defined
         AUTH_ARGS_COUNT=0
@@ -154,7 +154,7 @@ runs:
         
           if [[ "$POLL" != "true" ]]; then
             if [[ "$MAX_RETRIES" -gt 0 ]]; then
-              echo "::warning::provision-max-retries has no effect when poll is false"
+              echo "::warning::retries has no effect when poll is false"
             fi
             break
           fi
@@ -168,9 +168,15 @@ runs:
           echo "::group::Retrieve phase results to determine exit status"
           SETUP_STATUS=$(testflinger results $JOB_ID | jq '.setup_status // 1')
           echo "::endgroup::"
+        
           if [[ $SETUP_STATUS -ne 0 ]]; then
-            echo "::error::Testflinger setup phase failed"
-            exit $SETUP_STATUS
+            echo "::error::Testflinger setup phase failed (attempt $((ATTEMPT+1)))"
+            if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
+              exit $SETUP_STATUS
+            fi
+            ((++ATTEMPT))
+            echo "::notice::Retrying job submission (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
+            continue
           fi
           
           # provision phase
@@ -186,16 +192,20 @@ runs:
           echo "::group::Retrieve phase results to determine exit status"
           PROVISION_STATUS=$(testflinger results $JOB_ID | jq '.provision_status // 1')
           echo "::endgroup::"
-          if [[ $PROVISION_STATUS -eq 0 ]]; then
-            break
+        
+          if [[ $PROVISION_STATUS -ne 0 ]]; then
+            echo "::error::Testflinger provision phase failed (attempt $((ATTEMPT+1)))"
+            if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
+              exit $PROVISION_STATUS
+            fi
+            ((++ATTEMPT))
+            echo "::notice::Retrying job submission (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
+            continue
           fi
         
-          echo "::error::Testflinger provision phase failed (attempt $((ATTEMPT+1)))"
-          if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
-            exit $PROVISION_STATUS
-          fi
-          ((++ATTEMPT))
-          echo "::notice::Retrying job submission for provision (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
+          # provision phase succeeded, exit retry loop
+          break
+        
         done
 
     - name: Track test phase

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -173,7 +173,7 @@ runs:
         
           echo "::group::Retrieve setup phase exit status"
           SETUP_STATUS=$(testflinger results $JOB_ID 2>/dev/null | jq '.setup_status // 1') \
-            || { echo "::error::Failed to retrieve setup phase results for $JOB_ID"; exit 1; }
+            || { echo "::warning::Failed to retrieve setup phase results for $JOB_ID, treating as failure"; SETUP_STATUS=1; }
           echo "::endgroup::"
         
           if [[ $SETUP_STATUS -ne 0 ]]; then
@@ -198,7 +198,7 @@ runs:
         
           echo "::group::Retrieve provision phase exit status"
           PROVISION_STATUS=$(testflinger results $JOB_ID 2>/dev/null | jq '.provision_status // 1') \
-            || { echo "::error::Failed to retrieve provision phase results for $JOB_ID"; exit 1; }
+            || { echo "::warning::Failed to retrieve provision phase results for $JOB_ID, treating as failure"; PROVISION_STATUS=1; }
           echo "::endgroup::"
         
           if [[ $PROVISION_STATUS -ne 0 ]]; then

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -34,9 +34,9 @@ inputs:
     default: "0"
   provision-timeout:
     description: >
-      Maximum time to wait for the provision phase to complete before cancelling
-      the job and treating it as a failure (e.g. "30m", "1h", "3600s").
-      Leave empty for no timeout.
+      Maximum time to wait for the provision phase to complete before cancelling the job and treating it as a failure (e.g. "30m", "1h", "3600s").
+      Leave empty to not impose a timeout in the action. 
+      Note that the Testflinger server may still impose its own timeout for the provision phase, independent of this action.
     required: false
     default: ""
 outputs:

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -29,7 +29,7 @@ inputs:
     description: Secret key for jobs requiring authentication
     required: false
   retries:
-    description: Number of times to retry submitting the job if it failed before completing the provision phase (0 = no retry)
+    description: Number of times to retry submitting the job if it failed before reaching the test phase (0 = no retry)
     required: false
     default: "0"
 outputs:

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -210,7 +210,7 @@ runs:
           PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
           echo "::endgroup::"
           echo "::group::Retrieve phase results to determine exit status"
-          SETUP_STATUS=$(testflinger results $JOB_ID | jq .setup_status)
+            SETUP_STATUS=$(testflinger results $JOB_ID | jq '.setup_status // 1')
           echo "::endgroup::"
           if [[ $SETUP_STATUS -ne 0 ]]; then
             echo "::error::Testflinger setup phase failed"
@@ -239,7 +239,7 @@ runs:
             PROVISION_STATUS=1
           else
             echo "::group::Retrieve phase results to determine exit status"
-            PROVISION_STATUS=$(testflinger results $JOB_ID | jq .provision_status)
+              PROVISION_STATUS=$(testflinger results $JOB_ID | jq '.provision_status // 1')
             echo "::endgroup::"
           fi
           if [[ $PROVISION_STATUS -eq 0 ]]; then

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -32,13 +32,6 @@ inputs:
     description: Maximum number of times to retry the job when the provision phase fails (0 = no retry)
     required: false
     default: "0"
-  provision-timeout:
-    description: >
-      Maximum time to wait for the provision phase to complete before cancelling the job and treating it as a failure (e.g. "30m", "1h", "3600s").
-      Leave empty to not impose a timeout in the action. 
-      Note that the Testflinger server may still impose its own timeout for the provision phase, independent of this action.
-    required: false
-    default: ""
 outputs:
   id:
     description: 'The ID of the submitted job'
@@ -133,7 +126,6 @@ runs:
         POLL: ${{ inputs.poll }}
         HAS_PROVISION: ${{ steps.check-phases.outputs.provision }}
         MAX_RETRIES: ${{ inputs.provision-max-retries }}
-        PROVISION_TIMEOUT: ${{ inputs.provision-timeout }}
       run: |
         # check that the auth solution has the right number of params defined
         AUTH_ARGS_COUNT=0
@@ -225,21 +217,13 @@ runs:
           echo "::group::Tracking $JOB_ID provision phase (attempt $((ATTEMPT+1)))"
           PROVISION_START=$(date +%s)
           POLL_EXIT=0
-          if [[ -n "$PROVISION_TIMEOUT" ]]; then
-              PYTHONUNBUFFERED=1 timeout "$PROVISION_TIMEOUT" \
-                testflinger poll $JOB_ID --phase provision 2>/dev/null \
-                || POLL_EXIT=$?
-            else
-              PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null \
-                || POLL_EXIT=$?
-          fi
+          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null \
+            || POLL_EXIT=$?
           PROVISION_DURATION=$(( $(date +%s) - PROVISION_START ))
           echo "Provision phase duration: ${PROVISION_DURATION}s"
           echo "::endgroup::"
-          if [[ $POLL_EXIT -eq 124 ]]; then
-            echo "::error::Provision phase timed out after ${PROVISION_DURATION}s — cancelling job $JOB_ID"
-            testflinger cancel $JOB_ID \
-              || echo "::warning::Failed to cancel job $JOB_ID — it may still be running on the server"
+          if [[ $POLL_EXIT -ne 0 ]]; then
+            echo "::error::Provision phase polling failed after ${PROVISION_DURATION}s"
             PROVISION_STATUS=1
           else
             echo "::group::Retrieve phase results to determine exit status"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -199,6 +199,9 @@ runs:
           echo "::group::Submit job to the Testflinger server (attempt $((ATTEMPT+1)))"
           JOB_ID=$(            testflinger submit --quiet             ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"}             "$JOB"           )
           echo "::endgroup::"
+          # Write immediately so the job ID is available to downstream steps
+          # even if this step exits early (e.g. due to a timeout)
+          echo "id=$JOB_ID" >> $GITHUB_OUTPUT
           echo "::notice::Testflinger job id: $JOB_ID"
           if [[ "$POLL" != "true" ]]; then
             break
@@ -211,7 +214,6 @@ runs:
           echo "::endgroup::"
           if [[ $SETUP_STATUS -ne 0 ]]; then
             echo "::error::Testflinger setup phase failed"
-            echo "id=$JOB_ID" >> $GITHUB_OUTPUT
             exit $SETUP_STATUS
           fi
           if [[ "$HAS_PROVISION" != "true" ]]; then
@@ -219,12 +221,14 @@ runs:
           fi
           echo "::group::Tracking $JOB_ID provision phase (attempt $((ATTEMPT+1)))"
           PROVISION_START=$(date +%s)
+          POLL_EXIT=0
           if [[ -n "$PROVISION_TIMEOUT" ]]; then
-            PYTHONUNBUFFERED=1 timeout "$PROVISION_TIMEOUT"               testflinger poll $JOB_ID --phase provision 2>/dev/null
-            POLL_EXIT=$?
-          else
-            PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
-            POLL_EXIT=$?
+              PYTHONUNBUFFERED=1 timeout "$PROVISION_TIMEOUT" \
+                testflinger poll $JOB_ID --phase provision 2>/dev/null \
+                || POLL_EXIT=$?
+            else
+              PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null \
+                || POLL_EXIT=$?
           fi
           PROVISION_DURATION=$(( $(date +%s) - PROVISION_START ))
           echo "Provision phase duration: ${PROVISION_DURATION}s"
@@ -243,13 +247,12 @@ runs:
           fi
           echo "::error::Testflinger provision phase failed (attempt $((ATTEMPT+1)))"
           if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
-            echo "id=$JOB_ID" >> $GITHUB_OUTPUT
             exit $PROVISION_STATUS
           fi
           ((++ATTEMPT))
           echo "::notice::Retrying job submission for provision (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
         done
-        echo "id=$JOB_ID" >> $GITHUB_OUTPUT
+
 
     - name: Track test phase
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.test == 'true'

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -28,6 +28,10 @@ inputs:
   secret-key:
     description: Secret key for jobs requiring authentication
     required: false
+  provision-max-retries:
+    description: Maximum number of times to retry the job when the provision phase fails (0 = no retry)
+    required: false
+    default: "0"
 outputs:
   id:
     description: 'The ID of the submitted job'
@@ -109,7 +113,7 @@ runs:
         done
         echo "::endgroup::"
 
-    - name: Submit job to the Testflinger server
+    - name: Submit job and track until provision (with retry on provision failure)
       id: submit
       if: inputs.dry-run != 'true'
       shell: bash
@@ -119,9 +123,10 @@ runs:
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB: ${{ steps.create-job-file.outputs.job }}
+        POLL: ${{ inputs.poll }}
+        HAS_PROVISION: ${{ steps.check-phases.outputs.provision }}
+        MAX_RETRIES: ${{ inputs.provision-max-retries }}
       run: |
-        echo "::group::Submit job to the Testflinger server"
-        
         # check that the auth solution has the right number of params defined
         AUTH_ARGS_COUNT=0
         [[ -n $TESTFLINGER_CLIENT_ID ]] && ((++AUTH_ARGS_COUNT))
@@ -131,55 +136,97 @@ runs:
             2) echo "Testflinger credentials present." ;;
             1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
         esac
-
-        JOB_ID=$(\
-          testflinger submit --quiet \
-          ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"} \
-          "$JOB" \
-        )
+        ATTEMPT=0
+        while true; do
+          echo "::group::Submit job to the Testflinger server (attempt $((ATTEMPT+1)))"
+          JOB_ID=$(            testflinger submit --quiet             ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"}             "$JOB"           )
+          echo "::endgroup::"
+          echo "::notice::Testflinger job id: $JOB_ID"
+          if [[ "$POLL" != "true" ]]; then
+            break
+          fi
+          echo "::group::Tracking $JOB_ID setup phase"
+          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
+          echo "::endgroup::"
+          echo "::group::Retrieve phase results to determine exit status"
+          SETUP_STATUS=$(testflinger results $JOB_ID | jq .setup_status)
+          echo "::endgroup::"
+          if [[ $SETUP_STATUS -ne 0 ]]; then
+            echo "::error::Testflinger setup phase failed"
+            echo "id=$JOB_ID" >> $GITHUB_OUTPUT
+            exit $SETUP_STATUS
+          fi
+          if [[ "$HAS_PROVISION" != "true" ]]; then
+            break
+          fi
+          echo "::group::Tracking $JOB_ID provision phase (attempt $((ATTEMPT+1)))"
+          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
+          echo "::endgroup::"
+          echo "::group::Retrieve phase results to determine exit status"
+          PROVISION_STATUS=$(testflinger results $JOB_ID | jq .provision_status)
+          echo "::endgroup::"
+          if [[ $PROVISION_STATUS -eq 0 ]]; then
+            break
+          fi
+          echo "::error::Testflinger provision phase failed (attempt $((ATTEMPT+1)))"
+          if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
+            echo "id=$JOB_ID" >> $GITHUB_OUTPUT
+            exit $PROVISION_STATUS
+          fi
+          ((++ATTEMPT))
+          echo "::notice::Retrying job submission for provision (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
+        done
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT
-        echo "::endgroup::"
-        echo "::notice::Testflinger job id: $JOB_ID"
+        AUTH_ARGS_COUNT=0
+        [[ -n $TESTFLINGER_CLIENT_ID ]] && ((++AUTH_ARGS_COUNT))
+        [[ -n $TESTFLINGER_SECRET_KEY ]] && ((++AUTH_ARGS_COUNT))
+        case $AUTH_ARGS_COUNT in
+            0) TESTFLINGER_CLIENT_ID=() ;;
+            2) echo "Testflinger credentials present." ;;
+            1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
+        esac
 
-    - name: Track setup phase
-      if: inputs.poll == 'true' && inputs.dry-run != 'true'
-      shell: bash
-      env:
-        TESTFLINGER_SERVER: https://${{ inputs.server }}
-        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
-        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
-        JOB_ID: ${{ steps.submit.outputs.id }}
-      run: |
-        echo "::group:: Tracking $JOB_ID setup phase"
-        # poll setup phase
-        PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
-        echo "::endgroup::"
-
-        echo "::group::Retrieve phase results to determine exit status"
-        EXIT_STATUS=$(testflinger results $JOB_ID | jq .setup_status)
-        [[ $EXIT_STATUS -ne 0 ]] && echo "::error::Testflinger setup phase failed"
-        echo "::endgroup::"
-        exit $EXIT_STATUS
-
-    - name: Track provision phase
-      if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.provision == 'true'
-      shell: bash
-      env: 
-        TESTFLINGER_SERVER: https://${{ inputs.server }}
-        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
-        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
-        JOB_ID: ${{ steps.submit.outputs.id }}
-      run: |
-        echo "::group:: Tracking $JOB_ID provision phase"
-        # poll provision phase
-        PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
-        echo "::endgroup::"
-
-        echo "::group::Retrieve phase results to determine exit status"
-        EXIT_STATUS=$(testflinger results $JOB_ID | jq .provision_status)
-        [[ $EXIT_STATUS -ne 0 ]] && echo "::error::Testflinger provision phase failed"
-        echo "::endgroup::"
-        exit $EXIT_STATUS
+        ATTEMPT=0
+        while true; do
+          echo "::group::Submit job to the Testflinger server (attempt $((ATTEMPT+1)))"
+          JOB_ID=$(            testflinger submit --quiet             ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"}             "$JOB"           )
+          echo "::endgroup::"
+          echo "::notice::Testflinger job id: $JOB_ID"
+          if [[ "$POLL" != "true" ]]; then
+            break
+          fi
+          echo "::group::Tracking $JOB_ID setup phase"
+          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
+          echo "::endgroup::"
+          echo "::group::Retrieve phase results to determine exit status"
+          SETUP_STATUS=$(testflinger results $JOB_ID | jq .setup_status)
+          echo "::endgroup::"
+          if [[ $SETUP_STATUS -ne 0 ]]; then
+            echo "::error::Testflinger setup phase failed"
+            echo "id=$JOB_ID" >> $GITHUB_OUTPUT
+            exit $SETUP_STATUS
+          fi
+          if [[ "$HAS_PROVISION" != "true" ]]; then
+            break
+          fi
+          echo "::group::Tracking $JOB_ID provision phase (attempt $((ATTEMPT+1)))"
+          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
+          echo "::endgroup::"
+          echo "::group::Retrieve phase results to determine exit status"
+          PROVISION_STATUS=$(testflinger results $JOB_ID | jq .provision_status)
+          echo "::endgroup::"
+          if [[ $PROVISION_STATUS -eq 0 ]]; then
+            break
+          fi
+          echo "::error::Testflinger provision phase failed (attempt $((ATTEMPT+1)))"
+          if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
+            echo "id=$JOB_ID" >> $GITHUB_OUTPUT
+            exit $PROVISION_STATUS
+          fi
+          ((++ATTEMPT))
+          echo "::notice::Retrying job submission for provision (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
+        done
+        echo "id=$JOB_ID" >> $GITHUB_OUTPUT
 
     - name: Track test phase
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.test == 'true'

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -139,60 +139,12 @@ runs:
         ATTEMPT=0
         while true; do
           echo "::group::Submit job to the Testflinger server (attempt $((ATTEMPT+1)))"
-          JOB_ID=$(            testflinger submit --quiet             ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"}             "$JOB"           )
+          JOB_ID=$(\
+            testflinger submit --quiet \
+            ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"} \
+            "$JOB" \
+          )
           echo "::endgroup::"
-          echo "::notice::Testflinger job id: $JOB_ID"
-          if [[ "$POLL" != "true" ]]; then
-            break
-          fi
-          echo "::group::Tracking $JOB_ID setup phase"
-          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
-          echo "::endgroup::"
-          echo "::group::Retrieve phase results to determine exit status"
-          SETUP_STATUS=$(testflinger results $JOB_ID | jq .setup_status)
-          echo "::endgroup::"
-          if [[ $SETUP_STATUS -ne 0 ]]; then
-            echo "::error::Testflinger setup phase failed"
-            echo "id=$JOB_ID" >> $GITHUB_OUTPUT
-            exit $SETUP_STATUS
-          fi
-          if [[ "$HAS_PROVISION" != "true" ]]; then
-            break
-          fi
-          echo "::group::Tracking $JOB_ID provision phase (attempt $((ATTEMPT+1)))"
-          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
-          echo "::endgroup::"
-          echo "::group::Retrieve phase results to determine exit status"
-          PROVISION_STATUS=$(testflinger results $JOB_ID | jq .provision_status)
-          echo "::endgroup::"
-          if [[ $PROVISION_STATUS -eq 0 ]]; then
-            break
-          fi
-          echo "::error::Testflinger provision phase failed (attempt $((ATTEMPT+1)))"
-          if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
-            echo "id=$JOB_ID" >> $GITHUB_OUTPUT
-            exit $PROVISION_STATUS
-          fi
-          ((++ATTEMPT))
-          echo "::notice::Retrying job submission for provision (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
-        done
-        echo "id=$JOB_ID" >> $GITHUB_OUTPUT
-        AUTH_ARGS_COUNT=0
-        [[ -n $TESTFLINGER_CLIENT_ID ]] && ((++AUTH_ARGS_COUNT))
-        [[ -n $TESTFLINGER_SECRET_KEY ]] && ((++AUTH_ARGS_COUNT))
-        case $AUTH_ARGS_COUNT in
-            0) TESTFLINGER_CLIENT_ID=() ;;
-            2) echo "Testflinger credentials present." ;;
-            1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
-        esac
-
-        ATTEMPT=0
-        while true; do
-          echo "::group::Submit job to the Testflinger server (attempt $((ATTEMPT+1)))"
-          JOB_ID=$(            testflinger submit --quiet             ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"}             "$JOB"           )
-          echo "::endgroup::"
-          # Write immediately so the job ID is available to downstream steps
-          # even if this step exits early (e.g. due to a timeout)
           echo "id=$JOB_ID" >> $GITHUB_OUTPUT
           echo "::notice::Testflinger job id: $JOB_ID"
           if [[ "$POLL" != "true" ]]; then
@@ -205,7 +157,7 @@ runs:
           PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
           echo "::endgroup::"
           echo "::group::Retrieve phase results to determine exit status"
-            SETUP_STATUS=$(testflinger results $JOB_ID | jq '.setup_status // 1')
+          SETUP_STATUS=$(testflinger results $JOB_ID | jq '.setup_status // 1')
           echo "::endgroup::"
           if [[ $SETUP_STATUS -ne 0 ]]; then
             echo "::error::Testflinger setup phase failed"
@@ -215,21 +167,11 @@ runs:
             break
           fi
           echo "::group::Tracking $JOB_ID provision phase (attempt $((ATTEMPT+1)))"
-          PROVISION_START=$(date +%s)
-          POLL_EXIT=0
-          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null \
-            || POLL_EXIT=$?
-          PROVISION_DURATION=$(( $(date +%s) - PROVISION_START ))
-          echo "Provision phase duration: ${PROVISION_DURATION}s"
+          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
           echo "::endgroup::"
-          if [[ $POLL_EXIT -ne 0 ]]; then
-            echo "::error::Provision phase polling failed after ${PROVISION_DURATION}s"
-            PROVISION_STATUS=1
-          else
-            echo "::group::Retrieve phase results to determine exit status"
-              PROVISION_STATUS=$(testflinger results $JOB_ID | jq '.provision_status // 1')
-            echo "::endgroup::"
-          fi
+          echo "::group::Retrieve phase results to determine exit status"
+          PROVISION_STATUS=$(testflinger results $JOB_ID | jq '.provision_status // 1')
+          echo "::endgroup::"
           if [[ $PROVISION_STATUS -eq 0 ]]; then
             break
           fi
@@ -240,7 +182,6 @@ runs:
           ((++ATTEMPT))
           echo "::notice::Retrying job submission for provision (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
         done
-
     - name: Track test phase
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.test == 'true'
       shell: bash

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -172,8 +172,7 @@ runs:
           echo "::endgroup::"
         
           echo "::group::Retrieve setup phase exit status"
-          SETUP_STATUS=$(testflinger results $JOB_ID 2>/dev/null | jq '.setup_status // 1') \
-            || { echo "::warning::Failed to retrieve setup phase results for $JOB_ID, treating as failure"; SETUP_STATUS=1; }
+          SETUP_STATUS=$(testflinger results $JOB_ID | jq '.setup_status // 1')
           echo "::endgroup::"
         
           if [[ $SETUP_STATUS -ne 0 ]]; then
@@ -197,8 +196,7 @@ runs:
           echo "::endgroup::"
         
           echo "::group::Retrieve provision phase exit status"
-          PROVISION_STATUS=$(testflinger results $JOB_ID 2>/dev/null | jq '.provision_status // 1') \
-            || { echo "::warning::Failed to retrieve provision phase results for $JOB_ID, treating as failure"; PROVISION_STATUS=1; }
+          PROVISION_STATUS=$(testflinger results $JOB_ID | jq '.provision_status // 1')
           echo "::endgroup::"
         
           if [[ $PROVISION_STATUS -ne 0 ]]; then

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -32,6 +32,13 @@ inputs:
     description: Maximum number of times to retry the job when the provision phase fails (0 = no retry)
     required: false
     default: "0"
+  provision-timeout:
+    description: >
+      Maximum time to wait for the provision phase to complete before cancelling
+      the job and treating it as a failure (e.g. "30m", "1h", "3600s").
+      Leave empty for no timeout.
+    required: false
+    default: ""
 outputs:
   id:
     description: 'The ID of the submitted job'
@@ -126,6 +133,7 @@ runs:
         POLL: ${{ inputs.poll }}
         HAS_PROVISION: ${{ steps.check-phases.outputs.provision }}
         MAX_RETRIES: ${{ inputs.provision-max-retries }}
+        PROVISION_TIMEOUT: ${{ inputs.provision-timeout }}
       run: |
         # check that the auth solution has the right number of params defined
         AUTH_ARGS_COUNT=0
@@ -210,11 +218,26 @@ runs:
             break
           fi
           echo "::group::Tracking $JOB_ID provision phase (attempt $((ATTEMPT+1)))"
-          PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
+          PROVISION_START=$(date +%s)
+          if [[ -n "$PROVISION_TIMEOUT" ]]; then
+            PYTHONUNBUFFERED=1 timeout "$PROVISION_TIMEOUT"               testflinger poll $JOB_ID --phase provision 2>/dev/null
+            POLL_EXIT=$?
+          else
+            PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
+            POLL_EXIT=$?
+          fi
+          PROVISION_DURATION=$(( $(date +%s) - PROVISION_START ))
+          echo "Provision phase duration: ${PROVISION_DURATION}s"
           echo "::endgroup::"
-          echo "::group::Retrieve phase results to determine exit status"
-          PROVISION_STATUS=$(testflinger results $JOB_ID | jq .provision_status)
-          echo "::endgroup::"
+          if [[ $POLL_EXIT -eq 124 ]]; then
+            echo "::error::Provision phase timed out after ${PROVISION_DURATION}s — cancelling job $JOB_ID"
+            testflinger cancel $JOB_ID
+            PROVISION_STATUS=1
+          else
+            echo "::group::Retrieve phase results to determine exit status"
+            PROVISION_STATUS=$(testflinger results $JOB_ID | jq .provision_status)
+            echo "::endgroup::"
+          fi
           if [[ $PROVISION_STATUS -eq 0 ]]; then
             break
           fi

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -29,7 +29,7 @@ inputs:
     description: Secret key for jobs requiring authentication
     required: false
   retries:
-    description: Number of times to retry submitting the job if it failed before reaching the test phase (0 = no retry)
+    description: Number of times to retry submitting the job if it failed before completing the provision phase (0 = no retry)
     required: false
     default: "0"
 outputs:
@@ -145,73 +145,79 @@ runs:
 
         ATTEMPT=0
         while true; do
-        
+
           # submit job
-        
+
           echo "::group::Submit job to the Testflinger server (attempt $((ATTEMPT+1)))"
           JOB_ID=$(\
             testflinger submit --quiet \
             ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"} \
             "$JOB" \
           )
-          echo "id=$JOB_ID" >> $GITHUB_OUTPUT
           echo "::endgroup::"
+          if [[ -z "$JOB_ID" ]]; then
+            echo "::error::Failed to submit job to Testflinger server"
+            exit 1
+          fi
+          echo "id=$JOB_ID" >> $GITHUB_OUTPUT
           echo "::notice::Testflinger job id: $JOB_ID"
-        
+
           if [[ "$POLL" != "true" ]]; then
             if [[ "$MAX_RETRIES" -gt 0 ]]; then
               echo "::warning::retries has no effect when poll is false"
             fi
             break
           fi
-        
+
           # setup phase
-        
+
           echo "::group::Tracking $JOB_ID setup phase"
           PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
           echo "::endgroup::"
-        
+
           echo "::group::Retrieve setup phase exit status"
           SETUP_STATUS=$(testflinger results $JOB_ID | jq '.setup_status // 1')
           echo "::endgroup::"
-        
+
           if [[ $SETUP_STATUS -ne 0 ]]; then
             echo "::error::Testflinger setup phase failed (attempt $((ATTEMPT+1)))"
             if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
               exit $SETUP_STATUS
             fi
+            testflinger cancel $JOB_ID || true
             ATTEMPT=$((ATTEMPT + 1))
             echo "::notice::Retrying job submission (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
             continue
           fi
-          
+
           # provision phase
-          
+
           if [[ "$HAS_PROVISION" != "true" ]]; then
             break
           fi
-        
+
           echo "::group::Tracking $JOB_ID provision phase (attempt $((ATTEMPT+1)))"
           PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
           echo "::endgroup::"
-        
+
           echo "::group::Retrieve provision phase exit status"
           PROVISION_STATUS=$(testflinger results $JOB_ID | jq '.provision_status // 1')
           echo "::endgroup::"
-        
+
           if [[ $PROVISION_STATUS -ne 0 ]]; then
             echo "::error::Testflinger provision phase failed (attempt $((ATTEMPT+1)))"
             if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
               exit $PROVISION_STATUS
             fi
+            testflinger cancel $JOB_ID || true
             ATTEMPT=$((ATTEMPT + 1))
             echo "::notice::Retrying job submission (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
             continue
           fi
-        
+
           # provision phase succeeded, exit retry loop
           break
-        
+
         done
 
     - name: Track test phase

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -113,7 +113,7 @@ runs:
         done
         echo "::endgroup::"
 
-    - name: Submit job and track until provision (with retry on provision failure)
+    - name: Submit job and track until provision
       id: submit
       if: inputs.dry-run != 'true'
       shell: bash

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -257,7 +257,6 @@ runs:
           echo "::notice::Retrying job submission for provision (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
         done
 
-
     - name: Track test phase
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.test == 'true'
       shell: bash

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -136,26 +136,35 @@ runs:
             2) echo "Testflinger credentials present." ;;
             1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
         esac
+        
         ATTEMPT=0
         while true; do
+        
+          # submit job
+        
           echo "::group::Submit job to the Testflinger server (attempt $((ATTEMPT+1)))"
           JOB_ID=$(\
             testflinger submit --quiet \
             ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"} \
             "$JOB" \
           )
-          echo "::endgroup::"
           echo "id=$JOB_ID" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
           echo "::notice::Testflinger job id: $JOB_ID"
+        
           if [[ "$POLL" != "true" ]]; then
             if [[ "$MAX_RETRIES" -gt 0 ]]; then
               echo "::warning::provision-max-retries has no effect when poll is false"
             fi
             break
           fi
+        
+          # setup phase
+        
           echo "::group::Tracking $JOB_ID setup phase"
           PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
           echo "::endgroup::"
+        
           echo "::group::Retrieve phase results to determine exit status"
           SETUP_STATUS=$(testflinger results $JOB_ID | jq '.setup_status // 1')
           echo "::endgroup::"
@@ -163,18 +172,24 @@ runs:
             echo "::error::Testflinger setup phase failed"
             exit $SETUP_STATUS
           fi
+          
+          # provision phase
+          
           if [[ "$HAS_PROVISION" != "true" ]]; then
             break
           fi
+        
           echo "::group::Tracking $JOB_ID provision phase (attempt $((ATTEMPT+1)))"
           PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
           echo "::endgroup::"
+        
           echo "::group::Retrieve phase results to determine exit status"
           PROVISION_STATUS=$(testflinger results $JOB_ID | jq '.provision_status // 1')
           echo "::endgroup::"
           if [[ $PROVISION_STATUS -eq 0 ]]; then
             break
           fi
+        
           echo "::error::Testflinger provision phase failed (attempt $((ATTEMPT+1)))"
           if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
             exit $PROVISION_STATUS
@@ -182,6 +197,7 @@ runs:
           ((++ATTEMPT))
           echo "::notice::Retrying job submission for provision (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
         done
+
     - name: Track test phase
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.test == 'true'
       shell: bash

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -204,6 +204,9 @@ runs:
           echo "id=$JOB_ID" >> $GITHUB_OUTPUT
           echo "::notice::Testflinger job id: $JOB_ID"
           if [[ "$POLL" != "true" ]]; then
+            if [[ "$MAX_RETRIES" -gt 0 ]]; then
+              echo "::warning::provision-max-retries has no effect when poll is false"
+            fi
             break
           fi
           echo "::group::Tracking $JOB_ID setup phase"
@@ -235,7 +238,8 @@ runs:
           echo "::endgroup::"
           if [[ $POLL_EXIT -eq 124 ]]; then
             echo "::error::Provision phase timed out after ${PROVISION_DURATION}s — cancelling job $JOB_ID"
-            testflinger cancel $JOB_ID
+            testflinger cancel $JOB_ID \
+              || echo "::warning::Failed to cancel job $JOB_ID — it may still be running on the server"
             PROVISION_STATUS=1
           else
             echo "::group::Retrieve phase results to determine exit status"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -129,14 +129,20 @@ runs:
       run: |
         # check that the auth solution has the right number of params defined
         AUTH_ARGS_COUNT=0
-        [[ -n $TESTFLINGER_CLIENT_ID ]] && ((++AUTH_ARGS_COUNT))
-        [[ -n $TESTFLINGER_SECRET_KEY ]] && ((++AUTH_ARGS_COUNT))
+        [[ -n $TESTFLINGER_CLIENT_ID ]] && AUTH_ARGS_COUNT=$((AUTH_ARGS_COUNT + 1))
+        [[ -n $TESTFLINGER_SECRET_KEY ]] && AUTH_ARGS_COUNT=$((AUTH_ARGS_COUNT + 1))
         case $AUTH_ARGS_COUNT in
             0) TESTFLINGER_CLIENT_ID=() ;;
             2) echo "Testflinger credentials present." ;;
             1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
         esac
         
+        # validate retries input
+        if ! [[ "$MAX_RETRIES" =~ ^[0-9]+$ ]]; then
+          echo "::error::'retries' must be a non-negative integer, got: $MAX_RETRIES"
+          exit 1
+        fi
+
         ATTEMPT=0
         while true; do
         
@@ -165,8 +171,9 @@ runs:
           PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
           echo "::endgroup::"
         
-          echo "::group::Retrieve phase results to determine exit status"
-          SETUP_STATUS=$(testflinger results $JOB_ID | jq '.setup_status // 1')
+          echo "::group::Retrieve setup phase exit status"
+          SETUP_STATUS=$(testflinger results $JOB_ID 2>/dev/null | jq '.setup_status // 1') \
+            || { echo "::error::Failed to retrieve setup phase results for $JOB_ID"; exit 1; }
           echo "::endgroup::"
         
           if [[ $SETUP_STATUS -ne 0 ]]; then
@@ -174,7 +181,7 @@ runs:
             if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
               exit $SETUP_STATUS
             fi
-            ((++ATTEMPT))
+            ATTEMPT=$((ATTEMPT + 1))
             echo "::notice::Retrying job submission (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
             continue
           fi
@@ -189,8 +196,9 @@ runs:
           PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
           echo "::endgroup::"
         
-          echo "::group::Retrieve phase results to determine exit status"
-          PROVISION_STATUS=$(testflinger results $JOB_ID | jq '.provision_status // 1')
+          echo "::group::Retrieve provision phase exit status"
+          PROVISION_STATUS=$(testflinger results $JOB_ID 2>/dev/null | jq '.provision_status // 1') \
+            || { echo "::error::Failed to retrieve provision phase results for $JOB_ID"; exit 1; }
           echo "::endgroup::"
         
           if [[ $PROVISION_STATUS -ne 0 ]]; then
@@ -198,7 +206,7 @@ runs:
             if [[ $ATTEMPT -ge $MAX_RETRIES ]]; then
               exit $PROVISION_STATUS
             fi
-            ((++ATTEMPT))
+            ATTEMPT=$((ATTEMPT + 1))
             echo "::notice::Retrying job submission (attempt $((ATTEMPT+1)) of $((MAX_RETRIES+1)))"
             continue
           fi

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -159,7 +159,7 @@ runs:
             echo "::error::Failed to submit job to Testflinger server"
             exit 1
           fi
-          echo "id=$JOB_ID" >> $GITHUB_OUTPUT
+          echo "id=$JOB_ID" > "$GITHUB_OUTPUT"
           echo "::notice::Testflinger job id: $JOB_ID"
 
           if [[ "$POLL" != "true" ]]; then


### PR DESCRIPTION
## Description

This PR addresses two common problems we face:

1. It is very common that our CI tests with testflinger fail, because the provisioning of the machines fail. This requires us to manually re-run the tests, hoping we get a different agent on the same queue, which provisions successfully.

~~2. We also often see provisioning taking very long and fails. We see on average that a successful provisioning take <20 minutes, so whenever it takes longer, we already know it will fail. It is currently not possible to cancel and rerun a specific run in a github workflow job matrix.~~ _Removed in favour of alternative fix in maas2 connector (feature/dev-maas-more-detail)._

## Resolved issues

This PR solves these two issues by introducing:

1. An input variable setting the number of times the job will be re-submitted if it failed before reaching the test phase.

~~2. Add a timeout for the provisioning step. If the configured timeout is reached, the testflinger job is cancelled, and the retry logic can much quicker retry.~~

## Documentation

Action README is updated.

## Web service API changes

none

## Tests

Manually tested:

* No provisioning: https://github.com/canonical/inference-snaps-testing/actions/runs/27683162149
* Provisioning no fail: https://github.com/canonical/inference-snaps-testing/actions/runs/27809664602/job/82296920146
* Provisioning with retries: https://github.com/canonical/inference-snaps-testing/actions/runs/27809598276/job/82296717462

With retries set to 3, we see:
<img width="1002" height="1056" alt="image" src="https://github.com/user-attachments/assets/fffb4759-197d-4e20-a22f-b7782e0fcb2f" />
