### PR TITLE
fix(server-charm): add pydantic validation to CSFLE master key

### DIFF
--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -294,6 +294,14 @@ class TestflingerCharm(ops.CharmBase):
         new_key = self.typed_config.testflinger_secrets_master_key
         stored_key = self._stored.previous_master_key
 
+        # If the key was unset, clear the stored key so the next
+        # config-changed with a valid key is treated as a fresh deployment.
+        if not new_key:
+            logger.info("Master key unset, clearing stored key")
+            self._stored.previous_master_key = ""
+            self._update_layer_and_restart()
+            return
+
         # Rotate only if master key was previously defined, has changed,
         # and this is the leader unit.
         if stored_key and new_key != stored_key and self.unit.is_leader():

--- a/server/charm/src/config.py
+++ b/server/charm/src/config.py
@@ -2,9 +2,13 @@
 # See LICENSE file for licensing details.
 """Charm configuration."""
 
+import base64
+import binascii
 from urllib.parse import urlparse
 
 import pydantic
+
+MONGO_CSFLE_KEY_LENGTH = 96  # bytes
 
 
 class TestflingerServerConfig(pydantic.BaseModel):
@@ -68,6 +72,25 @@ class TestflingerServerConfig(pydantic.BaseModel):
         if not parsed_oidc.netloc:
             raise ValueError("oidc_provider_issuer must include a host")
         return value.rstrip("/")
+
+    @pydantic.field_validator("testflinger_secrets_master_key")
+    @classmethod
+    def validate_csfle_master_key(cls, value):
+        """Validate that the CSFLE master key is valid base64."""
+        if value:
+            try:
+                key_bytes = base64.b64decode(value, validate=True)
+            except (binascii.Error, ValueError) as error:
+                raise ValueError(
+                    "Invalid 'testflinger_secrets_master_key': "
+                    "value is not valid base64"
+                ) from error
+            if len(key_bytes) != MONGO_CSFLE_KEY_LENGTH:
+                raise ValueError(
+                    "Invalid 'testflinger_secrets_master_key': "
+                    f"decoded key must be {MONGO_CSFLE_KEY_LENGTH} bytes long"
+                )
+        return value
 
     @pydantic.model_validator(mode="after")
     def validate_oidc_config(self):

--- a/server/charm/tests/unit/test_charm.py
+++ b/server/charm/tests/unit/test_charm.py
@@ -533,3 +533,24 @@ def test_conflict_cleared_on_route_changed(ctx):
         state_in,
     )
     assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_config_changed_clears_stored_key_on_unset(ctx, make_state, caplog):
+    """Test that stored key is cleared when config key is unset."""
+    old_key = helpers.generate_b64_key()
+    state_in = make_state(
+        config={"testflinger_secrets_master_key": ""},
+        stored_key=old_key,
+    )
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # Verify log message
+    assert "Master key unset, clearing stored key" in caplog.text
+
+    # Verify stored key is cleared
+    stored = next(
+        state
+        for state in state_out.stored_states
+        if state.owner_path == "TestflingerCharm" and state.name == "_stored"
+    )
+    assert stored.content["previous_master_key"] == ""

--- a/server/charm/tests/unit/test_config.py
+++ b/server/charm/tests/unit/test_config.py
@@ -2,6 +2,9 @@
 # See LICENSE file for licensing details.
 """Unit tests for config.py."""
 
+import base64
+import secrets
+
 import pytest
 
 from config import TestflingerServerConfig
@@ -143,3 +146,43 @@ def test_invalid_oidc_provider_issuer():
             oidc_provider_issuer="https:///issuer",
             web_secret_key="web-secret-key",  # noqa: S106
         )
+
+
+def test_valid_csfle_master_key():
+    """Test that valid CSFLE master key is accepted."""
+    # Generate a valid 96-byte key and encode it in base64
+    valid_key_bytes = secrets.token_bytes(96)
+    valid_key_b64 = base64.b64encode(valid_key_bytes).decode("utf-8")
+
+    config = TestflingerServerConfig(
+        testflinger_secrets_master_key=valid_key_b64
+    )
+    assert config.testflinger_secrets_master_key == valid_key_b64
+
+
+def test_invalid_csfle_master_key(caplog):
+    """Test that invalid CSFLE master key raises validation error."""
+    # Invalid base64 string
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Invalid 'testflinger_secrets_master_key': "
+            "value is not valid base64"
+        ),
+    ):
+        TestflingerServerConfig(
+            testflinger_secrets_master_key="invalid_base64_string"
+        )
+
+    # Valid base64 but not 96 bytes when decoded
+    invalid_key_bytes = secrets.token_bytes(32)
+    invalid_key_b64 = base64.b64encode(invalid_key_bytes).decode("utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Invalid 'testflinger_secrets_master_key': "
+            "decoded key must be 96 bytes long"
+        ),
+    ):
+        TestflingerServerConfig(testflinger_secrets_master_key=invalid_key_b64)


### PR DESCRIPTION
## Description
This add a pydantic validation at charm level so MongoDB CSFLE encryption key is valid base64 with 96-byte length. 
When unset, this will also clear the stored CSFLE key in charm. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
NA
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
NA
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests for this behavior
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
