### PR TITLE
bugfix: Use environment variables for GH submit action.

### DIFF
--- a/.github/actions/poll-multi/action.yaml
+++ b/.github/actions/poll-multi/action.yaml
@@ -40,7 +40,7 @@ runs:
       id: data
       shell: bash
       env:
-        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_SERVER: https://${{ inputs.server }}
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ inputs.job-id }}
@@ -58,14 +58,14 @@ runs:
         esac
 
         while true; do
-          STATUS=$(testflinger --server $SERVER  status $JOB_ID)
+          STATUS=$(testflinger status $JOB_ID)
           echo "Parent job status: $STATUS"
           [ "$STATUS" == "complete" ] && echo "Parent job $JOB_ID complete -> allocation complete" && break
           sleep 10
         done
         echo "::endgroup::"
         echo "::group::Retrieve IDs of children jobs"
-        RESULTS=$(testflinger --server $SERVER  results $JOB_ID)
+        RESULTS=$(testflinger results $JOB_ID)
         if ! jq -e '.provision_status == 0' <<< "$RESULTS" >/dev/null; then
           echo "::error::The provision phase of the parent job $JOB_ID failed"
           exit 1
@@ -75,7 +75,7 @@ runs:
         echo "::notice::" $JOB_IDS
         echo "::endgroup::"
         echo "::group::Retrieve IPs of reserved devices"
-        IPS=$(for JOB_ID in $JOB_IDS; do testflinger --server $SERVER results $JOB_ID | jq -r '.device_info.device_ip'; done)
+        IPS=$(for JOB_ID in $JOB_IDS; do testflinger results $JOB_ID | jq -r '.device_info.device_ip'; done)
         echo "::notice::" $IPS
         echo "::endgroup::"
         echo "::group::Construct output"
@@ -94,7 +94,7 @@ runs:
         while true; do
           REMAINING_JOB_IDS=
           for JOB_ID in $JOB_IDS; do
-            JOB_STATUS=$(testflinger --server $SERVER status $JOB_ID)
+            JOB_STATUS=$(testflinger status $JOB_ID)
             echo "Job $JOB_ID is in the $JOB_STATUS phase"
             [[ "$JOB_STATUS" != "$SENTINEL_PHASE" ]] && REMAINING_JOB_IDS="$REMAINING_JOB_IDS $JOB_ID"
           done

--- a/.github/actions/poll-multi/action.yaml
+++ b/.github/actions/poll-multi/action.yaml
@@ -9,6 +9,16 @@ inputs:
       The phase that all child jobs must reach before this action terminates
     required: false
     default: complete
+  server:
+    description: The Testflinger server to use
+    required: false
+    default: testflinger.canonical.com
+  client-id:
+    description: Client ID for jobs requiring authentication
+    required: false
+  secret-key:
+    description: Secret key for jobs requiring authentication
+    required: false
 outputs:
   jobs:
     description: >
@@ -30,18 +40,21 @@ runs:
       id: data
       shell: bash
       env:
+        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
+        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ inputs.job-id }}
       run: |
         echo "::group::Wait for parent job $JOB_ID to complete"
         while true; do
-          STATUS=$(testflinger status $JOB_ID)
+          STATUS=$(testflinger --server $SERVER  status $JOB_ID)
           echo "Parent job status: $STATUS"
           [ "$STATUS" == "complete" ] && echo "Parent job $JOB_ID complete -> allocation complete" && break
           sleep 10
         done
         echo "::endgroup::"
         echo "::group::Retrieve IDs of children jobs"
-        RESULTS=$(testflinger results $JOB_ID)
+        RESULTS=$(testflinger --server $SERVER  results $JOB_ID)
         if ! jq -e '.provision_status == 0' <<< "$RESULTS" >/dev/null; then
           echo "::error::The provision phase of the parent job $JOB_ID failed"
           exit 1
@@ -51,7 +64,7 @@ runs:
         echo "::notice::" $JOB_IDS
         echo "::endgroup::"
         echo "::group::Retrieve IPs of reserved devices"
-        IPS=$(for JOB_ID in $JOB_IDS; do testflinger results $JOB_ID | jq -r '.device_info.device_ip'; done)
+        IPS=$(for JOB_ID in $JOB_IDS; do testflinger --server $SERVER results $JOB_ID | jq -r '.device_info.device_ip'; done)
         echo "::notice::" $IPS
         echo "::endgroup::"
         echo "::group::Construct output"
@@ -70,7 +83,7 @@ runs:
         while true; do
           REMAINING_JOB_IDS=
           for JOB_ID in $JOB_IDS; do
-            JOB_STATUS=$(testflinger status $JOB_ID)
+            JOB_STATUS=$(testflinger --server $SERVER status $JOB_ID)
             echo "Job $JOB_ID is in the $JOB_STATUS phase"
             [[ "$JOB_STATUS" != "$SENTINEL_PHASE" ]] && REMAINING_JOB_IDS="$REMAINING_JOB_IDS $JOB_ID"
           done

--- a/.github/actions/poll-multi/action.yaml
+++ b/.github/actions/poll-multi/action.yaml
@@ -46,6 +46,17 @@ runs:
         JOB_ID: ${{ inputs.job-id }}
       run: |
         echo "::group::Wait for parent job $JOB_ID to complete"
+        
+        # check that the auth solution has the right number of params defined
+        AUTH_ARGS_COUNT=0
+        [[ -n $TESTFLINGER_CLIENT_ID ]] && ((++AUTH_ARGS_COUNT))
+        [[ -n $TESTFLINGER_SECRET_KEY ]] && ((++AUTH_ARGS_COUNT))
+        case $AUTH_ARGS_COUNT in
+            0) TESTFLINGER_CLIENT_ID=() ;;
+            2) echo "Testflinger credentials present." ;;
+            1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
+        esac
+
         while true; do
           STATUS=$(testflinger --server $SERVER  status $JOB_ID)
           echo "Parent job status: $STATUS"

--- a/.github/actions/queue-status/action.yaml
+++ b/.github/actions/queue-status/action.yaml
@@ -70,6 +70,17 @@ runs:
         QUEUE: ${{ inputs.queue }}
       run: |
         echo "::group::Get $QUEUE queue-status"
+        
+        # check that the auth solution has the right number of params defined
+        AUTH_ARGS_COUNT=0
+        [[ -n $TESTFLINGER_CLIENT_ID ]] && ((++AUTH_ARGS_COUNT))
+        [[ -n $TESTFLINGER_SECRET_KEY ]] && ((++AUTH_ARGS_COUNT))
+        case $AUTH_ARGS_COUNT in
+            0) TESTFLINGER_CLIENT_ID=() ;;
+            2) echo "Testflinger credentials present." ;;
+            1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
+        esac
+
         RESULT=$(testflinger --server "$SERVER" queue-status "$QUEUE")
         echo "$RESULT"
         

--- a/.github/actions/queue-status/action.yaml
+++ b/.github/actions/queue-status/action.yaml
@@ -64,7 +64,7 @@ runs:
       id: queue-status
       shell: bash
       env:
-        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_SERVER: https://${{ inputs.server }}
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         QUEUE: ${{ inputs.queue }}
@@ -81,7 +81,7 @@ runs:
             1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
         esac
 
-        RESULT=$(testflinger --server "$SERVER" queue-status "$QUEUE")
+        RESULT=$(testflinger queue-status "$QUEUE")
         echo "$RESULT"
         
         MAP=(

--- a/.github/actions/queue-status/action.yaml
+++ b/.github/actions/queue-status/action.yaml
@@ -8,6 +8,12 @@ inputs:
     description: The Testflinger server to use
     required: false
     default: testflinger.canonical.com
+  client-id:
+    description: Client ID for jobs requiring authentication
+    required: false
+  secret-key:
+    description: Secret key for jobs requiring authentication
+    required: false
 outputs:
   agents_in_queue:
     description: 'Number of agents in the queue'
@@ -59,6 +65,8 @@ runs:
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
+        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
+        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         QUEUE: ${{ inputs.queue }}
       run: |
         echo "::group::Get $QUEUE queue-status"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -116,23 +116,14 @@ runs:
       env:
         SERVER: https://${{ inputs.server }}
         RELATIVE_TO: ${{ inputs.attachments-relative-to }}
-        CLIENT_ID: ${{ inputs.client-id }}
-        SECRET_KEY: ${{ inputs.secret-key }}
+        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
+        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB: ${{ steps.create-job-file.outputs.job }}
       run: |
         echo "::group::Submit job to the Testflinger server"
-        AUTH_ARGS_COUNT=0
-        [[ -n $CLIENT_ID ]] && ((++AUTH_ARGS_COUNT))
-        [[ -n $SECRET_KEY ]] && ((++AUTH_ARGS_COUNT))
-        case $AUTH_ARGS_COUNT in
-            0) AUTH_ARGS=() ;;
-            2) AUTH_ARGS=( --client_id "$CLIENT_ID" --secret_key "$SECRET_KEY" ) ;;
-            1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
-        esac
         JOB_ID=$(\
           testflinger --server "$SERVER" submit --quiet \
           ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"} \
-          "${AUTH_ARGS[@]}" \
           "$JOB" \
         )
         echo "id=$JOB_ID" >> $GITHUB_OUTPUT

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -114,7 +114,7 @@ runs:
       if: inputs.dry-run != 'true'
       shell: bash
       env:
-        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_SERVER: https://${{ inputs.server }}
         RELATIVE_TO: ${{ inputs.attachments-relative-to }}
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
@@ -133,7 +133,7 @@ runs:
         esac
 
         JOB_ID=$(\
-          testflinger --server "$SERVER" submit --quiet \
+          testflinger submit --quiet \
           ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"} \
           "$JOB" \
         )
@@ -145,18 +145,18 @@ runs:
       if: inputs.poll == 'true' && inputs.dry-run != 'true'
       shell: bash
       env:
-        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_SERVER: https://${{ inputs.server }}
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group:: Tracking $JOB_ID setup phase"
         # poll setup phase
-        PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID --phase setup 2>/dev/null
+        PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase setup 2>/dev/null
         echo "::endgroup::"
 
         echo "::group::Retrieve phase results to determine exit status"
-        EXIT_STATUS=$(testflinger --server $SERVER results $JOB_ID | jq .setup_status)
+        EXIT_STATUS=$(testflinger results $JOB_ID | jq .setup_status)
         [[ $EXIT_STATUS -ne 0 ]] && echo "::error::Testflinger setup phase failed"
         echo "::endgroup::"
         exit $EXIT_STATUS
@@ -165,18 +165,18 @@ runs:
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.provision == 'true'
       shell: bash
       env: 
-        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_SERVER: https://${{ inputs.server }}
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group:: Tracking $JOB_ID provision phase"
         # poll provision phase
-        PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID --phase provision 2>/dev/null
+        PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase provision 2>/dev/null
         echo "::endgroup::"
 
         echo "::group::Retrieve phase results to determine exit status"
-        EXIT_STATUS=$(testflinger --server $SERVER results $JOB_ID | jq .provision_status)
+        EXIT_STATUS=$(testflinger results $JOB_ID | jq .provision_status)
         [[ $EXIT_STATUS -ne 0 ]] && echo "::error::Testflinger provision phase failed"
         echo "::endgroup::"
         exit $EXIT_STATUS
@@ -185,18 +185,18 @@ runs:
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.test == 'true'
       shell: bash
       env: 
-        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_SERVER: https://${{ inputs.server }}
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group:: Tracking $JOB_ID test phase"
         # poll test phase
-        PYTHONUNBUFFERED=1 testflinger --server $SERVER poll $JOB_ID --phase test 2>/dev/null
+        PYTHONUNBUFFERED=1 testflinger poll $JOB_ID --phase test 2>/dev/null
         echo "::endgroup::"
 
         echo "::group::Retrieve phase results to determine exit status"
-        EXIT_STATUS=$(testflinger --server $SERVER results $JOB_ID | jq .test_status)
+        EXIT_STATUS=$(testflinger results $JOB_ID | jq .test_status)
         [[ $EXIT_STATUS -ne 0 ]] && echo "::error::Testflinger test phase failed"
         echo "::endgroup::"
         exit $EXIT_STATUS
@@ -206,7 +206,7 @@ runs:
       if: inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.reserve == 'true'
       shell: bash
       env:
-        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_SERVER: https://${{ inputs.server }}
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
@@ -219,7 +219,7 @@ runs:
         # poll with oneshot until the captured output contains the TERMINATION string
         while true; do
           # extract the last fragment number so we can start from the next fragment
-          POLL_OUTPUT=$(PYTHONUNBUFFERED=1 testflinger --server $SERVER poll --oneshot --phase reserve --start_fragment $LAST_FRAGMENT $JOB_ID) || true
+          POLL_OUTPUT=$(PYTHONUNBUFFERED=1 testflinger poll --oneshot --phase reserve --start_fragment $LAST_FRAGMENT $JOB_ID) || true
           FRAG=$(echo "$POLL_OUTPUT" | sed -n 's/^Last Fragment Number: \([0-9]*\)$/\1/p')
           if [ -n "$FRAG" ]; then
             LAST_FRAGMENT=$((FRAG + 1))
@@ -230,7 +230,7 @@ runs:
             EXIT_STATUS=0
             break
           fi
-          JOB_STATUS="$(testflinger --server $SERVER status $JOB_ID)"
+          JOB_STATUS="$(testflinger status $JOB_ID)"
           if [[ "$JOB_STATUS" =~ ^(complete|cancelled)$ ]]; then
             EXIT_STATUS=1
             break
@@ -252,14 +252,14 @@ runs:
       if: always() && !cancelled() && inputs.poll == 'true' && inputs.dry-run != 'true' && steps.check-phases.outputs.reserve == 'false'
       shell: bash
       env:
-        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_SERVER: https://${{ inputs.server }}
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group::Waiting for job $JOB_ID to complete"
         while true; do
-          JOB_STATUS="$(testflinger --server $SERVER status $JOB_ID)"
+          JOB_STATUS="$(testflinger status $JOB_ID)"
           if [[ "$JOB_STATUS" =~ ^(complete|cancelled)$ ]]; then
             break
           fi
@@ -271,11 +271,11 @@ runs:
       if: ${{ cancelled() }}
       shell: bash
       env:
-        SERVER: https://${{ inputs.server }}
+        TESTFLINGER_SERVER: https://${{ inputs.server }}
         TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
         TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group::Cancel job"
-        testflinger --server $SERVER cancel $JOB_ID
+        testflinger cancel $JOB_ID
         echo "::endgroup::"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -135,6 +135,8 @@ runs:
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
+        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
+        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group:: Tracking $JOB_ID setup phase"
@@ -153,6 +155,8 @@ runs:
       shell: bash
       env: 
         SERVER: https://${{ inputs.server }}
+        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
+        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group:: Tracking $JOB_ID provision phase"
@@ -171,6 +175,8 @@ runs:
       shell: bash
       env: 
         SERVER: https://${{ inputs.server }}
+        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
+        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group:: Tracking $JOB_ID test phase"
@@ -190,6 +196,8 @@ runs:
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
+        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
+        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
         TERMINATION: "TESTFLINGER SYSTEM RESERVED"
       run: |
@@ -234,6 +242,8 @@ runs:
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
+        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
+        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group::Waiting for job $JOB_ID to complete"
@@ -251,6 +261,8 @@ runs:
       shell: bash
       env:
         SERVER: https://${{ inputs.server }}
+        TESTFLINGER_CLIENT_ID: ${{ inputs.client-id }}
+        TESTFLINGER_SECRET_KEY: ${{ inputs.secret-key }}
         JOB_ID: ${{ steps.submit.outputs.id }}
       run: |
         echo "::group::Cancel job"

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -121,6 +121,17 @@ runs:
         JOB: ${{ steps.create-job-file.outputs.job }}
       run: |
         echo "::group::Submit job to the Testflinger server"
+        
+        # check that the auth solution has the right number of params defined
+        AUTH_ARGS_COUNT=0
+        [[ -n $TESTFLINGER_CLIENT_ID ]] && ((++AUTH_ARGS_COUNT))
+        [[ -n $TESTFLINGER_SECRET_KEY ]] && ((++AUTH_ARGS_COUNT))
+        case $AUTH_ARGS_COUNT in
+            0) TESTFLINGER_CLIENT_ID=() ;;
+            2) echo "Testflinger credentials present." ;;
+            1) echo "::error::Both 'client-id' and 'secret-key' must be provided or neither"; exit 1 ;;
+        esac
+
         JOB_ID=$(\
           testflinger --server "$SERVER" submit --quiet \
           ${RELATIVE_TO:+--attachments-relative-to "$RELATIVE_TO"} \


### PR DESCRIPTION
## Description

GitHub actions were using command line args to pass the authentication credentials, and even then, only in the submit action. All GH action scripts need to be able to use testflinger credentials in a secure way.

## Resolved issues

- Testflinger GH actions now use environment variables to pass credentials. 
- All actions now support use of testflinger credentials

## Documentation

N/A

## Web service API changes

N/A

## Tests

Tested via https://github.com/canonical/tf-submit-action-test/actions/runs/27429394484/job/81075511860