### PR TITLE
bugfix: fix bug with running certain tests in parallel

### DIFF
--- a/device-connectors/tests/test_cmd.py
+++ b/device-connectors/tests/test_cmd.py
@@ -54,8 +54,9 @@ def test_invalid_stage():
     assert err.value.code == 2
 
 
-def test_exception_logging(tmp_path):
+def test_exception_logging(tmp_path, monkeypatch):
     """Tests exception logging decorator that adds file logging."""
+    monkeypatch.chdir(tmp_path)
     open("device-connector-error.json", "w").close()
 
     exception_info = {
@@ -76,8 +77,9 @@ def test_exception_logging(tmp_path):
         assert json.loads(error_file.read()) == exception_info
 
 
-def test_exception_logging_no_cause(tmp_path):
+def test_exception_logging_no_cause(tmp_path, monkeypatch):
     """Tests exception logging for causeless exceptions."""
+    monkeypatch.chdir(tmp_path)
     open("device-connector-error.json", "w").close()
 
     exception_info = {


### PR DESCRIPTION
## Description

This fixed a small but whereby under certain testing scenarios tests were individually failing, supposedly (thanks AI) because of being run in parallel.

These changes appear to be good in general and in fact did seem to fix the problem that I was seeing.

## Resolved issues

Allowed the tests to pass when run in parrallel.

## Documentation

N/A

## Web service API changes

N/A

## Tests

They work now!