### PR TITLE
fix(cli): ignore broken pipe during status line cleanup

### DIFF
--- a/cli/testflinger_cli/status_line.py
+++ b/cli/testflinger_cli/status_line.py
@@ -79,11 +79,15 @@ class StatusLine:
         cls._running = False
         if cls._timer_thread:
             cls._timer_thread.join(timeout=2.0)
-        if cls._started:
-            sys.stdout.write("\n")
-        sys.stdout.flush()
-        builtins.print = _original_print
-        builtins.input = _original_input
+        try:
+            if cls._started:
+                sys.stdout.write("\n")
+            sys.stdout.flush()
+        except BrokenPipeError:
+            pass
+        finally:
+            builtins.print = _original_print
+            builtins.input = _original_input
 
     @classmethod
     def _timer_loop(cls):

--- a/cli/testflinger_cli/status_line.py
+++ b/cli/testflinger_cli/status_line.py
@@ -77,13 +77,13 @@ class StatusLine:
     def stop(cls):
         """Stop the status line timer thread and restore original builtins."""
         cls._running = False
-        if cls._timer_thread:
-            cls._timer_thread.join(timeout=2.0)
         try:
+            if cls._timer_thread:
+                cls._timer_thread.join(timeout=2.0)
             if cls._started:
                 sys.stdout.write("\n")
             sys.stdout.flush()
-        except BrokenPipeError:
+        except (BrokenPipeError, KeyboardInterrupt):
             pass
         finally:
             builtins.print = _original_print

--- a/cli/tests/test_status_line.py
+++ b/cli/tests/test_status_line.py
@@ -14,6 +14,7 @@
 
 """Unit tests for StatusLine."""
 
+import builtins
 import threading
 from unittest import mock
 
@@ -52,6 +53,25 @@ class TestStatusLineInit:
         StatusLine.stop()
 
         # After stop, builtins should be restored
+        assert builtins.print == original_print
+        assert builtins.input == original_input
+
+    def test_stop_ignores_broken_pipe_and_restores_builtins(self, mock_tty):
+        """stop() should handle closed output pipes during cleanup."""
+        original_print = builtins.print
+        original_input = builtins.input
+
+        StatusLine.init()
+        StatusLine._running = False
+        if StatusLine._timer_thread:
+            StatusLine._timer_thread.join(timeout=2.0)
+
+        with mock.patch(
+            "testflinger_cli.status_line.sys.stdout.flush",
+            side_effect=BrokenPipeError,
+        ):
+            StatusLine.stop()
+
         assert builtins.print == original_print
         assert builtins.input == original_input
 

--- a/cli/tests/test_status_line.py
+++ b/cli/tests/test_status_line.py
@@ -75,6 +75,20 @@ class TestStatusLineInit:
         assert builtins.print == original_print
         assert builtins.input == original_input
 
+    def test_stop_ignores_keyboard_interrupt_during_join(self, mock_tty):
+        """stop() should handle a second Ctrl-C during cleanup."""
+        original_print = builtins.print
+        original_input = builtins.input
+
+        StatusLine.init()
+        StatusLine._timer_thread = mock.Mock()
+        StatusLine._timer_thread.join.side_effect = KeyboardInterrupt
+
+        StatusLine.stop()
+
+        assert builtins.print == original_print
+        assert builtins.input == original_input
+
 
 class TestStatusLineElapsedTime:
     """Tests for elapsed time display."""


### PR DESCRIPTION
## Summary
- ignore `BrokenPipeError` while `StatusLine.stop()` writes/flushed terminal cleanup output
- always restore the wrapped `print` and `input` builtins during status line shutdown
- add a regression test for closed stdout pipes during cleanup

Closes #1150

## Tests
- `uv run pytest tests/test_status_line.py::TestStatusLineInit::test_stop_ignores_broken_pipe_and_restores_builtins -q`
- `uv run pytest tests/test_status_line.py -q`
- `uvx --with tox-uv tox run -e lock`
- `uvx --with tox-uv tox run -e lint`
- `uvx --with tox-uv tox run -e unit -- tests/test_status_line.py`

## Notes
- `uvx --with tox-uv tox run -e unit` on this macOS machine reached `222 passed` but failed two unrelated helper tests: `test_is_in_snap_private_dir` and `test_parse_filename_snap_private`. Those tests expect `/tmp/job.yaml` to remain under `/tmp`; on macOS `Path.resolve()` maps it under `/private/tmp`, so it no longer matches `SNAP_PRIVATE_DIRS = ["/tmp"]`.

AI assistance was used under my direction.