### PR TITLE
new: forward power scripts to control host

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -202,6 +202,8 @@ class ZapperConnector(ABC, DefaultDevice):
                 "cid": self.config.get("env", {}).get("CID"),
                 "device_ip": self.config["device_ip"],
                 "reboot_script": self.config["reboot_script"],
+                "poweron_script": self.config.get("poweron_script"),
+                "poweroff_script": self.config.get("poweroff_script"),
             }
         )
         payload = {

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -75,6 +75,8 @@ class ZapperConnectorTests(unittest.TestCase):
             "agent_name": "my-agent",
             "control_host": "zapper-host",
             "reboot_script": ["cmd1", "cmd2"],
+            "poweron_script": ["poweron1"],
+            "poweroff_script": ["poweroff1"],
             "env": {"CID": "202507-01234"},
         }
         connector = MockConnector(fake_config)
@@ -357,6 +359,8 @@ class TestZapperConnectorRun:
             "agent_name": "my-agent",
             "control_host": "zapper-host",
             "reboot_script": ["cmd1"],
+            "poweron_script": ["poweron1"],
+            "poweroff_script": ["poweroff1"],
             "env": {"CID": "202507-01234"},
         }
         return MockConnector(config)


### PR DESCRIPTION
## Description

Forward power scripts to control_host for more fine-grained control over provisioning.

## Resolved issues

User feedback

## Documentation

Server side

## Web service API changes

No

## Tests

Unit tests
