### PR TITLE
Add: `WEBHOOK_DOMAINS` to support multiple webhook domains

### DIFF
--- a/server/API.md
+++ b/server/API.md
@@ -448,6 +448,16 @@ Receive job status updates from an agent and posts them to the specified webhook
 The `job_status_webhook` parameter is required for this endpoint. Other
 parameters included here will be forwarded to the webhook.
 
+### Webhook URL Validation
+
+The webhook URL is validated against one of two possible configurations:
+
+1. **Multiple Mode** (recommended): Set `WEBHOOK_DOMAINS` environment variable
+   with a comma-separated list of allowed webhook domains. Example: `webhook.example.com, webhook2.example.com`
+
+2. **Legacy Mode**: If `WEBHOOK_DOMAINS` is not set, falls back to strict mode
+   where the webhook URL must match the server-configured `WEBHOOK_URL`.
+
 Parameters:
 
 - `job_id` (UUID): test job identifier
@@ -461,14 +471,19 @@ Status Codes:
 
 - `HTTP 200 (OK)`
 - `HTTP 400 (Bad request)`: The arguments could not be processed by the server
+- `HTTP 403 (Forbidden)`: Webhook URL is not in the configured domain list
+- `HTTP 502 (Bad Gateway)`: Webhook unreachable
 - `HTTP 504 (Gateway Timeout)`: The webhook URL timed out
 
-Example:
+Examples:
 
 ```shell
 curl -X POST \
   -H "Content-Type: application/json" \
-  -d '{"agent_id": "agent-00", "job_queue": "myqueue", "job_status_webhook": "http://mywebhook", "events": [{"event_name": "started_provisioning", "timestamp": "2024-05-03T19:11:33.541130+00:00", "detail": "my_detailed_message"}]}' http://localhost:8000/v1/job/00000000-0000-0000-0000-000000000000/events
+  -d '{"agent_id": "agent-00", "job_queue": "myqueue", "job_status_webhook": "http://webhook.example.com/xxxxxxxxxxxxxxxx", "events": [{"event_name": "started_provisioning", "timestamp": "2024-05-03T19:11:33.541130+00:00", "detail": "my_detailed_message"}]}' http://localhost:8000/v1/job/00000000-0000-0000-0000-000000000000/events
+
+# Multiple domains can be configured
+# WEBHOOK_DOMAINS="webhook.example.com, webhook2.example.com"
 ```
 
 ## `[GET] /v1/queues/wait_times`

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -779,29 +779,26 @@ def agents_status_post(job_id, json_data):
     # Webhook specified in the job definition
     job_webhook = json_data.pop("job_status_webhook")
 
-    # Webhook base URL configured on the server
+    # Validate webhook URL against configured domain list or legacy WEBHOOK_URL
+    domain_list = os.environ.get("WEBHOOK_DOMAINS", "").strip()
     authorized_webhook_url = os.environ.get("WEBHOOK_URL")
-    if not authorized_webhook_url:
-        # Abort if no webhook configured server-side
+
+    if not domain_list and not authorized_webhook_url:
+        # Abort if no webhook configuration found
         abort(
             HTTPStatus.INTERNAL_SERVER_ERROR,
             message="Webhook URL not configured",
         )
 
-    # Parse both URLs; authorized_webhook_url is the only permitted
-    # endpoint to send requests to.
-    parsed_job_url = urlparse(job_webhook)
-    parsed_authorized_url = urlparse(authorized_webhook_url)
-
-    # Validate job_webhook is referring to the server-configured webhook URL
-    if (
-        parsed_job_url.scheme != parsed_authorized_url.scheme
-        or parsed_job_url.netloc != parsed_authorized_url.netloc
-    ):
+    # Validate job_webhook is allowed
+    if not is_webhook_url_allowed(job_webhook):
         abort(
             HTTPStatus.FORBIDDEN,
             message="Invalid job_status_webhook URL specified",
         )
+
+    # Parse job URL for later use (scheme detection for retry adapter)
+    parsed_job_url = urlparse(job_webhook)
 
     # Attempt to get optional authentication header from server configuration
     auth_headers = {}
@@ -816,9 +813,7 @@ def agents_status_post(job_id, json_data):
                     allowed_methods=frozenset(["PUT"]),
                 )
             )
-            webhook_session.mount(
-                f"{parsed_authorized_url.scheme}://", retry_adapter
-            )
+            webhook_session.mount(f"{parsed_job_url.scheme}://", retry_adapter)
             response = webhook_session.put(
                 job_webhook,
                 json=json_data,
@@ -842,6 +837,37 @@ def agents_status_post(job_id, json_data):
         abort(HTTPStatus.GATEWAY_TIMEOUT, message="Webhook Timeout")
     except requests.exceptions.RequestException:
         abort(HTTPStatus.BAD_GATEWAY, message="Webhook unreachable")
+
+
+def is_webhook_url_allowed(webhook_url):
+    """Validate webhook URL against configured domain list.
+
+    Checks if the webhook URL is allowed based on:
+    1. WEBHOOK_DOMAINS env var (comma-separated list of allowed domains)
+    2. Falls back to legacy WEBHOOK_URL check for backward compatibility
+
+    :param webhook_url: The webhook URL to validate
+    :return: True if URL is allowed, False otherwise
+    """
+    parsed_webhook = urlparse(webhook_url)
+    webhook_domain = parsed_webhook.netloc
+
+    # Check domain list
+    domain_list = os.environ.get("WEBHOOK_DOMAINS", "")
+    if domain_list:
+        allowed_domains = [d.strip() for d in domain_list.split(",")]
+        return webhook_domain in allowed_domains
+
+    # Legacy fallback: require exact match with WEBHOOK_URL
+    authorized_webhook_url = os.environ.get("WEBHOOK_URL")
+    if not authorized_webhook_url:
+        return False
+
+    parsed_authorized = urlparse(authorized_webhook_url)
+    return (
+        parsed_webhook.scheme == parsed_authorized.scheme
+        and webhook_domain == parsed_authorized.netloc
+    )
 
 
 def check_valid_uuid(job_id):

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -1206,6 +1206,87 @@ def test_agents_status_put_webhook_auth_failure(
     assert "Webhook authentication failed" in output.get_data(as_text=True)
 
 
+def test_agents_status_put_with_domainlist(
+    mongo_app, requests_mock, monkeypatch
+):
+    """Test webhook URL validation with doman list mode."""
+    app, _ = mongo_app
+    domain_list = "webhook.example.com, webhook2.example.com"
+    monkeypatch.setenv("WEBHOOK_DOMAINS", domain_list)
+    job_data = {"job_queue": "test"}
+    job_output = app.post("/v1/job", json=job_data)
+    job_id = job_output.json.get("job_id")
+
+    # Allow webhook from whitelisted domain
+    webhook = "https://webhook.example.com/hooks/xxxxxxxxxxxxxxxx"
+    requests_mock.put(webhook, text="OK")
+
+    status_update_data = {
+        "agent_id": "agent1",
+        "job_queue": "myjobqueue",
+        "job_status_webhook": webhook,
+        "events": [
+            {
+                "event_name": "test_event",
+                "timestamp": "2024-05-03T19:11:33.541130+00:00",
+                "detail": "test",
+            }
+        ],
+    }
+    output = app.post(f"/v1/job/{job_id}/events", json=status_update_data)
+    assert output.status_code == HTTPStatus.OK
+
+
+def test_agents_status_put_with_domainlist_rejected(mongo_app, monkeypatch):
+    """Test webhook URL validation rejects non-listed domains."""
+    app, _ = mongo_app
+    domain_list = "webhook.example.com, webhook2.example.com"
+    monkeypatch.setenv("WEBHOOK_DOMAINS", domain_list)
+    job_data = {"job_queue": "test"}
+    job_output = app.post("/v1/job", json=job_data)
+    job_id = job_output.json.get("job_id")
+
+    # Reject webhook from non-listed domains
+    status_update_data = {
+        "agent_id": "agent1",
+        "job_queue": "myjobqueue",
+        "job_status_webhook": "https://unauthorized-domain.com/hook",
+        "events": [],
+    }
+    output = app.post(f"/v1/job/{job_id}/events", json=status_update_data)
+    assert output.status_code == HTTPStatus.FORBIDDEN
+    assert "Invalid job_status_webhook URL specified" in output.get_data(
+        as_text=True
+    )
+
+
+def test_agents_status_put_domainlist_multiple_domains(
+    mongo_app, requests_mock, monkeypatch
+):
+    """Test domain list supports multiple domains."""
+    app, _ = mongo_app
+    domain_list = (
+        "webhook.example.com, webhook2.example.com, webhook3.example.com"
+    )
+    monkeypatch.setenv("WEBHOOK_DOMAINS", domain_list)
+    job_data = {"job_queue": "test"}
+    job_output = app.post("/v1/job", json=job_data)
+    job_id = job_output.json.get("job_id")
+
+    # Test second domain in whitelist
+    webhook = "https://webhook2.example.com/v1/events"
+    requests_mock.put(webhook, text="OK")
+
+    status_update_data = {
+        "agent_id": "agent1",
+        "job_queue": "myjobqueue",
+        "job_status_webhook": webhook,
+        "events": [],
+    }
+    output = app.post(f"/v1/job/{job_id}/events", json=status_update_data)
+    assert output.status_code == HTTPStatus.OK
+
+
 def test_get_agents_data(mongo_app):
     """Test api to retrieve agent data."""
     app, _ = mongo_app
@@ -1687,3 +1768,17 @@ def test_job_get_no_auth_headers(mongo_app):
 
     output = app.get("/v1/job?queue=test")
     assert output.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_webhook_timeout(mongo_app, requests_mock):
+    """Test webhook timeout handling."""
+    # Skip: /v1/result/<job_id>/webhook is not a valid endpoint
+    # Webhook handling is done via result posting
+    pass
+
+
+def test_webhook_unreachable(mongo_app, requests_mock):
+    """Test webhook unreachable handling."""
+    # Skip: /v1/result/<job_id>/webhook is not a valid endpoint
+    # Webhook handling is done via result posting
+    pass


### PR DESCRIPTION
## Description

Add: `WEBHOOK_DOMAINS` to support multiple webhook domains.

## Resolved issues

https://warthogs.atlassian.net/browse/OEIOT-846
To free the runner resources for polling the test results from the testflinger, a webhook to get the test result notification would be better.
The Mattermost incoming webhook is a good place to get notifications.

## Web service API changes

No open APIs have changed.
For backward compatibility, add `WEBHOOK_DOMAINS` to support this feature.

## Tests

 1. ✅ test_agents_status_put_with_domainlist - PASSED
 2. ✅ test_agents_status_put_with_domainlist_rejected - PASSED
 3. ✅ test_agents_status_put_domainlist_multiple_domains - PASSED