### PR TITLE
fix: retry control_host commands

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/muxpi.py
@@ -45,6 +45,9 @@ ATTACHMENTS_DIR = "attachments"
 class MuxPi:
     """Device Connector for MuxPi."""
 
+    CONTROL_CMD_RETRY_TIMEOUT = 60
+    CONTROL_CMD_RETRY_INTERVAL = 5
+
     IMAGE_PATH_IDS = {
         "writable/usr/bin/firefox": "pi-desktop",
         "writable/etc": "ubuntu",
@@ -97,13 +100,26 @@ class MuxPi:
             f"{control_user}@{control_host}",
             cmd,
         ]
-        try:
-            output = subprocess.check_output(
-                ssh_cmd, stderr=subprocess.STDOUT, timeout=timeout
-            )
-        except subprocess.SubprocessError as e:
-            raise ProvisioningError(e.output) from e
-        return output
+        retry_interval = self.CONTROL_CMD_RETRY_INTERVAL
+        max_attempts = (self.CONTROL_CMD_RETRY_TIMEOUT // retry_interval) + 1
+
+        for attempt in range(max_attempts):
+            try:
+                output = subprocess.check_output(
+                    ssh_cmd, stderr=subprocess.STDOUT, timeout=timeout
+                )
+                return output
+            except subprocess.SubprocessError as e:
+                if attempt >= max_attempts - 1:
+                    raise ProvisioningError(e.output) from e
+                logger.info(
+                    "Control command failed, retrying in %ss (%s/%s): %s",
+                    retry_interval,
+                    attempt + 1,
+                    max_attempts,
+                    cmd,
+                )
+                time.sleep(retry_interval)
 
     def _copy_to_control(self, local_file, remote_file):
         """Copy a file to the control host over ssh.

--- a/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py
@@ -52,6 +52,8 @@ def test_manages_dut_power_during_reboot():
 
 def test_check_ce_oem_iot_image(mocker):
     """Test check_ce_oem_iot_image."""
+    mocker.patch("time.sleep")
+
     series = "2404"
     mocker.patch(
         "subprocess.check_output",
@@ -132,6 +134,40 @@ def test_check_test_image_booted_fails(mocker):
     )
     with pytest.raises(ProvisioningError, match="Failed to boot test image!"):
         muxpi.check_test_image_booted()
+
+
+def test_run_control_retries_until_success(mocker):
+    """Test _run_control retries failures before succeeding."""
+    muxpi = MuxPi()
+    muxpi.config = {"control_host": "control-host", "control_user": "ubuntu"}
+    mock_sleep = mocker.patch("time.sleep")
+    mock_check_output = mocker.patch(
+        "subprocess.check_output",
+        side_effect=[subprocess.CalledProcessError(1, "cmd"), b"ok"],
+    )
+
+    out = muxpi._run_control("true")
+
+    assert out == b"ok"
+    assert mock_check_output.call_count == 2
+    mock_sleep.assert_called_once_with(5)
+
+
+def test_run_control_raises_after_retry_timeout(mocker):
+    """Test _run_control raises when retries are exhausted."""
+    muxpi = MuxPi()
+    muxpi.config = {"control_host": "control-host", "control_user": "ubuntu"}
+    mock_sleep = mocker.patch("time.sleep")
+    mock_check_output = mocker.patch(
+        "subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "cmd", output=b"boom"),
+    )
+
+    with pytest.raises(ProvisioningError, match="boom"):
+        muxpi._run_control("true")
+
+    assert mock_check_output.call_count == 13
+    assert mock_sleep.call_count == 12
 
 
 class TestMuxPiProvisionWithZapper:


### PR DESCRIPTION
## Description

We get to provisioning when the control_host REST service is available, but `muxpi` is still relying on CLI commands over SSH which are not necessarily ready as soon as we expect. This adds a simple retry logic to `_run_control`, up to 60 seconds.

## Resolved issues

User feedback

## Documentation

N/A

## Web service API changes

No

## Tests

- Unit tested
- Local testing
```
$ DISABLE_CONTROL_HOST_POWERCYCLE=1 uv run testflinger-device-connector muxpi provision -c ./local.yaml local.json
6-06-18 08:25:11,576 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-06-18 08:25:11,577 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Skipping control host power cycle (DISABLE_CONTROL_HOST_POWERCYCLE is set).
2026-06-18 08:25:11,579 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: BEGIN provision
2026-06-18 08:25:11,579 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Provisioning device
2026-06-18 08:25:11,589 hp-pro-sff-400-g9-desktop-pc-c30464 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server. Retrying in the background...
2026-06-18 08:25:17,295 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Control command failed, retrying in 5s (1/13): sdwire set DUT
2026-06-18 08:25:25,320 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Control command failed, retrying in 5s (2/13): sdwire set DUT
2026-06-18 08:25:33,331 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Control command failed, retrying in 5s (3/13): sdwire set DUT
2026-06-18 08:25:41,713 hp-pro-sff-400-g9-desktop-pc-c30464 ERROR: DEVICE CONNECTOR: 'test_device'
```
