### PR TITLE
feat(server/cli): add IDP authentication via Device Authentication Flow

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -149,6 +149,7 @@ class TestflingerCli:
             or os.environ.get("TESTFLINGER_ERROR_THRESHOLD")
             or consts.TESTFLINGER_ERROR_THRESHOLD
         )
+        auth_method = getattr(self.args, "method", "credentials")
 
         # Allow config subcommand without worrying about server or client
         if hasattr(self.args, "func") and self.args.func == self.configure:
@@ -160,7 +161,7 @@ class TestflingerCli:
             )
         self.client = client.Client(server, error_threshold=error_threshold)
         self.auth = TestflingerCliAuth(
-            self.client_id, self.secret_key, self.client
+            auth_method, self.client_id, self.secret_key, self.client
         )
 
     def run(self):
@@ -290,6 +291,17 @@ class TestflingerCli:
             help="Authenticate with server",
         )
         parser.set_defaults(func=self.login)
+        parser.add_argument(
+            "--method",
+            nargs="?",
+            choices=["credentials", "oidc"],
+            default="credentials",
+            help=(
+                "Authentication method to use. "
+                "'credentials' uses client-id and secret-key (default). "
+                "'oidc' opens a browser for IDP-based login."
+            ),
+        )
         self._add_auth_args(parser)
 
     def _add_poll_args_generic(self, parser):
@@ -1859,9 +1871,9 @@ class TestflingerCli:
         # Clear refresh token if user is attempting reauthentication
         self.auth.clear_refresh_token()
         try:
-            # Since refresh token was cleared, credentials are always needed
+            # Since refresh token was cleared, we need to re-authenticate
             if self.auth.authenticate():
-                print(f"Successfully authenticated as user '{self.client_id}'")
+                print(f"Successfully authenticated as '{self.auth.client_id}'")
             else:
                 # authenticate can return None if no credentials were provided
                 sys.exit("Please provide credentials and reattempt login")

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -161,7 +161,7 @@ class TestflingerCli:
             )
         self.client = client.Client(server, error_threshold=error_threshold)
         self.auth = TestflingerCliAuth(
-            auth_method, self.client_id, self.secret_key, self.client
+            self.client, auth_method, self.client_id, self.secret_key
         )
 
     def run(self):

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -149,7 +149,6 @@ class TestflingerCli:
             or os.environ.get("TESTFLINGER_ERROR_THRESHOLD")
             or consts.TESTFLINGER_ERROR_THRESHOLD
         )
-        auth_method = getattr(self.args, "method", "credentials")
 
         # Allow config subcommand without worrying about server or client
         if hasattr(self.args, "func") and self.args.func == self.configure:
@@ -161,7 +160,7 @@ class TestflingerCli:
             )
         self.client = client.Client(server, error_threshold=error_threshold)
         self.auth = TestflingerCliAuth(
-            self.client, auth_method, self.client_id, self.secret_key
+            self.client, self.client_id, self.secret_key
         )
 
     def run(self):
@@ -187,6 +186,7 @@ class TestflingerCli:
         parser.add_argument(
             "--server", default=None, help="Testflinger server to use"
         )
+        parser.set_defaults(client_id=None, secret_key=None)
         subparsers = parser.add_subparsers()
         self.admin_cli = TestflingerAdminCLI(subparsers, self)
         self._add_artifacts_args(subparsers)
@@ -213,6 +213,12 @@ class TestflingerCli:
         except SnapPrivateFileError as exc:
             parser.error(exc)
         self.help = parser.format_help()
+
+        # Early validation of credentials
+        if bool(self.args.client_id) != bool(self.args.secret_key):
+            parser.error(
+                "Both --client-id and --secret-key must be provided together"
+            )
 
     def _add_auth_args(self, parser):
         parser.add_argument(
@@ -291,17 +297,6 @@ class TestflingerCli:
             help="Authenticate with server",
         )
         parser.set_defaults(func=self.login)
-        parser.add_argument(
-            "--method",
-            nargs="?",
-            choices=["credentials", "oidc"],
-            default="credentials",
-            help=(
-                "Authentication method to use. "
-                "'credentials' uses client-id and secret-key (default). "
-                "'oidc' opens a browser for IDP-based login."
-            ),
-        )
         self._add_auth_args(parser)
 
     def _add_poll_args_generic(self, parser):

--- a/cli/testflinger_cli/auth.py
+++ b/cli/testflinger_cli/auth.py
@@ -18,7 +18,6 @@
 
 import configparser
 import contextlib
-import sys
 import time
 import webbrowser
 from functools import cached_property, wraps
@@ -34,6 +33,7 @@ from testflinger_cli.errors import (
     AuthenticationError,
     AuthorizationError,
     InvalidTokenError,
+    OidcError,
 )
 
 
@@ -43,11 +43,9 @@ class TestflingerCliAuth:
     def __init__(
         self,
         tf_client: client.Client,
-        method: str = "credentials",
         client_id: str | None = None,
         secret_key: str | None = None,
     ):
-        self.method = method
         self.client_id: Optional[str] = client_id
         self.secret_key = secret_key
         self.client = tf_client
@@ -75,20 +73,29 @@ class TestflingerCliAuth:
         :raises InvalidTokenError: Refresh token already expired
         :return: string with access token (jwt token)
         """
-        # If OIDC method is selected, initialize OIDC device auth flow
-        if self.method == "oidc":
-            return self._authenticate_with_oidc()
-
-        # Authenticate with credentials if provided in args or env file
+        # 1. Attempt to authenticate with credentials from args or envvars
+        # Higher priority to honor users intent when credentials present
         if self.client_id and self.secret_key:
             return self._authenticate_with_credentials()
 
-        # Authenticate with refresh token if available
+        # 2. Authenticate with refresh token if available
+        # This covers persistent login for both credentials and OIDC logins
         refresh_token = self.get_stored_refresh_token()
+        token_expired: InvalidTokenError | None = None
         if refresh_token:
-            return self._authenticate_with_refresh_token(refresh_token)
+            try:
+                return self._authenticate_with_refresh_token(refresh_token)
+            except InvalidTokenError as exc:
+                token_expired = exc
 
-        return None
+        # 3. Authenticate with OIDC if no credentials or refresh token
+        # This should fail gracefully if OIDC is not enabled on the server
+        access_token = self._authenticate_with_oidc()
+        if not access_token and token_expired:
+            # If neither authentication method worked and refresh token invalid
+            # raise the InvalidTokenError to force reauthentication
+            raise token_expired
+        return access_token
 
     def _authenticate_with_credentials(self) -> str | None:
         """Authenticate using client_id and secret_key."""
@@ -113,7 +120,9 @@ class TestflingerCliAuth:
         except client.HTTPError as exc:
             if exc.status == HTTPStatus.BAD_REQUEST:
                 self.clear_refresh_token()
-                raise InvalidTokenError(exc.msg) from exc
+                raise InvalidTokenError(
+                    "Invalid or expired refresh token."
+                ) from exc
             self._handle_auth_error(exc)
             return None
 
@@ -227,7 +236,13 @@ class TestflingerCliAuth:
         try:
             init_data = self.client.oidc_auth_initiate()
         except client.HTTPError as exc:
-            sys.exit(f"Failed to initiate OIDC login: {exc.msg}")
+            if exc.status == HTTPStatus.NOT_FOUND:
+                # Server does not have OIDC enabled
+                # Need to return None to fail gracefully
+                return None
+            raise OidcError(
+                f"Failed to initiate OIDC login: {exc.msg}"
+            ) from exc
 
         verification_uri = init_data["verification_uri"]
         user_code = init_data["user_code"]
@@ -264,16 +279,20 @@ class TestflingerCliAuth:
                     case "slow_down":
                         interval += int(exc.headers.get("Retry-After", 5))
                     case "access_denied":
-                        sys.exit("Authentication failed: access denied")
+                        raise OidcError(
+                            "Authentication failed: access denied"
+                        ) from exc
                     case "expired_token":
-                        sys.exit("Authentication timed out. Please try again.")
+                        raise OidcError(
+                            "Authentication timed out. Please try again."
+                        ) from exc
                     case _:
-                        sys.exit(
+                        raise OidcError(
                             "Unexpected error during OIDC "
                             f"authentication: {exc.msg}"
-                        )
+                        ) from exc
 
-        sys.exit("Authentication timed out. Please try again.")
+        raise OidcError("Authentication timed out. Please try again.")
 
 
 def require_role(*roles):

--- a/cli/testflinger_cli/auth.py
+++ b/cli/testflinger_cli/auth.py
@@ -18,6 +18,9 @@
 
 import configparser
 import contextlib
+import sys
+import time
+import webbrowser
 from functools import cached_property, wraps
 from http import HTTPStatus
 from typing import Optional
@@ -37,7 +40,14 @@ from testflinger_cli.errors import (
 class TestflingerCliAuth:
     """Class to handle authentication and authorisation for Testflinger CLI."""
 
-    def __init__(self, client_id: str | None, secret_key: str, tf_client):
+    def __init__(
+        self,
+        method: str = "credentials",
+        client_id: str | None = None,
+        secret_key: str | None = None,
+        tf_client: client.Client = None,
+    ):
+        self.method = method
         self.client_id: Optional[str] = client_id
         self.secret_key = secret_key
         self.client = tf_client
@@ -65,6 +75,10 @@ class TestflingerCliAuth:
         :raises InvalidTokenError: Refresh token already expired
         :return: string with access token (jwt token)
         """
+        # If OIDC method is selected, initialize OIDC device auth flow
+        if self.method == "oidc":
+            return self._authenticate_with_oidc()
+
         # Authenticate with credentials if provided in args or env file
         if self.client_id and self.secret_key:
             return self._authenticate_with_credentials()
@@ -168,22 +182,23 @@ class TestflingerCliAuth:
             else None
         )
 
-    def decode_jwt_token(self) -> Optional[dict]:
+    def decode_jwt_token(self, token: str | None = None) -> Optional[dict]:
         """Decode JWT token without verifying signature.
 
         This is not for security but for quick screening,
         server will still enforce the JWT token validation.
 
+        :param token: optional token to decode, defaults to self.jwt_token
         :return: Dict with the decoded JWT
         """
-        if not self.is_authenticated() or not self.jwt_token:
+        token_to_decode = token or self.jwt_token
+        if not token_to_decode:
             return None
 
         try:
-            decoded_jwt = jwt.decode(
-                self.jwt_token, options={"verify_signature": False}
+            return jwt.decode(
+                token_to_decode, options={"verify_signature": False}
             )
-            return decoded_jwt
         except jwt.exceptions.DecodeError:
             return None
 
@@ -206,6 +221,59 @@ class TestflingerCliAuth:
         # If there is a decoded token, the user was authenticated
         # Default role for legacy client_ids is contributor
         return permissions.get("role", ServerRoles.CONTRIBUTOR)
+
+    def _authenticate_with_oidc(self) -> str | None:
+        """Authenticate using OIDC device flow."""
+        try:
+            init_data = self.client.oidc_auth_initiate()
+        except client.HTTPError as exc:
+            sys.exit(f"Failed to initiate OIDC login: {exc.msg}")
+
+        verification_uri = init_data["verification_uri"]
+        user_code = init_data["user_code"]
+        interval = init_data.get("interval", 5)
+        expires_in = init_data.get("expires_in", 300)
+        request_id = init_data["request_id"]
+
+        print(
+            f"Please visit {verification_uri} and enter code "
+            f"{user_code} to login."
+        )
+
+        # Attempt to launch the browser for the user to login
+        webbrowser.open(verification_uri)
+
+        code_expiration = time.monotonic() + expires_in
+        while time.monotonic() < code_expiration:
+            time.sleep(interval)
+            try:
+                auth_data = self.client.oidc_auth_poll(request_id)
+                decoded = self.decode_jwt_token(auth_data["access_token"])
+                self.client_id = (
+                    decoded.get("permissions", {}).get("client_id")
+                    if decoded
+                    else None
+                )
+                if self.client_id:
+                    self.store_refresh_token(auth_data["refresh_token"])
+                return auth_data["access_token"]
+            except client.HTTPError as exc:
+                match exc.error_code:
+                    case "authorization_pending":
+                        pass
+                    case "slow_down":
+                        interval += int(exc.headers.get("Retry-After", 5))
+                    case "access_denied":
+                        sys.exit("Authentication failed: access denied")
+                    case "expired_token":
+                        sys.exit("Authentication timed out. Please try again.")
+                    case _:
+                        sys.exit(
+                            "Unexpected error during OIDC "
+                            f"authentication: {exc.msg}"
+                        )
+
+        sys.exit("Authentication timed out. Please try again.")
 
 
 def require_role(*roles):

--- a/cli/testflinger_cli/auth.py
+++ b/cli/testflinger_cli/auth.py
@@ -42,10 +42,10 @@ class TestflingerCliAuth:
 
     def __init__(
         self,
+        tf_client: client.Client,
         method: str = "credentials",
         client_id: str | None = None,
         secret_key: str | None = None,
-        tf_client: client.Client = None,
     ):
         self.method = method
         self.client_id: Optional[str] = client_id

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -39,10 +39,12 @@ MAX_BACKOFF_TIME = 60
 class HTTPError(Exception):
     """Exception class for HTTP error codes."""
 
-    def __init__(self, status, msg=""):
+    def __init__(self, status, msg="", headers=None, error_code=None):
         super().__init__(status)
         self.status = status
         self.msg = msg
+        self.headers = headers or {}
+        self.error_code = error_code
 
 
 class Client:
@@ -68,10 +70,14 @@ class Client:
                 raise VPNError from exc
 
             # Raise HTTPError with clear text message if any other ValueError
-            raise HTTPError(status=req.status_code, msg=req.text) from exc
+            raise HTTPError(
+                status=req.status_code, msg=req.text, headers=req.headers
+            ) from exc
 
         # flask `abort` returns a JSON object with error message
         error_message = error_json.get("message", req.text)
+        # Oauth2 error responses may include an "error" field
+        error_code = error_json.get("error")
         # For schema validation errors, try to get detailed error info
         if req.status_code == HTTPStatus.UNPROCESSABLE_ENTITY and (
             validation_errors := error_json.get("detail", {}).get("json", {})
@@ -81,7 +87,12 @@ class Client:
             )
             error_message = f"{error_message} - {error_details}"
 
-        raise HTTPError(status=req.status_code, msg=error_message)
+        raise HTTPError(
+            status=req.status_code,
+            msg=error_message,
+            headers=req.headers,
+            error_code=error_code,
+        )
 
     def get(
         self, uri_frag: str, timeout: int = 15, headers: dict | None = None
@@ -495,3 +506,23 @@ class Client:
         """
         endpoint = f"/v1/client-permissions/{tf_client_id}"
         self.delete(endpoint, headers=auth_header)
+
+    def oidc_auth_initiate(self) -> dict:
+        """Initiate OIDC authentication with the server.
+
+        :return: dict containing required OIDC parameters for client to
+            authenticate with provider
+        """
+        endpoint = "/oidc/auth-init"
+        response = self.post(endpoint, data={})
+        return json.loads(response)
+
+    def oidc_auth_poll(self, request_id: str) -> dict:
+        """Poll for OIDC authentication result based on request ID.
+
+        :param request_id: unique request ID generated during auth initiation
+        :return: dict containing auth result and TF tokens if successful
+        """
+        endpoint = f"/oidc/auth-poll/{request_id}"
+        response = self.post(endpoint, data={})
+        return json.loads(response)

--- a/cli/testflinger_cli/client.py
+++ b/cli/testflinger_cli/client.py
@@ -76,8 +76,6 @@ class Client:
 
         # flask `abort` returns a JSON object with error message
         error_message = error_json.get("message", req.text)
-        # Oauth2 error responses may include an "error" field
-        error_code = error_json.get("error")
         # For schema validation errors, try to get detailed error info
         if req.status_code == HTTPStatus.UNPROCESSABLE_ENTITY and (
             validation_errors := error_json.get("detail", {}).get("json", {})
@@ -87,6 +85,8 @@ class Client:
             )
             error_message = f"{error_message} - {error_details}"
 
+        # Oauth2 error responses may include an "error" field
+        error_code = error_json.get("error")
         raise HTTPError(
             status=req.status_code,
             msg=error_message,

--- a/cli/testflinger_cli/errors.py
+++ b/cli/testflinger_cli/errors.py
@@ -106,3 +106,14 @@ class VPNError(NetworkError):
             "403 Forbidden Error: Server access requires a VPN connection.\n"
             "Please make sure you are connected to the VPN and try again."
         )
+
+
+class OidcError(CredentialsError):
+    """Exception thrown when OIDC authentication fails."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(
+            "OIDC authentication with Testflinger server failed with "
+            f"following reason: {reason} "
+            "Please reauthenticate with server."
+        )

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -19,6 +19,7 @@ import uuid
 import jwt
 import pytest
 
+from testflinger_cli.enums import ServerRoles
 from testflinger_cli.status_line import StatusLine
 
 from .test_cli import URL
@@ -27,6 +28,7 @@ from .test_cli import URL
 TEST_CLIENT_ID = "my_client_id"
 TEST_SECRET_KEY = "my_secret_key"
 JWT_SIGNING_KEY = "my-secret"
+OIDC_USER = "user@example.com"
 
 
 @pytest.fixture(autouse=True)
@@ -67,7 +69,51 @@ def auth_fixture(monkeypatch, requests_mock):
     return _fixture
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
+def oidc_auth_fixture(requests_mock):
+    """Configure fixture for tests that require OIDC authentication."""
+    fake_access_token = jwt.encode(
+        {
+            "permissions": {
+                "client_id": OIDC_USER,
+                "role": ServerRoles.CONTRIBUTOR,
+            }
+        },
+        JWT_SIGNING_KEY,
+        algorithm="HS256",
+    )
+    request_id = "test-oidc-request-id"
+
+    def _fixture(poll_responses):
+        requests_mock.post(
+            f"{URL}/oidc/auth-init",
+            json={
+                "verification_uri": "http://example.com/device",
+                "user_code": "ABCD-1234",
+                "expires_in": 300,
+                "interval": 5,
+                "request_id": request_id,
+            },
+        )
+        responses = (
+            poll_responses
+            if isinstance(poll_responses, list)
+            else [poll_responses]
+        )
+        requests_mock.post(f"{URL}/oidc/auth-poll/{request_id}", responses)
+
+    _fixture.oidc_user = OIDC_USER
+    _fixture.success_response = {
+        "json": {
+            "access_token": fake_access_token,
+            "token_type": "Bearer",
+            "expires_in": 30,
+            "refresh_token": str(uuid.uuid4()),
+        }
+    }
+    return _fixture
+
+
 def reset_status_line():
     """Reset StatusLine state before and after each test."""
     # Reset before test

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -114,6 +114,7 @@ def oidc_auth_fixture(requests_mock):
     return _fixture
 
 
+@pytest.fixture(autouse=True)
 def reset_status_line():
     """Reset StatusLine state before and after each test."""
     # Reset before test

--- a/cli/tests/test_cli_auth.py
+++ b/cli/tests/test_cli_auth.py
@@ -17,7 +17,6 @@
 
 import configparser
 import json
-import os
 import sys
 import uuid
 from http import HTTPStatus
@@ -29,6 +28,7 @@ import testflinger_cli
 from testflinger_cli.enums import ServerRoles
 from testflinger_cli.errors import NetworkError
 
+from .conftest import TEST_CLIENT_ID
 from .test_cli import URL
 
 
@@ -302,7 +302,6 @@ def test_cli_login_defaults_credentials(auth_fixture, capsys):
     """Test login command with default method authentication."""
     # This loads credentials as environment variables for the test
     auth_fixture(ServerRoles.CONTRIBUTOR)
-    client_id = os.environ.get("TESTFLINGER_CLIENT_ID")
 
     sys.argv = ["", "login"]
     tfcli = testflinger_cli.TestflingerCli()
@@ -312,7 +311,7 @@ def test_cli_login_defaults_credentials(auth_fixture, capsys):
     refresh_token = tfcli.auth.get_stored_refresh_token()
 
     assert refresh_token is not None
-    assert f"Successfully authenticated as '{client_id}'" in std.out
+    assert f"Successfully authenticated as '{TEST_CLIENT_ID}'" in std.out
 
 
 @patch("testflinger_cli.auth.time.sleep")

--- a/cli/tests/test_cli_auth.py
+++ b/cli/tests/test_cli_auth.py
@@ -396,7 +396,7 @@ def test_login_oidc_poll_terminal_errors(
 def test_login_oidc_poll_pending_then_success(
     mock_open, mock_sleep, oidc_auth_fixture, capsys
 ):
-    """Test OIDC polling retries on 202 until authentication completes."""
+    """Test OIDC poll retries on authorization_pending until auth succeeds."""
     oidc_auth_fixture(
         [
             {
@@ -421,7 +421,7 @@ def test_login_oidc_poll_pending_then_success(
 def test_login_oidc_poll_slow_down(
     mock_open, mock_sleep, oidc_auth_fixture, capsys
 ):
-    """Test OIDC polling increases interval on 429 using Retry-After header."""
+    """Test OIDC polling increases interval using Retry-After header."""
     oidc_auth_fixture(
         [
             {

--- a/cli/tests/test_cli_auth.py
+++ b/cli/tests/test_cli_auth.py
@@ -17,9 +17,11 @@
 
 import configparser
 import json
+import os
 import sys
 import uuid
 from http import HTTPStatus
+from unittest.mock import call, patch
 
 import pytest
 
@@ -233,21 +235,6 @@ def test_authentication_error(tmp_path, requests_mock, monkeypatch):
     assert "Authentication with Testflinger server failed" in str(err.value)
 
 
-def test_cli_login(auth_fixture, capsys):
-    """Test authentication succeeds when running login command."""
-    auth_fixture(ServerRoles.CONTRIBUTOR)
-
-    sys.argv = ["", "login"]
-    tfcli = testflinger_cli.TestflingerCli()
-    tfcli.login()
-    std = capsys.readouterr()
-    # Make sure login also stores refresh token
-    refresh_token = tfcli.auth.get_stored_refresh_token()
-
-    assert refresh_token is not None
-    assert "Successfully authenticated as user" in std.out
-
-
 def test_multiple_login_clear_refresh_token(auth_fixture):
     """Test multiple user login clears refresh_token and issue new one."""
     auth_fixture(ServerRoles.CONTRIBUTOR)
@@ -309,3 +296,147 @@ def test_refresh_token_expired(tmp_path, requests_mock, monkeypatch):
     history = requests_mock.request_history
     assert len(history) == 2
     assert history[1].path == "/v1/oauth2/refresh"
+
+
+def test_cli_login_defaults_credentials(auth_fixture, capsys):
+    """Test login command with default method authentication."""
+    # This loads credentials as environment variables for the test
+    auth_fixture(ServerRoles.CONTRIBUTOR)
+    client_id = os.environ.get("TESTFLINGER_CLIENT_ID")
+
+    sys.argv = ["", "login"]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.login()
+    std = capsys.readouterr()
+    # Make sure login also stores refresh token
+    refresh_token = tfcli.auth.get_stored_refresh_token()
+
+    assert refresh_token is not None
+    assert f"Successfully authenticated as '{client_id}'" in std.out
+
+
+@patch("testflinger_cli.auth.time.sleep")
+@patch("testflinger_cli.auth.webbrowser.open")
+def test_login_with_oidc(mock_open, mock_sleep, oidc_auth_fixture, capsys):
+    """Test login with OIDC method."""
+    oidc_auth_fixture(oidc_auth_fixture.success_response)
+
+    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.login()
+    std = capsys.readouterr()
+
+    assert tfcli.auth.get_stored_refresh_token() is not None
+    assert (
+        f"Successfully authenticated as '{oidc_auth_fixture.oidc_user}'"
+        in std.out
+    )
+
+
+def test_login_initiate_oidc_failure(requests_mock):
+    """Test login with OIDC method fails if auth-init endpoint fails."""
+    requests_mock.post(
+        f"{URL}/oidc/auth-init",
+        status_code=HTTPStatus.BAD_GATEWAY,
+        text="OIDC provider unreachable",
+    )
+
+    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    tfcli = testflinger_cli.TestflingerCli()
+    with pytest.raises(SystemExit) as exc:
+        tfcli.login()
+
+    assert "Failed to initiate OIDC login" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "poll_response, expected_message",
+    [
+        (
+            {
+                "status_code": HTTPStatus.BAD_REQUEST,
+                "json": {"error": "access_denied"},
+            },
+            "Authentication failed: access denied",
+        ),
+        (
+            {
+                "status_code": HTTPStatus.BAD_REQUEST,
+                "json": {"error": "expired_token"},
+            },
+            "Authentication timed out",
+        ),
+        (
+            {
+                "status_code": HTTPStatus.BAD_GATEWAY,
+                "json": {"message": "infra error"},
+            },
+            "Unexpected error during OIDC authentication",
+        ),
+    ],
+)
+@patch("testflinger_cli.auth.time.sleep")
+@patch("testflinger_cli.auth.webbrowser.open")
+def test_login_oidc_poll_terminal_errors(
+    mock_open, mock_sleep, oidc_auth_fixture, poll_response, expected_message
+):
+    """Test OIDC polling exits on RFC 8628 terminal error codes."""
+    oidc_auth_fixture(poll_response)
+
+    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    tfcli = testflinger_cli.TestflingerCli()
+    with pytest.raises(SystemExit) as exc:
+        tfcli.login()
+
+    assert expected_message in str(exc.value)
+
+
+@patch("testflinger_cli.auth.time.sleep")
+@patch("testflinger_cli.auth.webbrowser.open")
+def test_login_oidc_poll_pending_then_success(
+    mock_open, mock_sleep, oidc_auth_fixture, capsys
+):
+    """Test OIDC polling retries on 202 until authentication completes."""
+    oidc_auth_fixture(
+        [
+            {
+                "status_code": HTTPStatus.BAD_REQUEST,
+                "json": {"error": "authorization_pending"},
+            },
+            oidc_auth_fixture.success_response,
+        ]
+    )
+
+    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.login()
+
+    # sleep called once before 400, once before 200
+    assert mock_sleep.call_args_list == [call(5), call(5)]
+    assert tfcli.auth.get_stored_refresh_token() is not None
+
+
+@patch("testflinger_cli.auth.time.sleep")
+@patch("testflinger_cli.auth.webbrowser.open")
+def test_login_oidc_poll_slow_down(
+    mock_open, mock_sleep, oidc_auth_fixture, capsys
+):
+    """Test OIDC polling increases interval on 429 using Retry-After header."""
+    oidc_auth_fixture(
+        [
+            {
+                "status_code": HTTPStatus.BAD_REQUEST,
+                "headers": {"Retry-After": "5"},
+                "json": {"error": "slow_down"},
+            },
+            oidc_auth_fixture.success_response,
+        ]
+    )
+
+    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.login()
+
+    # interval starts at 5, increases by Retry-After (5) after slow_down
+    assert mock_sleep.call_args_list == [call(5), call(10)]
+    assert tfcli.auth.get_stored_refresh_token() is not None

--- a/cli/tests/test_cli_auth.py
+++ b/cli/tests/test_cli_auth.py
@@ -127,6 +127,9 @@ def test_retrieve_regular_user_role(tmp_path, requests_mock):
     job_file.write_text(json.dumps(job_data))
 
     requests_mock.post(f"{URL}/v1/oauth2/token")
+    requests_mock.post(
+        f"{URL}/oidc/auth-init", status_code=HTTPStatus.NOT_FOUND
+    )
     sys.argv = ["", "submit", str(job_file)]
     tfcli = testflinger_cli.TestflingerCli()
     role = tfcli.auth.get_user_role()
@@ -282,6 +285,10 @@ def test_refresh_token_expired(tmp_path, requests_mock, monkeypatch):
         text="Refresh token expired",
         status_code=HTTPStatus.BAD_REQUEST,
     )
+    # OIDC not enabled on this server
+    requests_mock.post(
+        f"{URL}/oidc/auth-init", status_code=HTTPStatus.NOT_FOUND
+    )
     # Mock agents endpoint for available agents
     requests_mock.get(
         f"{URL}/v1/queues/fake/agents",
@@ -294,7 +301,7 @@ def test_refresh_token_expired(tmp_path, requests_mock, monkeypatch):
     assert "Please reauthenticate with server" in str(exc.value)
 
     history = requests_mock.request_history
-    assert len(history) == 2
+    assert len(history) == 3
     assert history[1].path == "/v1/oauth2/refresh"
 
 
@@ -320,7 +327,7 @@ def test_login_with_oidc(mock_open, mock_sleep, oidc_auth_fixture, capsys):
     """Test login with OIDC method."""
     oidc_auth_fixture(oidc_auth_fixture.success_response)
 
-    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    sys.argv = ["testflinger-cli", "login"]
     tfcli = testflinger_cli.TestflingerCli()
     tfcli.login()
     std = capsys.readouterr()
@@ -340,7 +347,7 @@ def test_login_initiate_oidc_failure(requests_mock):
         text="OIDC provider unreachable",
     )
 
-    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    sys.argv = ["testflinger-cli", "login"]
     tfcli = testflinger_cli.TestflingerCli()
     with pytest.raises(SystemExit) as exc:
         tfcli.login()
@@ -382,7 +389,7 @@ def test_login_oidc_poll_terminal_errors(
     """Test OIDC polling exits on RFC 8628 terminal error codes."""
     oidc_auth_fixture(poll_response)
 
-    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    sys.argv = ["testflinger-cli", "login"]
     tfcli = testflinger_cli.TestflingerCli()
     with pytest.raises(SystemExit) as exc:
         tfcli.login()
@@ -406,7 +413,7 @@ def test_login_oidc_poll_pending_then_success(
         ]
     )
 
-    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    sys.argv = ["testflinger-cli", "login"]
     tfcli = testflinger_cli.TestflingerCli()
     tfcli.login()
 
@@ -432,7 +439,7 @@ def test_login_oidc_poll_slow_down(
         ]
     )
 
-    sys.argv = ["testflinger-cli", "login", "--method", "oidc"]
+    sys.argv = ["testflinger-cli", "login"]
     tfcli = testflinger_cli.TestflingerCli()
     tfcli.login()
 

--- a/cli/tests/test_secret.py
+++ b/cli/tests/test_secret.py
@@ -164,8 +164,13 @@ def test_secret_delete_http_error(auth_fixture, requests_mock):
 
 
 @pytest.mark.parametrize("subcommand", ["write", "delete"])
-def test_secret_no_authentication(subcommand):
+def test_secret_no_authentication(subcommand, requests_mock):
     """Test secret operations fail when authentication is not configured."""
+    # OIDC not enabled on this server
+    requests_mock.post(
+        f"{URL}/oidc/auth-init", status_code=HTTPStatus.NOT_FOUND
+    )
+
     if subcommand == "write":
         sys.argv = ["", "secret", "write", "test/path", "test_value"]
     else:

--- a/cli/tests/test_secret.py
+++ b/cli/tests/test_secret.py
@@ -238,6 +238,10 @@ def test_secret_invalid_token_error(requests_mock, subcommand):
         text="Refresh token expired",
         status_code=HTTPStatus.BAD_REQUEST,
     )
+    # OIDC not enabled on this server
+    requests_mock.post(
+        f"{URL}/oidc/auth-init", status_code=HTTPStatus.NOT_FOUND
+    )
 
     if subcommand == "write":
         sys.argv = ["", "secret", "write", "test/path", "test_value"]

--- a/server/charm/src/config.py
+++ b/server/charm/src/config.py
@@ -79,6 +79,7 @@ class TestflingerServerConfig(pydantic.BaseModel):
         ]
         if any(required_oidc_params) and not all(required_oidc_params):
             raise ValueError(
-                "All OIDC parameters must be set if any are configured"
+                "oidc_client_id, oidc_provider_issuer, and web_secret_key"
+                " must all be set if any OIDC configuration is provided"
             )
         return self

--- a/server/charm/src/config.py
+++ b/server/charm/src/config.py
@@ -71,14 +71,13 @@ class TestflingerServerConfig(pydantic.BaseModel):
 
     @pydantic.model_validator(mode="after")
     def validate_oidc_config(self):
-        """Validate that all OIDC parameters are set if any are configured."""
-        oidc_params = [
+        """Validate required OIDC parameters are set if any are configured."""
+        required_oidc_params = [
             self.oidc_client_id,
-            self.oidc_client_secret,
             self.oidc_provider_issuer,
             self.web_secret_key,
         ]
-        if any(oidc_params) and not all(oidc_params):
+        if any(required_oidc_params) and not all(required_oidc_params):
             raise ValueError(
                 "All OIDC parameters must be set if any are configured"
             )

--- a/server/charm/tests/unit/test_config.py
+++ b/server/charm/tests/unit/test_config.py
@@ -86,14 +86,6 @@ def test_invalid_oidc_configuration():
             web_secret_key="web-secret-key",  # noqa: S106
         )
 
-    # Missing oidc_client_secret
-    with pytest.raises(ValueError):
-        TestflingerServerConfig(
-            oidc_client_id="client-id",
-            oidc_provider_issuer="https://oidc-provider.local",
-            web_secret_key="web-secret-key",  # noqa: S106
-        )
-
     # Missing oidc_client_id
     with pytest.raises(ValueError):
         TestflingerServerConfig(

--- a/server/devel/dex-config.yaml
+++ b/server/devel/dex-config.yaml
@@ -1,4 +1,4 @@
-issuer: http://dex:5556/dex
+issuer: http://dex:5556
 storage:
   type: memory
 web:
@@ -9,11 +9,18 @@ staticClients:
       - 'http://testflinger-server:5000/auth/callback'
       - 'http://localhost:5000/auth/callback'
       - 'http://127.0.0.1:5000/auth/callback'
+      - '/device/callback'
     name: 'Testflinger Dev'
-    secret: my-oidc-secret
+    public: true
+    grantTypes:
 enablePasswordDB: true
 staticPasswords:
   - email: "testflinger@example.com"
     hash: "$2a$10$FWI.y.8Zpa9PhTTcV6GDIuxPzrwYJoiVCimgCA427HoyR5FR50mBu"
     username: "testflinger-admin"
     userID: "1234"
+oauth2:
+  grantTypes:
+    - "authorization_code"
+    - "refresh_token"
+    - "urn:ietf:params:oauth:grant-type:device_code"

--- a/server/devel/openapi_app.py
+++ b/server/devel/openapi_app.py
@@ -28,6 +28,7 @@ Usage:
 
 from dataclasses import dataclass
 from testflinger.application import create_flask_app
+from testflinger.oidc.api import oidc_api
 
 
 @dataclass
@@ -39,3 +40,7 @@ class OpenAPIConfig:
 
 # Create and expose the app in TESTING mode for Flask CLI to use
 app = create_flask_app(OpenAPIConfig)
+
+# Register OIDC blueprint unconditionally so /oidc endpoints appear in the
+# schema regardless of whether OIDC is configured
+app.register_blueprint(oidc_api, url_prefix="/oidc")

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       # TESTFLINGER_VAULT_URL: http://vault:8200
       WEB_SECRET_KEY: my_web_secret_key
       OIDC_CLIENT_ID: testflinger-client
-      OIDC_CLIENT_SECRET: my-oidc-secret
-      OIDC_PROVIDER_ISSUER: http://dex:5556/dex
+      OIDC_CLIENT_SECRET: ""
+      OIDC_PROVIDER_ISSUER: http://dex:5556
     command: --reload
     ports:
       - 5000:5000

--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -660,6 +660,65 @@
         "summary": "Prometheus Metrics"
       }
     },
+    "/oidc/auth-init": {
+      "post": {
+        "description": ":return: dict containing required OIDC parameters for client to\nauthenticate with provider",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful response"
+          }
+        },
+        "summary": "Initiate client request and proxy request to OIDC provider.",
+        "tags": [
+          "Oidc_Api"
+        ]
+      }
+    },
+    "/oidc/auth-poll/{request_id}": {
+      "post": {
+        "description": ":param request_id: unique request ID generated during auth initiation\n:return: dict containing authentication result and user info if successful",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPError"
+                }
+              }
+            },
+            "description": "Not found"
+          }
+        },
+        "summary": "Poll for OIDC authentication result based on request ID.",
+        "tags": [
+          "Oidc_Api"
+        ]
+      }
+    },
     "/v1/": {
       "get": {
         "parameters": [],
@@ -2427,6 +2486,9 @@
   "tags": [
     {
       "name": "V1"
+    },
+    {
+      "name": "Oidc_Api"
     }
   ]
 }

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -371,8 +371,8 @@ def issue_tokens(
     :param refresh_token_ttl: Optional expiration time for refresh token
     :return: Dict with access_token, token_type, expires_in, refresh_token
     """
-    secret_key = os.environ.get("JWT_SIGNING_KEY")
-    access_token = generate_access_token(allowed_resources, secret_key)
+    signing_key = os.environ.get("JWT_SIGNING_KEY")
+    access_token = generate_access_token(allowed_resources, signing_key)
 
     role = ServerRoles(allowed_resources.get("role", ServerRoles.CONTRIBUTOR))
     refresh_expires_in = (
@@ -384,13 +384,6 @@ def issue_tokens(
         client_id, expires_in=refresh_expires_in
     )
 
-    current_app.owasp_logger.authn_login_success(
-        userid=client_id,
-        description=(
-            f"Client {client_id} successfully authenticated with role {role}"
-        ),
-        **OWASPLogger.get_request_metadata(request),
-    )
     current_app.owasp_logger.authn_token_created(
         userid=client_id,
         entitlements=[role],

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -31,6 +31,19 @@ from testflinger_common.enums import ServerRoles
 from testflinger import database
 from testflinger.owasp import OWASPLogger
 
+DEFAULT_REFRESH_TOKEN_EXPIRATION = 6 * 24 * 60 * 60  # 6 days in seconds
+
+# Fields from client_permissions to include in the Testflinger JWT
+PERMISSIONS_FIELDS = frozenset(
+    {
+        "role",
+        "max_priority",
+        "allowed_queues",
+        "max_reservation_time",
+        "client_id",
+    }
+)
+
 
 def hash_secret(secret: str):
     """Securely hash a secret before storing in database.
@@ -341,6 +354,59 @@ def generate_refresh_token(client_id: str, expires_in: int | None) -> str:
     }
     database.add_refresh_token(token_data)
     return refresh_token
+
+
+def issue_tokens(
+    client_id: str,
+    allowed_resources: dict,
+    refresh_token_ttl: int | None = DEFAULT_REFRESH_TOKEN_EXPIRATION,
+) -> dict:
+    """Issue Testflinger access and refresh tokens for an authenticated client.
+
+    Handles token generation, refresh token expiration, and OWASP logging.
+    Used by both credential-based and OIDC-based authentication flows.
+
+    :param client_id: Testflinger client ID for which to issue tokens
+    :param allowed_resources: Permissions dict to encode into the JWT
+    :param refresh_token_ttl: Optional expiration time for refresh token
+    :return: Dict with access_token, token_type, expires_in, refresh_token
+    """
+    secret_key = os.environ.get("JWT_SIGNING_KEY")
+    access_token = generate_access_token(allowed_resources, secret_key)
+
+    role = ServerRoles(allowed_resources.get("role", ServerRoles.CONTRIBUTOR))
+    refresh_expires_in = (
+        None
+        if role in (ServerRoles.ADMIN, ServerRoles.MANAGER)
+        else refresh_token_ttl
+    )
+    refresh_token = generate_refresh_token(
+        client_id, expires_in=refresh_expires_in
+    )
+
+    current_app.owasp_logger.authn_login_success(
+        userid=client_id,
+        description=(
+            f"Client {client_id} successfully authenticated with role {role}"
+        ),
+        **OWASPLogger.get_request_metadata(request),
+    )
+    current_app.owasp_logger.authn_token_created(
+        userid=client_id,
+        entitlements=[role],
+        description=(
+            f"JWT access token and refresh token issued for "
+            f"client {client_id} with role: {role}."
+        ),
+        **OWASPLogger.get_request_metadata(request),
+    )
+
+    return {
+        "access_token": access_token,
+        "token_type": "Bearer",
+        "expires_in": 30,
+        "refresh_token": refresh_token,
+    }
 
 
 def validate_refresh_token(token: str) -> dict:

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -330,13 +330,12 @@ def require_role(*roles):
     return decorator
 
 
-def generate_refresh_token(client_id: str, expires_in: int | None) -> str:
+def generate_refresh_token(client_id: str, expires_in: int) -> str:
     """
     Generate opaque string as a new refresh token.
 
     :param client_id: Client ID associated with this refresh token.
-    :param expires_in: Expiration time in seconds (default 30 days).
-                       Set to None for non-expiring token.
+    :param expires_in: Expiration time in seconds.
 
     :return: Refresh token string.
     """
@@ -346,9 +345,7 @@ def generate_refresh_token(client_id: str, expires_in: int | None) -> str:
         "client_id": client_id,
         "refresh_token": refresh_token,
         "issued_at": now,
-        "expires_at": None
-        if expires_in is None
-        else now + timedelta(seconds=expires_in),
+        "expires_at": now + timedelta(seconds=expires_in),
         "revoked": False,
         "last_accessed": now,
     }
@@ -359,7 +356,7 @@ def generate_refresh_token(client_id: str, expires_in: int | None) -> str:
 def issue_tokens(
     client_id: str,
     allowed_resources: dict,
-    refresh_token_ttl: int | None = DEFAULT_REFRESH_TOKEN_EXPIRATION,
+    refresh_token_ttl: int = DEFAULT_REFRESH_TOKEN_EXPIRATION,
 ) -> dict:
     """Issue Testflinger access and refresh tokens for an authenticated client.
 
@@ -368,20 +365,15 @@ def issue_tokens(
 
     :param client_id: Testflinger client ID for which to issue tokens
     :param allowed_resources: Permissions dict to encode into the JWT
-    :param refresh_token_ttl: Optional expiration time for refresh token
+    :param refresh_token_ttl: Expiration time in seconds for the refresh token
     :return: Dict with access_token, token_type, expires_in, refresh_token
     """
     signing_key = os.environ.get("JWT_SIGNING_KEY")
     access_token = generate_access_token(allowed_resources, signing_key)
 
     role = ServerRoles(allowed_resources.get("role", ServerRoles.CONTRIBUTOR))
-    refresh_expires_in = (
-        None
-        if role in (ServerRoles.ADMIN, ServerRoles.MANAGER)
-        else refresh_token_ttl
-    )
     refresh_token = generate_refresh_token(
-        client_id, expires_in=refresh_expires_in
+        client_id, expires_in=refresh_token_ttl
     )
 
     current_app.owasp_logger.authn_token_created(

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -995,7 +995,7 @@ def retrieve_token():
             ),
             **OWASPLogger.get_request_metadata(request),
         )
-        return "No authorization header specified", 401
+        return "No authorization header specified", HTTPStatus.UNAUTHORIZED
 
     client_id = auth_header["username"]
     client_key = auth_header["password"]
@@ -1010,7 +1010,7 @@ def retrieve_token():
         )
         return (
             "Client id and key must be specified in authorization header",
-            401,
+            HTTPStatus.UNAUTHORIZED,
         )
 
     allowed_resources = auth.validate_client_key_pair(client_id, client_key)
@@ -1023,46 +1023,12 @@ def retrieve_token():
             ),
             **OWASPLogger.get_request_metadata(request),
         )
-        return "Invalid client id or client key", 401
+        return "Invalid client id or client key", HTTPStatus.UNAUTHORIZED
 
-    secret_key = os.environ.get("JWT_SIGNING_KEY")
-    access_token = auth.generate_access_token(allowed_resources, secret_key)
-
-    role = ServerRoles(allowed_resources.get("role", ServerRoles.CONTRIBUTOR))
-    if role in (ServerRoles.ADMIN, ServerRoles.MANAGER):
-        refresh_expires_in = None
-    else:
-        refresh_expires_in = 30 * 24 * 60 * 60  # 30 days in seconds
-
-    refresh_token = auth.generate_refresh_token(
-        client_id, expires_in=refresh_expires_in
+    return auth.issue_tokens(
+        client_id=client_id,
+        allowed_resources=allowed_resources,
     )
-
-    # Log successful authentication
-    entitlements = [role]
-    current_app.owasp_logger.authn_login_success(
-        userid=client_id,
-        description=(
-            f"Client {client_id} successfully authenticated with role {role}"
-        ),
-        **OWASPLogger.get_request_metadata(request),
-    )
-    current_app.owasp_logger.authn_token_created(
-        userid=client_id,
-        entitlements=entitlements,
-        description=(
-            f"JWT access token and refresh token issued for "
-            f"client {client_id} with role: {role}."
-        ),
-        **OWASPLogger.get_request_metadata(request),
-    )
-
-    return {
-        "access_token": access_token,
-        "token_type": "Bearer",
-        "expires_in": 30,
-        "refresh_token": refresh_token,
-    }
 
 
 @v1.post("/oauth2/refresh")
@@ -1082,8 +1048,13 @@ def refresh_access_token():
     client_id = token_entry["client_id"]
 
     client_permissions = database.get_client_permissions(client_id)
+    allowed_resources = {
+        permission: value
+        for permission, value in client_permissions.items()
+        if permission in auth.PERMISSIONS_FIELDS
+    }
     secret_key = os.environ.get("JWT_SIGNING_KEY")
-    access_token = auth.generate_access_token(client_permissions, secret_key)
+    access_token = auth.generate_access_token(allowed_resources, secret_key)
 
     # Log token refresh
     role = client_permissions.get("role")

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -1025,10 +1025,19 @@ def retrieve_token():
         )
         return "Invalid client id or client key", HTTPStatus.UNAUTHORIZED
 
-    return auth.issue_tokens(
+    auth_tokens = auth.issue_tokens(
         client_id=client_id,
         allowed_resources=allowed_resources,
     )
+    role = ServerRoles(allowed_resources.get("role", ServerRoles.CONTRIBUTOR))
+    current_app.owasp_logger.authn_login_success(
+        userid=client_id,
+        description=(
+            f"Client {client_id} successfully authenticated with role {role}"
+        ),
+        **OWASPLogger.get_request_metadata(request),
+    )
+    return auth_tokens
 
 
 @v1.post("/oauth2/refresh")

--- a/server/src/testflinger/application.py
+++ b/server/src/testflinger/application.py
@@ -28,6 +28,7 @@ from testflinger.api.v1 import LogTypeConverter, v1
 from testflinger.database import setup_mongodb
 from testflinger.extensions import metrics
 from testflinger.oidc import app_register_oidc
+from testflinger.oidc.api import oidc_api
 from testflinger.oidc.views import oidc_views
 from testflinger.owasp import OWASPLogger
 from testflinger.providers import ISODatetimeProvider
@@ -119,5 +120,6 @@ def create_flask_app(config=None, secrets_store=None):
     tf_app.register_blueprint(v1, url_prefix="/v1")
     if tf_app.oauth:
         tf_app.register_blueprint(oidc_views, url_prefix="/auth")
+        tf_app.register_blueprint(oidc_api, url_prefix="/oidc")
 
     return tf_app

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -17,7 +17,7 @@
 
 import os
 import urllib
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from flask_pymongo import PyMongo
@@ -28,6 +28,7 @@ from testflinger_common.enums import ServerRoles
 REFRESH_TOKEN_IDEL_EXPIRATION = 60 * 60 * 24 * 90  # 90 days
 DEFAULT_EXPIRATION = 60 * 60 * 24 * 7  # 7 days
 OUTPUT_EXPIRATION = 60 * 60 * 4  # 4 hours
+ACCOUNT_DELETE_EXPIRATION = 60 * 60 * 24 * 90  # 90 days
 
 mongo = PyMongo()
 
@@ -115,6 +116,14 @@ def create_indexes():
     # Remove refresh tokens that haven't been accessed over 90 days
     mongo.db.refresh_tokens.create_index(
         "last_accessed", expireAfterSeconds=REFRESH_TOKEN_IDEL_EXPIRATION
+    )
+
+    # Remove OIDC device codes after the defined expiration time
+    mongo.db.device_codes.create_index("expires_at", expireAfterSeconds=0)
+
+    # Remove stale client permissions after defined expiration
+    mongo.db.client_permissions.create_index(
+        "last_login", expireAfterSeconds=ACCOUNT_DELETE_EXPIRATION
     )
 
     # Faster lookups for common queries
@@ -575,42 +584,40 @@ def delete_refresh_token(token: str) -> None:
     mongo.db.refresh_tokens.delete_one({"refresh_token": token})
 
 
-def check_web_client_exists(sub: str):
-    """Validate the existance of a web client.
+def register_oidc_client(userinfo: dict) -> None:
+    """Register or update an OIDC user in client_permissions.
 
-    :param sub: Unique subject identifier returned by OIDC provider
-    :return: True or False based on client existance
+    This uses the OIDC subject identifier (sub) as the primary identity anchor,
+    but uses email as the client_id as human readable identifier for permission
+    lookups.
+
+    :param userinfo: User information dict from the OIDC id_token.
     """
-    return (
-        mongo.db.web_clients.find_one({"openid_sub": sub}, {"_id": False})
-        is not None
+    sub, email, name = (
+        userinfo["sub"],
+        userinfo.get("email", ""),
+        userinfo.get("name", ""),
     )
+    now = datetime.now(timezone.utc)
 
-
-def register_web_client(oidc_token: dict):
-    """Create a new web client upon first authentication.
-
-    If client already exists, will update the last login.
-
-    :param oidc_token: User information returned from OIDC provider.
-    """
-    sub = oidc_token["userinfo"]["sub"]
-    if check_web_client_exists(sub):
-        mongo.db.web_clients.update_one(
-            {"openid_sub": sub},
-            {"$set": {"last_login": datetime.now(timezone.utc)}},
-        )
-    else:
-        mongo.db.web_clients.insert_one(
-            {
-                "openid_sub": sub,
-                "email": oidc_token["userinfo"]["email"],
-                "name": oidc_token["userinfo"]["name"],
-                "created_at": datetime.now(timezone.utc),
-                "last_login": datetime.now(timezone.utc),
+    # Update or insert the OIDC user in client_permissions
+    # This uses the sub as the unique identifier but uses email as client_id
+    mongo.db.client_permissions.update_one(
+        {"sub": sub},
+        {
+            "$set": {
+                "client_id": email,
+                "name": name,
+                "last_login": now,
+            },
+            "$setOnInsert": {
+                "sub": sub,
                 "role": ServerRoles.CONTRIBUTOR,
-            }
-        )
+                "created_at": now,
+            },
+        },
+        upsert=True,
+    )
 
 
 def get_job_results(job_id: str):
@@ -638,3 +645,44 @@ def job_exists(job_id: str) -> bool:
     return (
         mongo.db.jobs.find_one({"job_id": job_id}, {"_id": True}) is not None
     )
+
+
+def add_oidc_device_code(device_code: str, request_id: str, expires_in: int):
+    """Add OIDC device code to the database with an expiration time.
+
+    :param device_code: The OIDC device code to store.
+    :param request_id: The unique request ID associated with the device code.
+    :param expires_in: The number of seconds until the device code expires.
+    """
+    mongo.db.device_codes.insert_one(
+        {
+            "device_code": device_code,
+            "request_id": request_id,
+            "expires_at": (
+                datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            ),
+        }
+    )
+
+
+def get_oidc_device_code(request_id: str) -> str | None:
+    """Retrieve the OIDC device code associated with a request ID.
+
+    :param request_id: The unique request ID to search for.
+    :return: The OIDC device code if found, or None if not found.
+    """
+    result = mongo.db.device_codes.find_one(
+        {"request_id": request_id}, {"_id": False, "device_code": True}
+    )
+    return result["device_code"] if result else None
+
+
+def delete_oidc_device_code(request_id: str) -> None:
+    """Delete the OIDC device code associated with a request ID.
+
+    while the TTL index will automatically remove expired device codes,
+    we need to ensure device code removal after successful authentication.
+
+    :param request_id: The unique request ID to delete.
+    """
+    mongo.db.device_codes.delete_one({"request_id": request_id})

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -123,7 +123,9 @@ def create_indexes():
 
     # Remove stale client permissions after defined expiration
     mongo.db.client_permissions.create_index(
-        "last_login", expireAfterSeconds=ACCOUNT_DELETE_EXPIRATION
+        "last_login",
+        expireAfterSeconds=ACCOUNT_DELETE_EXPIRATION,
+        partialFilterExpression={"sub": {"$exists": True}},
     )
 
     # Faster lookups for common queries

--- a/server/src/testflinger/oidc/__init__.py
+++ b/server/src/testflinger/oidc/__init__.py
@@ -48,7 +48,8 @@ def app_register_oidc(tf_app: APIFlask) -> OAuth | None:
     secret_key = tf_app.config["SECRET_KEY"]
 
     # If provider is not set, app will run without web authentication
-    if not all([client_id, client_secret, issuer, secret_key]):
+    # client_secret is optional: public clients may have none configured
+    if not all([client_id, issuer, secret_key]):
         logger.info("OIDC disabled due to missing configuration parameters")
         return None
 

--- a/server/src/testflinger/oidc/api.py
+++ b/server/src/testflinger/oidc/api.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2025 Canonical
+# Copyright (C) 2026 Canonical
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,11 +21,13 @@ from http import HTTPStatus
 
 import requests
 from apiflask import APIBlueprint, abort
-from flask import jsonify
+from flask import current_app, jsonify, request
+from testflinger_common.enums import ServerRoles
 
 from testflinger import database
 from testflinger.api import auth
 from testflinger.oidc import helpers
+from testflinger.owasp import OWASPLogger
 
 oidc_api = APIBlueprint("oidc_api", __name__)
 
@@ -101,10 +103,20 @@ def _register_and_issue_tokens(userinfo: dict, request_id: str) -> dict:
 
     # Delete device code after all operations have succeeded
     database.delete_oidc_device_code(request_id)
-    return auth.issue_tokens(
+    auth_tokens = auth.issue_tokens(
         client_id=client_id,
         allowed_resources=allowed_resources,
     )
+    role = ServerRoles(allowed_resources.get("role", ServerRoles.CONTRIBUTOR))
+    current_app.owasp_logger.authn_login_success(
+        userid=client_id,
+        description=(
+            f"Client {client_id} successfully authenticated via OIDC"
+            f" with role {role}"
+        ),
+        **OWASPLogger.get_request_metadata(request),
+    )
+    return auth_tokens
 
 
 @oidc_api.post("/auth-init")

--- a/server/src/testflinger/oidc/api.py
+++ b/server/src/testflinger/oidc/api.py
@@ -129,13 +129,36 @@ def oidc_auth_init() -> dict:
             data={"scope": "openid profile email"},
             headers={"content-type": "application/x-www-form-urlencoded"},
         )
-        oidc_response.raise_for_status()
-        oidc_data = oidc_response.json()
     except requests.RequestException:
         logger.exception("Failed to reach OIDC device authorization endpoint")
         abort(
             HTTPStatus.BAD_GATEWAY,
             message="Failed to communicate with OIDC provider",
+        )
+
+    if not oidc_response.ok:
+        logger.error(
+            "OIDC device authorization endpoint returned HTTP %s: %s",
+            oidc_response.status_code,
+            oidc_response.text,
+        )
+        abort(
+            HTTPStatus.BAD_GATEWAY,
+            message="OIDC provider rejected device authorization request",
+        )
+
+    try:
+        oidc_data = oidc_response.json()
+    except (ValueError, requests.exceptions.JSONDecodeError):
+        logger.error(
+            "Non-JSON response from OIDC device authorization endpoint"
+            " (status %s): %s",
+            oidc_response.status_code,
+            oidc_response.text,
+        )
+        abort(
+            HTTPStatus.BAD_GATEWAY,
+            message="OIDC provider returned an unexpected response",
         )
 
     device_code = oidc_data.pop("device_code", None)

--- a/server/src/testflinger/oidc/api.py
+++ b/server/src/testflinger/oidc/api.py
@@ -1,0 +1,203 @@
+# Copyright (C) 2022-2025 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""Testflinger OIDC API."""
+
+import logging
+import secrets
+from http import HTTPStatus
+
+import requests
+from apiflask import APIBlueprint, abort
+from flask import jsonify
+
+from testflinger import database
+from testflinger.api import auth
+from testflinger.oidc import helpers
+
+oidc_api = APIBlueprint("oidc_api", __name__)
+
+logger = logging.getLogger(__name__)
+
+REQUEST_ID_LENGTH = 32
+
+
+def _exchange_device_code(device_code: str) -> dict:
+    """Exchange a device code for tokens at the OIDC token endpoint.
+
+    :param device_code: device code received from the OIDC provider
+    :return: parsed JSON response from the OIDC token endpoint
+    """
+    token_endpoint = helpers.oidc_metadata().get("token_endpoint")
+    if not token_endpoint:
+        abort(
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            message="OIDC provider metadata missing token endpoint",
+        )
+
+    try:
+        token_response = helpers.oidc_post_request(
+            token_endpoint,
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": device_code,
+            },
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+    except requests.RequestException:
+        logger.exception("Failed to reach OIDC token endpoint")
+        abort(
+            HTTPStatus.BAD_GATEWAY,
+            message="Failed to communicate with OIDC provider",
+        )
+
+    try:
+        return token_response.json()
+    except (ValueError, requests.exceptions.JSONDecodeError):
+        logger.error(
+            "Non-JSON response from OIDC token endpoint (status %s)",
+            token_response.status_code,
+        )
+        abort(
+            HTTPStatus.BAD_GATEWAY,
+            message="OIDC provider returned an unexpected response",
+        )
+
+
+def _register_and_issue_tokens(userinfo: dict, request_id: str) -> dict:
+    """Register an OIDC user and issue Testflinger tokens.
+
+    :param userinfo: user info dict returned by the OIDC provider
+    :param request_id: unique request ID used to clean up the device code
+    :return: dict containing Testflinger access and refresh tokens
+    """
+    client_id = userinfo.get("email")
+    if not client_id:
+        abort(
+            HTTPStatus.BAD_GATEWAY,
+            message="OIDC provider did not return an email address",
+        )
+
+    database.register_oidc_client(userinfo)
+
+    client_permissions = database.get_client_permissions(client_id)
+    allowed_resources = {
+        permission: value
+        for permission, value in client_permissions.items()
+        if permission in auth.PERMISSIONS_FIELDS
+    }
+
+    # Delete device code after all operations have succeeded
+    database.delete_oidc_device_code(request_id)
+    return auth.issue_tokens(
+        client_id=client_id,
+        allowed_resources=allowed_resources,
+    )
+
+
+@oidc_api.post("/auth-init")
+def oidc_auth_init() -> dict:
+    """Initiate client request and proxy request to OIDC provider.
+
+    :return: dict containing required OIDC parameters for client to
+        authenticate with provider
+    """
+    device_auth_endpoint = helpers.oidc_metadata().get(
+        "device_authorization_endpoint"
+    )
+    if not device_auth_endpoint:
+        abort(
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            message="OIDC provider does not support device authorization",
+        )
+
+    try:
+        oidc_response = helpers.oidc_post_request(
+            device_auth_endpoint,
+            data={"scope": "openid profile email"},
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+        oidc_response.raise_for_status()
+        oidc_data = oidc_response.json()
+    except requests.RequestException:
+        logger.exception("Failed to reach OIDC device authorization endpoint")
+        abort(
+            HTTPStatus.BAD_GATEWAY,
+            message="Failed to communicate with OIDC provider",
+        )
+
+    device_code = oidc_data.pop("device_code", None)
+    if not device_code:
+        abort(
+            HTTPStatus.BAD_GATEWAY,
+            message="OIDC provider response missing device_code",
+        )
+
+    # Generate unique request ID for client to poll with based on device code
+    request_id = secrets.token_urlsafe(REQUEST_ID_LENGTH)
+
+    # Store device code in database with expiration for auth polling
+    database.add_oidc_device_code(
+        device_code=device_code,
+        request_id=request_id,
+        expires_in=oidc_data.get("expires_in", 300),
+    )
+
+    oidc_data["request_id"] = request_id
+    return oidc_data
+
+
+@oidc_api.post("/auth-poll/<request_id>")
+def oidc_auth_poll(request_id: str) -> dict:
+    """Poll for OIDC authentication result based on request ID.
+
+    :param request_id: unique request ID generated during auth initiation
+    :return: dict containing authentication result and user info if successful
+    """
+    device_code = database.get_oidc_device_code(request_id)
+    if not device_code:
+        abort(
+            HTTPStatus.BAD_REQUEST,
+            message="Invalid or expired request_id",
+        )
+
+    idp_token_data = _exchange_device_code(device_code)
+
+    if "error" in idp_token_data:
+        error = idp_token_data["error"]
+        if error == "authorization_pending":
+            return (
+                jsonify({"error": "authorization_pending"}),
+                HTTPStatus.BAD_REQUEST,
+            )
+        elif error == "slow_down":
+            response = jsonify({"error": "slow_down"})
+            response.headers["Retry-After"] = "5"
+            response.status_code = HTTPStatus.BAD_REQUEST
+            return response
+        else:
+            database.delete_oidc_device_code(request_id)
+            return jsonify({"error": error}), HTTPStatus.BAD_REQUEST
+
+    try:
+        userinfo = helpers.oidc_userinfo(idp_token_data["access_token"])
+    except (RuntimeError, requests.RequestException):
+        logger.exception("Failed to retrieve userinfo from OIDC provider")
+        abort(
+            HTTPStatus.BAD_GATEWAY,
+            message="Failed to retrieve user information from OIDC provider",
+        )
+
+    return _register_and_issue_tokens(userinfo, request_id)

--- a/server/src/testflinger/oidc/helpers.py
+++ b/server/src/testflinger/oidc/helpers.py
@@ -54,9 +54,8 @@ def oidc_post_request(
     client_secret = oidc_client().client_secret
 
     payload = dict(data or {})
+    payload["client_id"] = client_id
     basic_auth = (client_id, client_secret) if client_secret else None
-    if not basic_auth:
-        payload["client_id"] = client_id
 
     return requests.post(
         url,

--- a/server/src/testflinger/oidc/helpers.py
+++ b/server/src/testflinger/oidc/helpers.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Helpers module for OIDC."""
+
+import requests
+from authlib.integrations.flask_client import FlaskOAuth2App
+from flask import current_app
+
+
+def oidc_client() -> FlaskOAuth2App:
+    """Return the OIDC client from the current app.
+
+    :return: configured OIDC client for the current Flask app
+    """
+    return current_app.oauth.oidc
+
+
+def oidc_metadata() -> dict:
+    """Return the metadata from the OIDC provider.
+
+    :return: metadata dictionary from the OIDC provider
+    """
+    return oidc_client().load_server_metadata()
+
+
+def oidc_post_request(
+    url: str,
+    data: dict | None = None,
+    headers: dict | None = None,
+) -> requests.Response:
+    """Send a POST request to the OIDC provider with client auth.
+
+    Uses client_secret_basic (Authorization header) for confidential clients.
+    Falls back to including client_id in the request body for public clients.
+
+    :param url: URL to send the POST request to
+    :param data: optional dictionary of data to include in the request body
+    :param headers: optional dictionary of headers to include in the request
+    :return: Response object from the POST request
+    """
+    client_id = oidc_client().client_id
+    client_secret = oidc_client().client_secret
+
+    payload = dict(data or {})
+    basic_auth = (client_id, client_secret) if client_secret else None
+    if not basic_auth:
+        payload["client_id"] = client_id
+
+    return requests.post(
+        url,
+        data=payload,
+        auth=basic_auth,
+        headers=headers,
+        timeout=5,
+    )
+
+
+def oidc_userinfo(access_token: str) -> dict:
+    """Retrieve user info from the OIDC provider.
+
+    :param access_token: OIDC access token
+    :return: User info as a dictionary
+    :raises RuntimeError: if OIDC provider has no userinfo endpoint
+    :raises requests.RequestException: on network or HTTP errors
+    """
+    userinfo_endpoint = oidc_metadata().get("userinfo_endpoint")
+    if not userinfo_endpoint:
+        raise RuntimeError("OIDC provider has no userinfo endpoint")
+    response = requests.get(
+        userinfo_endpoint,
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=5,
+    )
+    response.raise_for_status()
+    return response.json()

--- a/server/src/testflinger/oidc/views.py
+++ b/server/src/testflinger/oidc/views.py
@@ -28,7 +28,7 @@ from flask import (
     url_for,
 )
 
-from testflinger.database import register_web_client
+from testflinger.database import register_oidc_client
 from testflinger.owasp import OWASPLogger
 
 oidc_views = Blueprint("oidc", __name__)
@@ -39,14 +39,13 @@ def callback():
     """Redirect callback from OIDC Provider."""
     try:
         token = current_app.oauth.oidc.authorize_access_token()
-        session["user"] = token["userinfo"]["name"]
-        register_web_client(token)
+        userinfo = token["userinfo"]
+        session["user"] = userinfo["name"]
+        register_oidc_client(userinfo)
         # Log successful OIDC authentication
         current_app.owasp_logger.authn_login_success(
-            userid=token["userinfo"]["name"],
-            description=(
-                f"User {token['userinfo']['name']} authenticated via OIDC"
-            ),
+            userid=userinfo["name"],
+            description=(f"User {userinfo['name']} authenticated via OIDC"),
             **OWASPLogger.get_request_metadata(request),
         )
     except (MismatchingStateError, OAuthError) as err:

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -116,6 +116,7 @@ def oidc_app(oidc_client, mongo_app, iam_server, monkeypatch):
     monkeypatch.setenv("OIDC_CLIENT_SECRET", oidc_client.client_secret)
     monkeypatch.setenv("OIDC_PROVIDER_ISSUER", iam_server.url)
     monkeypatch.setenv("WEB_SECRET_KEY", "my_web_secret_key")
+    monkeypatch.setenv("JWT_SIGNING_KEY", "my_secret_key")
 
     # Create Flask app with OIDC provider
     oidc_app = application.create_flask_app(TestingConfig)

--- a/server/tests/test_oidc.py
+++ b/server/tests/test_oidc.py
@@ -85,12 +85,12 @@ def test_first_login_registers_new_client(mock_current_app, oidc_app, user):
         assert response.status_code == HTTPStatus.FOUND
         assert response.location == url_for("testflinger.home")
 
-    # Validate new user was added
-    web_client = mongo.web_clients.find_one(
-        {"openid_sub": mock_token["userinfo"]["sub"]}
+    # Validate new user was added to client_permissions (keyed by email)
+    client_record = mongo.client_permissions.find_one(
+        {"sub": mock_token["userinfo"]["sub"]}
     )
-    assert web_client["name"] == mock_token["userinfo"]["name"]
-    assert web_client["email"] == mock_token["userinfo"]["email"]
+    assert client_record["name"] == mock_token["userinfo"]["name"]
+    assert client_record["client_id"] == mock_token["userinfo"]["email"]
 
 
 @patch("testflinger.oidc.views.current_app", new_callable=Mock)
@@ -103,8 +103,8 @@ def test_client_refresh_login_if_exists(mock_current_app, oidc_app, user):
     )
 
     client_entry = {
-        "openid_sub": "1234",
-        "email": user.emails[0],
+        "client_id": user.emails[0],
+        "sub": "1234",
         "name": user.user_name,
         "created_at": created_time,
         "last_login": last_login_time,
@@ -122,11 +122,11 @@ def test_client_refresh_login_if_exists(mock_current_app, oidc_app, user):
     }
 
     # Insert record directly into database
-    mongo.web_clients.insert_one(client_entry)
+    mongo.client_permissions.insert_one(client_entry)
 
     # Get the stored record for later comparison
-    client_record = mongo.web_clients.find_one(
-        {"openid_sub": mock_token["userinfo"]["sub"]}
+    client_record = mongo.client_permissions.find_one(
+        {"client_id": user.emails[0]}
     )
 
     # Mock authentication token return value
@@ -142,12 +142,12 @@ def test_client_refresh_login_if_exists(mock_current_app, oidc_app, user):
         assert response.status_code == HTTPStatus.FOUND
         assert response.location == url_for("testflinger.home")
 
-    web_client = mongo.web_clients.find_one(
-        {"openid_sub": mock_token["userinfo"]["sub"]}
+    web_client = mongo.client_permissions.find_one(
+        {"client_id": user.emails[0]}
     )
 
     # Validate client remains the same and only last_login was updated
-    assert mongo.web_clients.count_documents({}) == 1
+    assert mongo.client_permissions.count_documents({}) == 1
     assert web_client["created_at"] == client_record["created_at"]
     # Check that last_login was updated
     assert (

--- a/server/tests/test_oidc.py
+++ b/server/tests/test_oidc.py
@@ -85,7 +85,7 @@ def test_first_login_registers_new_client(mock_current_app, oidc_app, user):
         assert response.status_code == HTTPStatus.FOUND
         assert response.location == url_for("testflinger.home")
 
-    # Validate new user was added to client_permissions (keyed by email)
+    # Validate new user was added to client_permissions (keyed by sub)
     client_record = mongo.client_permissions.find_one(
         {"sub": mock_token["userinfo"]["sub"]}
     )

--- a/server/tests/test_oidc_api.py
+++ b/server/tests/test_oidc_api.py
@@ -71,7 +71,7 @@ def test_oidc_metadata_current_app(oidc_app):
         # iam_server fixture configuration may have a trailing slash
         assert metadata["issuer"] == app.config["OIDC_PROVIDER_ISSUER"].rstrip(
             "/"
-        )  # noqa: E501
+        )
 
 
 @patch("testflinger.oidc.helpers.requests.post")

--- a/server/tests/test_oidc_api.py
+++ b/server/tests/test_oidc_api.py
@@ -66,7 +66,6 @@ def test_oidc_metadata_current_app(oidc_app):
     app, _ = oidc_app
     with app.app_context():
         metadata = helpers.oidc_metadata()
-        print(metadata)
         assert isinstance(metadata, dict)
         assert "issuer" in metadata
         # iam_server fixture configuration may have a trailing slash
@@ -209,7 +208,7 @@ def test_auth_init_successful_request(
     device_auth_metadata,
     device_auth_response,
 ):
-    """Test /auth-init returns device_code and other parameters on success."""
+    """Test /auth-init returns request_id and other parameters on success."""
     app, mongo = oidc_app
     mock_metadata.return_value = device_auth_metadata
     mock_post.return_value = device_auth_response

--- a/server/tests/test_oidc_api.py
+++ b/server/tests/test_oidc_api.py
@@ -1,0 +1,412 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the OIDC authenticated endpoints."""
+
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from testflinger.oidc import helpers
+
+FAKE_DEVICE_AUTH_URL = "http://fake-idp/device/code"
+
+
+@pytest.fixture
+def device_auth_metadata():
+    """Fake OIDC metadata with a device authorization endpoint.
+
+    Tests aiming to verify OIDC device flow need to use this fixture
+    given iam_server fixture does not support the device flow.
+    """
+    return {"device_authorization_endpoint": FAKE_DEVICE_AUTH_URL}
+
+
+@pytest.fixture
+def device_auth_response():
+    """Fake successful device authorization response."""
+    response = MagicMock()
+    response.status_code = HTTPStatus.OK
+    response.json.return_value = {
+        "device_code": "test-device-code",
+        "user_code": "ABCD-1234",
+        "verification_uri": "http://fake-idp/device",
+        "expires_in": 300,
+        "interval": 5,
+    }
+    return response
+
+
+def test_oidc_client_current_app(oidc_app):
+    """Test that oidc_client returns the OIDC client from the current app."""
+    app, _ = oidc_app
+    with app.app_context():
+        client = helpers.oidc_client()
+        assert client is not None
+        assert client.client_id == app.config["OIDC_CLIENT_ID"]
+        assert client.client_secret == app.config["OIDC_CLIENT_SECRET"]
+
+
+def test_oidc_metadata_current_app(oidc_app):
+    """Test that oidc_metadata returns the metadata from the OIDC provider."""
+    app, _ = oidc_app
+    with app.app_context():
+        metadata = helpers.oidc_metadata()
+        print(metadata)
+        assert isinstance(metadata, dict)
+        assert "issuer" in metadata
+        # iam_server fixture configuration may have a trailing slash
+        assert metadata["issuer"] == app.config["OIDC_PROVIDER_ISSUER"].rstrip(
+            "/"
+        )  # noqa: E501
+
+
+@patch("testflinger.oidc.helpers.requests.post")
+@patch.object(helpers, "oidc_metadata")
+def test_oidc_device_authorization_request(
+    mock_metadata,
+    mock_post,
+    oidc_app,
+    device_auth_metadata,
+    device_auth_response,
+):
+    """Test device flow request to OIDC provider using current app's client."""
+    mock_metadata.return_value = device_auth_metadata
+    mock_post.return_value = device_auth_response
+    app, _ = oidc_app
+    with app.app_context():
+        device_auth_endpoint = helpers.oidc_metadata().get(
+            "device_authorization_endpoint"
+        )
+        response = helpers.oidc_post_request(
+            device_auth_endpoint,
+            data={"scope": "openid profile email"},
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert "device_code" in response.json()
+
+
+@patch("testflinger.oidc.helpers.requests.post")
+@patch.object(helpers, "oidc_metadata")
+def test_oidc_device_authorization_request_public_client(
+    mock_metadata,
+    mock_post,
+    oidc_app,
+    device_auth_metadata,
+    device_auth_response,
+):
+    """Test request contains client_id in request body for public clients."""
+    mock_metadata.return_value = device_auth_metadata
+    mock_post.return_value = device_auth_response
+    app, _ = oidc_app
+    with app.app_context():
+        # Simulate public client by removing client_secret
+        app.oauth.oidc.client_secret = None
+        device_auth_endpoint = helpers.oidc_metadata().get(
+            "device_authorization_endpoint"
+        )
+        response = helpers.oidc_post_request(
+            device_auth_endpoint,
+            data={"scope": "openid profile email"},
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert "device_code" in response.json()
+        # Verify client_id was sent in the request body (not as Basic auth)
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs["auth"] is None
+        assert "client_id" in call_kwargs.kwargs["data"]
+
+
+@patch("testflinger.oidc.helpers.requests.get")
+def test_oidc_userinfo_request(mock_get, oidc_app):
+    """Test getting user info from OIDC provider using current app's client."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "sub": "1234",
+        "email": "testflinger@example.com",
+    }
+    mock_get.return_value = mock_response
+    app, _ = oidc_app
+    with app.app_context():
+        userinfo = helpers.oidc_userinfo("valid-access-token")
+        assert isinstance(userinfo, dict)
+        assert "sub" in userinfo
+        assert "email" in userinfo
+
+
+def test_auth_init_aborts_if_device_auth_endpoint_missing(oidc_app):
+    """Test /auth-init aborts if OIDC provider does not support device flow."""
+    app, _ = oidc_app
+    with app.app_context():
+        response = app.test_client().post("/oidc/auth-init")
+        # Given the iam_server fixture does not support device flow,
+        # the endpoint should abort with 500 and a relevant message
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert (
+            b"OIDC provider does not support device authorization"
+            in response.data
+        )
+
+
+@patch("testflinger.oidc.helpers.requests.post")
+@patch.object(helpers, "oidc_metadata")
+def test_auth_init_aborts_if_oidc_connection_error(
+    mock_metadata, mock_post, oidc_app, device_auth_metadata
+):
+    """Test /auth-init aborts if OIDC provider connection fails."""
+    app, _ = oidc_app
+    mock_metadata.return_value = device_auth_metadata
+    mock_post.side_effect = requests.RequestException("Connection error")
+    with app.app_context():
+        response = app.test_client().post("/oidc/auth-init")
+        assert response.status_code == HTTPStatus.BAD_GATEWAY
+        assert b"Failed to communicate with OIDC provider" in response.data
+
+
+@patch("testflinger.oidc.helpers.requests.post")
+@patch.object(helpers, "oidc_metadata")
+def test_auth_init_aborts_if_device_code_missing(
+    mock_metadata,
+    mock_post,
+    oidc_app,
+    device_auth_metadata,
+    device_auth_response,
+):
+    """Test /auth-init aborts if OIDC provider response lacks device_code."""
+    app, _ = oidc_app
+    mock_metadata.return_value = device_auth_metadata
+    # Simulate missing device_code in the response
+    device_auth_response.json.return_value.pop("device_code")
+    mock_post.return_value = device_auth_response
+    with app.app_context():
+        response = app.test_client().post("/oidc/auth-init")
+        assert response.status_code == HTTPStatus.BAD_GATEWAY
+        assert b"OIDC provider response missing device_code" in response.data
+
+
+@patch("testflinger.oidc.helpers.requests.post")
+@patch.object(helpers, "oidc_metadata")
+def test_auth_init_successful_request(
+    mock_metadata,
+    mock_post,
+    oidc_app,
+    device_auth_metadata,
+    device_auth_response,
+):
+    """Test /auth-init returns device_code and other parameters on success."""
+    app, mongo = oidc_app
+    mock_metadata.return_value = device_auth_metadata
+    mock_post.return_value = device_auth_response
+    with app.app_context():
+        response = app.test_client().post("/oidc/auth-init")
+        assert response.status_code == HTTPStatus.OK
+        data = response.get_json()
+        assert "user_code" in data
+        assert "verification_uri" in data
+        assert "expires_in" in data
+        assert "interval" in data
+
+        # Device code should NOT be returned in the response
+        # Instead of device_code, a unique request_id is returned for polling
+        assert "device_code" not in data
+        assert "request_id" in data
+
+        # Verify device_code was stored in the database linked to request_id
+        db_entry = mongo.device_codes.find_one(
+            {"request_id": data["request_id"]}
+        )
+        assert db_entry is not None
+        assert db_entry["device_code"] == "test-device-code"
+        assert "expires_at" in db_entry
+
+
+def test_auth_poll_aborts_if_request_id_invalid(oidc_app):
+    """Test /auth-poll aborts if request_id is invalid or expired."""
+    app, _ = oidc_app
+    with app.app_context():
+        # Given no device code was stored for this request_id,
+        # the endpoint should abort
+        response = app.test_client().post("/oidc/auth-poll/invalid-id")
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert b"Invalid or expired request_id" in response.data
+
+
+@patch.object(helpers, "oidc_metadata")
+def test_auth_poll_aborts_if_token_endpoint_missing(mock_metadata, oidc_app):
+    """Test /auth-poll aborts if OIDC metadata is missing token_endpoint."""
+    app, mongo = oidc_app
+    # Metadata with no token_endpoint
+    mock_metadata.return_value = {}
+    with app.app_context():
+        # Pre-seed a device code so the request_id lookup succeeds
+        mongo.device_codes.insert_one(
+            {
+                "request_id": "test-request-id",
+                "device_code": "test-device-code",
+            }
+        )
+        response = app.test_client().post("/oidc/auth-poll/test-request-id")
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert (
+            b"OIDC provider metadata missing token endpoint" in response.data
+        )
+
+
+@patch("testflinger.oidc.helpers.requests.post")
+def test_auth_poll_aborts_if_oidc_connection_error(mock_post, oidc_app):
+    """Test /auth-poll aborts if OIDC provider connection fails."""
+    app, mongo = oidc_app
+    mock_post.side_effect = requests.RequestException("Connection error")
+    with app.app_context():
+        # Pre-seed a device code so the request_id lookup succeeds
+        mongo.device_codes.insert_one(
+            {
+                "request_id": "test-request-id",
+                "device_code": "test-device-code",
+            }
+        )
+
+        response = app.test_client().post("/oidc/auth-poll/test-request-id")
+        assert response.status_code == HTTPStatus.BAD_GATEWAY
+        assert b"Failed to communicate with OIDC provider" in response.data
+
+
+@pytest.mark.parametrize(
+    "error_code, expected_status, device_code_removed",
+    [
+        ("authorization_pending", HTTPStatus.BAD_REQUEST, False),
+        ("slow_down", HTTPStatus.BAD_REQUEST, False),
+        ("access_denied", HTTPStatus.BAD_REQUEST, True),
+    ],
+)
+@patch("testflinger.oidc.helpers.requests.post")
+def test_auth_poll_token_error_responses(
+    mock_post,
+    oidc_app,
+    error_code,
+    expected_status,
+    device_code_removed,
+):
+    """Test /auth-poll returns correct response for each IDP token error."""
+    app, mongo = oidc_app
+    mock_token_response = MagicMock()
+    mock_token_response.status_code = HTTPStatus.BAD_REQUEST
+    mock_token_response.json.return_value = {"error": error_code}
+    mock_post.return_value = mock_token_response
+    with app.app_context():
+        mongo.device_codes.insert_one(
+            {
+                "request_id": "test-request-id",
+                "device_code": "test-device-code",
+            }
+        )
+        response = app.test_client().post("/oidc/auth-poll/test-request-id")
+
+        # Validate the response status and body from the /auth-poll endpoint
+        assert response.status_code == expected_status
+        assert response.get_json()["error"] == error_code
+
+        # Only the "access_denied" error should remove the device code from db
+        db_entry = mongo.device_codes.find_one(
+            {"request_id": "test-request-id"}
+        )
+        if device_code_removed:
+            assert db_entry is None
+        else:
+            assert db_entry is not None
+
+
+@patch("testflinger.oidc.helpers.oidc_userinfo")
+@patch("testflinger.oidc.helpers.requests.post")
+def test_auth_poll_not_register_malformed_userinfo(
+    mock_post, mock_userinfo, oidc_app
+):
+    """Test /auth-poll aborts if OIDC provider returns malformed userinfo."""
+    app, mongo = oidc_app
+    mock_token_response = MagicMock()
+    mock_token_response.status_code = HTTPStatus.OK
+    mock_token_response.json.return_value = {
+        "access_token": "fake-access-token"
+    }
+    mock_post.return_value = mock_token_response
+    # No email in userinfo to simulate malformed response
+    mock_userinfo.return_value = {"sub": "1234"}
+    with app.app_context():
+        # Pre-seed a device code so the request_id lookup succeeds
+        mongo.device_codes.insert_one(
+            {
+                "request_id": "test-request-id",
+                "device_code": "test-device-code",
+            }
+        )
+        response = app.test_client().post("/oidc/auth-poll/test-request-id")
+        assert response.status_code == HTTPStatus.BAD_GATEWAY
+        assert (
+            b"OIDC provider did not return an email address" in response.data
+        )
+
+
+@patch("testflinger.oidc.helpers.oidc_userinfo")
+@patch("testflinger.oidc.helpers.requests.post")
+def test_auth_poll_successful_registration(
+    mock_post, mock_userinfo, oidc_app, user
+):
+    """Test /auth-poll successfully registers a new user on successful auth."""
+    app, mongo = oidc_app
+    mock_token_response = MagicMock()
+    mock_token_response.status_code = HTTPStatus.OK
+    mock_token_response.json.return_value = {
+        "access_token": "fake-access-token"
+    }
+    mock_post.return_value = mock_token_response
+    mock_userinfo.return_value = {
+        "sub": "test-sub-1234",
+        "email": user.emails[0],
+        "name": user.user_name,
+    }
+    with app.app_context():
+        mongo.device_codes.insert_one(
+            {
+                "request_id": "test-request-id",
+                "device_code": "test-device-code",
+            }
+        )
+        response = app.test_client().post("/oidc/auth-poll/test-request-id")
+        assert response.status_code == HTTPStatus.OK
+        data = response.get_json()
+
+        # Verify Testflinger tokens are returned (not the OIDC tokens)
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["token_type"] == "Bearer"  # noqa: S105
+        assert "expires_in" in data
+
+        # Device code must be removed after successful authentication
+        assert (
+            mongo.device_codes.find_one({"request_id": "test-request-id"})
+            is None
+        )
+
+        # User must be registered in client_permissions
+        # email is used as the client_id for OIDC users
+        client_entry = mongo.client_permissions.find_one(
+            {"client_id": user.emails[0]}
+        )
+        assert client_entry is not None
+        assert client_entry["sub"] == "test-sub-1234"

--- a/server/tests/test_v1_authorization.py
+++ b/server/tests/test_v1_authorization.py
@@ -1202,21 +1202,6 @@ def test_refresh_with_missing_token_field(mongo_app_with_permissions):
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
-def test_admin_refresh_token_has_no_expiration(mongo_app_with_permissions):
-    """Test that Admin refresh token does not expire (expires_at is None)."""
-    app, mongo, client_id, client_key, _ = mongo_app_with_permissions
-
-    authenticate_output = app.post(
-        "/v1/oauth2/token",
-        headers=create_auth_header(client_id, client_key),
-    )
-    assert authenticate_output.status_code == HTTPStatus.OK
-    refresh_token = authenticate_output.get_json()["refresh_token"]
-
-    stored = mongo.refresh_tokens.find_one({"refresh_token": refresh_token})
-    assert stored.get("expires_at") is None
-
-
 def test_contributor_refresh_token_has_expiration(mongo_app_with_permissions):
     """Test that Contributor refresh token expires in ~30 days."""
     app, mongo, client_id, client_key, _ = mongo_app_with_permissions


### PR DESCRIPTION
## Description
This PR adds the Device authentication Flow to be leveraged by the CLI. 

If OIDC is configured server side (and if the provider supports the Device Flow) authentication with `--method oidc` is now supported. 

This PR:
1. Adds two need server endpoints under `/oidc` route. With this endpoints, the Testflinger server can act as a proxy and redirect the request to the IDP provider. 
2. `auth-init`: returns a unique request ID to the user instead of the `device-code` (server holds this data for further validation) along with other relevant information for user login via browser
3. `auth-poll`: uses the `request_id` and the previously stored `device-code` to forward the request to the IDP and validate if user is already authenticated
4. Upon successful authentication, user is issued Testflinger access and refresh tokens (NOT IDP tokens)
5. Refresh token is stored so it can be reused until expiration (6 days)

This also removes the previous web_clients collections in favor of storing all user permissions on client_permissions collection. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-1196](https://warthogs.atlassian.net/browse/CERTTF-1196)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
For review simplicity, I will add the documentation on IDP usage on a follow up PR
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
This introduces a new route through `/oidc/<endpoints>` instead of `/v1/<endpoint`> given OIDC is optional
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Tested locally:

https://github.com/user-attachments/assets/ecc96246-fff9-41f2-80a2-d7aad45b3847


Tested on staging:
```
uv run testflinger-cli --server $SERVER login --method oidc
Please visit https://xxxxxxx/oauth2/device/verify and enter code xxxxxx to login.
Successfully authenticated as 'xxxxxxx@canonical.com'
```

Validate with admin credentials:
```
testflinger-cli --server $SERVER admin get client-permissions --testflinger-client-id 'xxxxxxx@canonical.com'
{"client_id": "xxxxxxx@canonical.com", "role": "contributor"}
```

Grant permissions:
```
testflinger-cli --server $SERVER admin set client-permissions --testflinger-client-id 'xxxxxxx@canonical.com' --max-reservation '{"audino": 36000}'
Updated permissions for client 'xxxxxxx@canonical.com'
```

Submit with extended reservation (8hrs):
```
uv run testflinger-cli --server $SERVER submit -p ~/Desktop/Testflinger/staging.yaml 
Job submitted successfully!
job_id: 53b9087f-1a60-4291-a12b-406923cb004f
This job will be picked up after the current job is complete (it is next in line)
...
Current time:           [2026-06-17T19:19:47.906408+00:00]
Reservation expires at: [2026-06-18T03:19:47.906458+00:00]
Reservation will automatically timeout in 28800 seconds

```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-1196]: https://warthogs.atlassian.net/browse/CERTTF-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ