### PR TITLE
update: reboot DUT before provisioning when reachable.

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/oemscript.py
@@ -85,6 +85,12 @@ class OemScript:
         except subprocess.CalledProcessError:
             self.hardreset()
             self.check_device_booted()
+        else:
+            # If we were able to reach the device, reboot it and wait for
+            # it to come back online before running the following steps.
+            logger.info("Rebooting the device before provisioning")
+            self.run_on_control_host("sudo reboot")
+            self.check_device_booted()
 
         provision_data = self.job_data.get("provision_data", {})
         image_url = provision_data.get("url")

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/tests/test_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/tests/test_oemscript.py
@@ -74,16 +74,16 @@ class TestOemScript(unittest.TestCase):
         """Test the device is rebooted when it is reachable up front."""
         device = OemScript(self.config_file.name, self.job_file.name)
 
-        with patch.object(
-            device, "copy_ssh_id"
-        ) as mock_copy_ssh_id, patch.object(
-            device, "run_on_control_host"
-        ) as mock_run_on_control_host, patch.object(
-            device, "check_device_booted"
-        ) as mock_check_device_booted, patch.object(
-            device, "hardreset"
-        ) as mock_hardreset, patch.object(
-            device, "run_recovery_script"
+        with (
+            patch.object(device, "copy_ssh_id") as mock_copy_ssh_id,
+            patch.object(
+                device, "run_on_control_host"
+            ) as mock_run_on_control_host,
+            patch.object(
+                device, "check_device_booted"
+            ) as mock_check_device_booted,
+            patch.object(device, "hardreset") as mock_hardreset,
+            patch.object(device, "run_recovery_script"),
         ):
             device.provision()
 
@@ -99,18 +99,18 @@ class TestOemScript(unittest.TestCase):
         """Test the device is hardreset when it is not reachable up front."""
         device = OemScript(self.config_file.name, self.job_file.name)
 
-        with patch.object(
-            device,
-            "copy_ssh_id",
-            side_effect=subprocess.CalledProcessError(1, "ssh-copy-id"),
-        ), patch.object(
-            device, "run_on_control_host"
-        ) as mock_run_on_control_host, patch.object(
-            device, "check_device_booted"
-        ), patch.object(
-            device, "hardreset"
-        ) as mock_hardreset, patch.object(
-            device, "run_recovery_script"
+        with (
+            patch.object(
+                device,
+                "copy_ssh_id",
+                side_effect=subprocess.CalledProcessError(1, "ssh-copy-id"),
+            ),
+            patch.object(
+                device, "run_on_control_host"
+            ) as mock_run_on_control_host,
+            patch.object(device, "check_device_booted"),
+            patch.object(device, "hardreset") as mock_hardreset,
+            patch.object(device, "run_recovery_script"),
         ):
             device.provision()
 

--- a/device-connectors/src/testflinger_device_connectors/devices/oemscript/tests/test_oemscript.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/oemscript/tests/test_oemscript.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the OemScript class."""
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from testflinger_device_connectors.devices.oemscript.oemscript import (
+    OemScript,
+)
+
+
+class TestOemScript(unittest.TestCase):
+    """Test cases for OemScript device connector."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.config_data = {
+            "device_ip": "192.168.1.100",
+            "agent_name": "test-agent",
+            "reboot_script": ["snmpset -v1 -c private 1.2.3.4 1.3.6.1 i 1"],
+        }
+        self.job_data = {
+            "job_id": "test-job-123",
+            "provision_data": {
+                "url": "http://example.com/test-image.iso",
+            },
+            "test_data": {
+                "test_username": "ubuntu",
+                "test_password": "insecure",
+            },
+        }
+
+        # Create temporary files for config and job data
+        self.config_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        )
+        yaml.dump(self.config_data, self.config_file)
+        self.config_file.close()
+
+        self.job_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        )
+        json.dump(self.job_data, self.job_file)
+        self.job_file.close()
+
+        yield
+
+        # Teardown
+        Path(self.config_file.name).unlink(missing_ok=True)
+        Path(self.job_file.name).unlink(missing_ok=True)
+
+    def test_provision_reachable_reboots_before_provisioning(self):
+        """Test the device is rebooted when it is reachable up front."""
+        device = OemScript(self.config_file.name, self.job_file.name)
+
+        with patch.object(
+            device, "copy_ssh_id"
+        ) as mock_copy_ssh_id, patch.object(
+            device, "run_on_control_host"
+        ) as mock_run_on_control_host, patch.object(
+            device, "check_device_booted"
+        ) as mock_check_device_booted, patch.object(
+            device, "hardreset"
+        ) as mock_hardreset, patch.object(
+            device, "run_recovery_script"
+        ):
+            device.provision()
+
+        # The device was reachable, so it should be rebooted over ssh and
+        # we should wait for it to come back online, not hardreset.
+        mock_copy_ssh_id.assert_called_once()
+        mock_run_on_control_host.assert_called_once_with("sudo reboot")
+        mock_hardreset.assert_not_called()
+        # check_device_booted runs after the reboot and after recovery
+        self.assertEqual(mock_check_device_booted.call_count, 2)
+
+    def test_provision_unreachable_hardresets(self):
+        """Test the device is hardreset when it is not reachable up front."""
+        device = OemScript(self.config_file.name, self.job_file.name)
+
+        with patch.object(
+            device,
+            "copy_ssh_id",
+            side_effect=subprocess.CalledProcessError(1, "ssh-copy-id"),
+        ), patch.object(
+            device, "run_on_control_host"
+        ) as mock_run_on_control_host, patch.object(
+            device, "check_device_booted"
+        ), patch.object(
+            device, "hardreset"
+        ) as mock_hardreset, patch.object(
+            device, "run_recovery_script"
+        ):
+            device.provision()
+
+        # The device was not reachable, so it should be hardreset and
+        # never rebooted over ssh.
+        mock_hardreset.assert_called_once()
+        mock_run_on_control_host.assert_not_called()


### PR DESCRIPTION
## Description

Some oemscript machines intermittently fail to mount the ISO file during provisioning. The only reliable way to recover from this state is to reboot the device. This PR adds a reboot step before running the recovery script.

## Resolved issues

```
+ sudo mount -o loop dell-bto-jammy-jellyfish-quilava-X120-20240118-9_A00.iso /mnt
mount: /mnt: /dev/loop8 already mounted or mount point busy.
```

## Tests

Test it from a local environment.

```
2026-06-23 05:34:13,645 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-06-23 05:34:13,645 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Attempt to power cycle the control host.
2026-06-23 05:34:43,792 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Running control host reboot script
2026-06-23 05:34:43,792 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Executing: snmpset -c private -v 2c 10.102.132.207 1.3.6.1.2.1.105.1.1.1.3.0.1 i 2
2026-06-23 05:34:44,059 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Executing: sleep 5
2026-06-23 05:34:49,062 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Executing: snmpset -c private -v 2c 10.102.132.207 1.3.6.1.2.1.105.1.1.1.3.0.1 i 1
2026-06-23 05:34:49,408 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Waiting for the REST API on control host 10.102.245.184
2026-06-23 05:36:04,401 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Set typecmux state to OFF on 10.102.245.184
2026-06-23 05:36:04,406 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: BEGIN provision
2026-06-23 05:36:04,406 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Provisioning device
2026-06-23 05:36:04,865 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Rebooting the device before provisioning
2026-06-23 05:36:05,250 dell-latitude-3450-c33223 INFO: DEVICE CONNECTOR: Checking to see if the device is available.

```
