### PR TITLE
new: flag to indicate whether the agent will have access to the DUT after provisioning

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -152,7 +152,9 @@ class DeviceConnector(ZapperConnector):
         # The key copy is also skipped when ubuntu_sso_email is set,
         # since the device is accessed with the SSO account keys instead.
         provision_data = self.job_data["provision_data"]
-        if provision_data.get(
-            "agent_ssh_access", True
-        ) and not provision_data.get("ubuntu_sso_email"):
+
+        agent_ssh_access = provision_data.get("agent_ssh_access", True)
+        using_sso = bool(provision_data.get("ubuntu_sso_email"))
+
+        if agent_ssh_access and not using_sso:
             self._copy_ssh_id()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/__init__.py
@@ -146,6 +146,13 @@ class DeviceConnector(ZapperConnector):
         """Run further actions after Zapper API returns successfully."""
         super()._post_run_actions(args)
 
-        # Copy the ssh id if ubuntu_sso_email is not provided in provision_data
-        if not self.job_data["provision_data"].get("ubuntu_sso_email"):
+        # When agent_ssh_access is false, the DUT won't be accessible
+        # by the agent over SSH (its key is not authorized or no SSH
+        # server is running at all), so don't attempt the key copy.
+        # The key copy is also skipped when ubuntu_sso_email is set,
+        # since the device is accessed with the SSO account keys instead.
+        provision_data = self.job_data["provision_data"]
+        if provision_data.get(
+            "agent_ssh_access", True
+        ) and not provision_data.get("ubuntu_sso_email"):
             self._copy_ssh_id()

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_iot/tests/test_zapper_iot.py
@@ -426,6 +426,23 @@ class ZapperIoTTests(unittest.TestCase):
         mock_copy_ssh_id.assert_not_called()
 
     @patch.object(DeviceConnector, "_copy_ssh_id")
+    def test_post_run_actions_not_copy_ssh_id_no_agent_ssh_access(
+        self, mock_copy_ssh_id
+    ):
+        """Test the function does not copy the ssh id if
+        agent_ssh_access is false.
+        """
+        fake_config = {"device_ip": "1.1.1.1", "control_host": "zapper-host"}
+        device = DeviceConnector(fake_config)
+        device.job_data = {
+            "provision_data": {
+                "agent_ssh_access": False,
+            }
+        }
+        device._post_run_actions(args=None)
+        mock_copy_ssh_id.assert_not_called()
+
+    @patch.object(DeviceConnector, "_copy_ssh_id")
     def test_post_run_actions_copy_ssh_id_provision_plan(
         self, mock_copy_ssh_id
     ):

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -180,6 +180,9 @@ class BaseZapperIoTProvisionData(BaseZapperProvisionData):
         required=False,
         validate=Length(max=1),
     )
+    # Whether the agent will have SSH access to the DUT after provisioning.
+    # When false, the agent skips copying its SSH key to the device.
+    agent_ssh_access = fields.Boolean(required=False)
 
     @validates_schema
     def validate_boot_image_source(self, data, **_):


### PR DESCRIPTION
## Description

There are a couple of cases where the provisioned image will NOT provide testflinger SSH access to the DUT.
- images w/o a SSH server, intentionally
- images w/ a system-user assertion built-in, intentionally made w/o the agent keys

## Resolved issues

N/A

## Documentation

On the server side

## Web service API changes

No

## Tests

The code change is limited, tested only via unit testing.
