### PR TITLE
refactor(agent): add authorization headers to all requests.

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/testflinger_client.py
+++ b/agent/charms/testflinger-agent-host-charm/src/testflinger_client.py
@@ -16,8 +16,8 @@ from defaults import DEFAULT_TOKEN_PATH
 
 logger = logging.getLogger(__name__)
 
-# Update refresh token weekly to ensure it stays valid
-REFRESH_INTERVAL_DAYS = 7
+# Update refresh token every 3 days to ensure it stays valid
+REFRESH_INTERVAL_DAYS = 3
 DEFAULT_TIMEOUT_SECONDS = 15
 
 
@@ -82,7 +82,7 @@ def get_token_data() -> dict | None:
 def token_update_needed() -> bool:
     """Check if the refresh token should be updated.
 
-    Tokens are refreshed weekly to ensure they stay valid.
+    Tokens are refreshed every 3 days to ensure they stay valid.
 
     :returns: True if token is missing, invalid, or needs refresh.
     """

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_client.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_testflinger_client.py
@@ -117,8 +117,8 @@ def test_token_update_needed_valid_token(mock_get_token_data):
 
 @patch("testflinger_client.get_token_data")
 def test_token_update_needed(mock_get_token_data):
-    """Test token_update_needed when token is older than 7 days."""
-    old_date = datetime.now(timezone.utc) - timedelta(days=7, minutes=5)
+    """Test token_update_needed when token is older than 3 days."""
+    old_date = datetime.now(timezone.utc) - timedelta(days=3, minutes=5)
     mock_get_token_data.return_value = {
         "refresh_token": "token123",
         "obtained_at": old_date.isoformat(),
@@ -131,8 +131,8 @@ def test_token_update_needed(mock_get_token_data):
 
 @patch("testflinger_client.get_token_data")
 def test_token_update_not_needed(mock_get_token_data):
-    """Test token_update_needed when token is older than 7 days."""
-    old_date = datetime.now(timezone.utc) - timedelta(days=6)
+    """Test token_update_needed when token is not older than 3 days."""
+    old_date = datetime.now(timezone.utc) - timedelta(days=2)
     mock_get_token_data.return_value = {
         "refresh_token": "token123",
         "obtained_at": old_date.isoformat(),

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -146,7 +146,8 @@ class TestflingerClient:
             if getattr(response.request, "_auth_retry", False):
                 return response
 
-            # Drain before releasing the connection
+            # Consume the response body to return the active connection to
+            # the pool for reuse
             _ = response.content
 
             del self.access_token

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -69,8 +69,8 @@ class ClientAuth(AuthBase):
         :param req: The prepared request object to modify
         :return: The modified request object with Authorization header
         """
-        if self.client.access_token:
-            req.headers["Authorization"] = f"Bearer {self.client.access_token}"
+        if access_token := self.client.access_token:
+            req.headers["Authorization"] = f"Bearer {access_token}"
         return req
 
 
@@ -147,15 +147,15 @@ class TestflingerClient:
                 return response
 
             # Drain before releasing the connection
-            response.content  # noqa: B018
+            _ = response.content
 
             del self.access_token
-            if not self.access_token:
+            if not (access_token := self.access_token):
                 return response
 
             new_request = response.request.copy()
             new_request.headers["Authorization"] = (
-                f"Bearer {self.access_token}"
+                f"Bearer {access_token}"
             )
             new_request._auth_retry = True
             new_response = response.connection.send(new_request, **kwargs)

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -154,9 +154,7 @@ class TestflingerClient:
                 return response
 
             new_request = response.request.copy()
-            new_request.headers["Authorization"] = (
-                f"Bearer {access_token}"
-            )
+            new_request.headers["Authorization"] = f"Bearer {access_token}"
             new_request._auth_retry = True
             new_response = response.connection.send(new_request, **kwargs)
             new_response.history.append(response)

--- a/agent/src/testflinger_agent/client.py
+++ b/agent/src/testflinger_agent/client.py
@@ -19,6 +19,7 @@ import shutil
 import tempfile
 import time
 from dataclasses import asdict, dataclass
+from functools import cached_property
 from http import HTTPStatus
 from pathlib import Path
 from typing import Dict, List
@@ -29,12 +30,15 @@ from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError
 from requests import HTTPError
 from requests.adapters import HTTPAdapter
+from requests.auth import AuthBase
 from testflinger_common.enums import LogType
 from urllib3.util import Retry
 
-from testflinger_agent.errors import InvalidTokenError, TFServerError
+from testflinger_agent.errors import TFServerError
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_AUTH_TIMEOUT = 15  # seconds
 
 
 @dataclass(frozen=True)
@@ -45,6 +49,29 @@ class LogEndpointInput:
     timestamp: str
     phase: str
     log_data: str
+
+
+class ClientAuth(AuthBase):
+    """Custom authentication for the agent client."""
+
+    def __init__(self, client: "TestflingerClient") -> None:
+        """Initialize the ClientAuth with a TestflingerClient instance.
+
+        :param client: Instance of the client to retrieve access token from
+        """
+        self.client = client
+
+    def __call__(
+        self, req: requests.PreparedRequest
+    ) -> requests.PreparedRequest:
+        """Attach the current access token to the request.
+
+        :param req: The prepared request object to modify
+        :return: The modified request object with Authorization header
+        """
+        if self.client.access_token:
+            req.headers["Authorization"] = f"Bearer {self.client.access_token}"
+        return req
 
 
 class TestflingerClient:
@@ -59,6 +86,8 @@ class TestflingerClient:
         if not self.server.lower().startswith("http"):
             self.server = f"http://{self.server}"
         self.session = self._requests_retry(retries=5)
+        self.session.auth = ClientAuth(self)
+        self.session.hooks["response"].append(self._handle_token_refresh)
         self.influx_agent_db = "agent_jobs"
         self.influx_client = self._configure_influx()
 
@@ -93,7 +122,6 @@ class TestflingerClient:
         influx_client = InfluxDBClient(
             host, port, user, password, self.influx_agent_db
         )
-
         # ensure we can connect to influxdb
         try:
             influx_client.create_database(self.influx_agent_db)
@@ -102,21 +130,39 @@ class TestflingerClient:
         else:
             return influx_client
 
-    def _update_session_auth(self) -> None:
-        """Ensure session has valid authentication.
+    def _handle_token_refresh(
+        self, response: requests.Response, **kwargs
+    ) -> requests.Response:
+        """Re-acquire the access token and replay the request on a 401.
 
-        This handles both token-based and cookie-based authentication.
+        When the server signals token expiry with a 401, this hook
+        invalidates the cached token, fetches a fresh one, and replays
+        the original exactly once.
+
+        :param response: The response object from the request
+        :return: The replayed response on token expiry, otherwise the original
         """
-        # Update Bearer token header
-        access_token = self.get_access_token()
-        if access_token:
-            self.session.headers.update(
-                {"Authorization": f"Bearer {access_token}"}
-            )
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            if getattr(response.request, "_auth_retry", False):
+                return response
 
-        # Update session cookies
-        if not self.session.cookies:
-            self.post_agent_data({"job_id": ""})
+            # Drain before releasing the connection
+            response.content  # noqa: B018
+
+            del self.access_token
+            if not self.access_token:
+                return response
+
+            new_request = response.request.copy()
+            new_request.headers["Authorization"] = (
+                f"Bearer {self.access_token}"
+            )
+            new_request._auth_retry = True
+            new_response = response.connection.send(new_request, **kwargs)
+            new_response.history.append(response)
+            return new_response
+
+        return response
 
     def check_jobs(self) -> dict | None:
         """Check for new jobs for on the Testflinger server.
@@ -139,18 +185,12 @@ class TestflingerClient:
         job_uri = urljoin(self.server, "/v1/job")
         logger.debug("Requesting a job")
         try:
-            self._update_session_auth()
             job_request = self.session.get(
                 job_uri, params={"queue": queue_list}, timeout=30
             )
             job_request.raise_for_status()
             if job_request.content:
                 return job_request.json()
-        except InvalidTokenError:
-            logger.error(
-                "Invalid refresh token. "
-                "Make sure the token file is correct and try again."
-            )
         except HTTPError as exc:
             if exc.response.status_code in (
                 HTTPStatus.UNAUTHORIZED,
@@ -174,7 +214,7 @@ class TestflingerClient:
             Where to save the attachment archive
         """
         uri = urljoin(self.server, f"/v1/job/{job_id}/attachments")
-        with requests.get(uri, stream=True, timeout=600) as response:
+        with self.session.get(uri, stream=True, timeout=600) as response:
             if not response:
                 logger.error(
                     "Unable to retrieve attachments for job: %s (error: %d)",
@@ -541,44 +581,45 @@ class TestflingerClient:
             interval = min(interval * (2**retry_count), max_interval)
             retry_count += 1
 
-    def get_access_token(self, timeout=30) -> str | None:
-        """Exchange a refresh token for an acess token.
+    @cached_property
+    def access_token(self) -> str | None:
+        """Fetch and cache an access token from the server.
 
-        This is used for authenticating with the Testflinger server.
-        Access token is short lived, so we need to refresh it upon request.
+        On first access or after clearing the cache, this method
+        exchanges the stored refresh token for a fresh access token.
+        Subsequent accesses return the cached value without a network call.
 
-        :param timeout: timeout in seconds for completing HTTP request
         :returns: Access token string if successful, None otherwise
-        :raises: InvalidTokenError if refresh token is invalid
         """
         token_file = self.config.get("token_file")
         refresh_url = urljoin(self.server, "/v1/oauth2/refresh")
 
-        if token_file:
-            try:
-                with Path(token_file).open() as f:
-                    token_data = json.load(f)
-            except (OSError, json.JSONDecodeError) as exc:
-                logger.error("Failed to read token file: %s", exc)
-                return None
+        if not token_file:
+            return None
 
-            refresh_token = token_data.get("refresh_token")
-            try:
-                response = self.session.post(
-                    refresh_url,
-                    json={"refresh_token": refresh_token},
-                    timeout=timeout,
-                )
-                response.raise_for_status()
-                token_data = response.json()
-                return token_data["access_token"]
-            except HTTPError as exc:
-                if exc.response.status_code == HTTPStatus.BAD_REQUEST:
-                    # Server returns a json error message on bad request
-                    # This handles missing or invalid refresh tokens
-                    logger.error(exc.response.json().get("message"))
-                    raise InvalidTokenError from exc
-            except requests.exceptions.RequestException as exc:
-                logger.error("Failed to refresh access token: %s", exc)
+        try:
+            with Path(token_file).open() as f:
+                token_data = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.error("Failed to read token file: %s", exc)
+            return None
+
+        refresh_token = token_data.get("refresh_token")
+        try:
+            # intentionally not using self.session to avoid auth loop
+            response = requests.post(
+                refresh_url,
+                json={"refresh_token": refresh_token},
+                timeout=DEFAULT_AUTH_TIMEOUT,
+            )
+            response.raise_for_status()
+            return response.json()["access_token"]
+        except HTTPError as exc:
+            if exc.response.status_code == HTTPStatus.BAD_REQUEST:
+                # Server returns a json error message on bad request
+                # This handles missing or invalid refresh tokens
+                logger.error(exc.response.json().get("message"))
+        except requests.exceptions.RequestException as exc:
+            logger.error("Failed to refresh access token: %s", exc)
 
         return None

--- a/agent/tests/test_client.py
+++ b/agent/tests/test_client.py
@@ -25,7 +25,7 @@ from testflinger_common.enums import LogType
 
 from testflinger_agent.client import LogEndpointInput
 from testflinger_agent.client import TestflingerClient as _TestflingerClient
-from testflinger_agent.errors import InvalidTokenError, TFServerError
+from testflinger_agent.errors import TFServerError
 
 
 class TestClient:
@@ -389,13 +389,8 @@ class TestClient:
         assert requests_mock.last_request.method == "GET"
         assert "/v1/job" in requests_mock.last_request.url
 
-    def test_check_jobs_without_agent_registration_reregisters(
-        self, client, requests_mock
-    ):
-        """
-        Test that check_jobs handles 401 (no agent_name cookie) by
-        re-registering the agent and returning None.
-        """
+    def test_check_jobs_unauthorized_returns_none(self, client, requests_mock):
+        """Test that check_jobs returns None on a 401 response."""
         requests_mock.get(
             "http://127.0.0.1:8000/v1/agents/data/test_agent",
             json={"restricted_to": {}},
@@ -405,24 +400,9 @@ class TestClient:
             status_code=HTTPStatus.UNAUTHORIZED,
             json={"message": "Agent not identified"},
         )
-        requests_mock.post(
-            "http://127.0.0.1:8000/v1/agents/data/test_agent",
-            status_code=HTTPStatus.OK,
-        )
 
-        # check_jobs should handle 401 by re-registering and returning None
         result = client.check_jobs()
         assert result is None
-
-        # Verify that post_agent_data was called for re-registration, i.e.
-        # the POST /agents/data/<agent_name> endpoint was called, once.
-        post_requests = [
-            req
-            for req in requests_mock.request_history
-            if req.method == "POST"
-        ]
-        assert len(post_requests) == 1
-        assert post_requests[0].json() == {"job_id": ""}
 
     def test_check_jobs_request_exception(self, client):
         """
@@ -567,10 +547,10 @@ class TestClient:
         result = client.check_jobs()
         assert result is None
 
-    def test_get_access_token_raises_on_bad_request(
+    def test_access_token_returns_none_on_bad_request(
         self, client, requests_mock, tmp_path
     ):
-        """Test that get_access_token raises InvalidTokenError on 400 error."""
+        """Test that access_token returns None on a 400 error."""
         token_file = tmp_path / "refresh_token"
         token_file.write_text(json.dumps({"refresh_token": "invalid-token"}))
         client.config["token_file"] = str(token_file)
@@ -582,8 +562,7 @@ class TestClient:
             json={"message": "Invalid refresh token."},
         )
 
-        with pytest.raises(InvalidTokenError):
-            client.get_access_token()
+        assert client.access_token is None
 
     def test_get_access_token_returns_none_on_server_error(
         self, client, requests_mock, tmp_path
@@ -598,7 +577,7 @@ class TestClient:
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
         )
 
-        result = client.get_access_token()
+        result = client.access_token
         assert result is None
 
     def test_get_access_token_refresh_network_error(
@@ -644,11 +623,8 @@ class TestClient:
         result = client.check_jobs()
         assert result is None
 
-    def test_update_session_auth_headers(
-        self, client, requests_mock, tmp_path
-    ):
-        """Test authentication headers gets updated on new access token."""
-        # Create a valid token file
+    def test_access_token_is_cached(self, client, requests_mock, tmp_path):
+        """Test that access token is cached and reused across requests."""
         token_file = tmp_path / "refresh_token"
         token_file.write_text(json.dumps({"refresh_token": "valid-token"}))
         client.config["token_file"] = str(token_file)
@@ -656,7 +632,6 @@ class TestClient:
         first_access_token = "access-token-1"  # noqa: S105
         second_access_token = "access-token-2"  # noqa: S105
 
-        # Mock refresh endpoint to return different tokens on each call
         requests_mock.post(
             f"{client.server}/v1/oauth2/refresh",
             [
@@ -664,91 +639,22 @@ class TestClient:
                 {"json": {"access_token": second_access_token}},
             ],
         )
-        # Mock post agent data endpoint for retrieving session cookie
-        requests_mock.post(
-            f"{client.server}/v1/agents/data/test_agent",
-            json={"job_id": ""},
-        )
-        # Mock agent data endpoint
-        requests_mock.get(
-            f"{client.server}/v1/agents/data/test_agent",
-            json={"restricted_to": {}},
-        )
-        # Mock job endpoint
-        requests_mock.get(
-            f"{client.server}/v1/job",
-            json={},
-        )
 
-        # First call should set the header with the first access token
-        client.check_jobs()
-        assert (
-            client.session.headers["Authorization"]
-            == f"Bearer {first_access_token}"
-        )
+        # First access fetches and caches the token
+        assert client.access_token == first_access_token
 
-        # Second call should update the header with the new access token
-        client.check_jobs()
-        assert (
-            client.session.headers["Authorization"]
-            == f"Bearer {second_access_token}"
-        )
-
-    def test_update_session_auth_refreshes_cookies(
-        self, client, requests_mock, tmp_path
-    ):
-        """Test session cookies are refreshed when empty."""
-        token_file = tmp_path / "refresh_token"
-        token_file.write_text(json.dumps({"refresh_token": "valid-token"}))
-        client.config["token_file"] = str(token_file)
-
-        requests_mock.post(
-            f"{client.server}/v1/oauth2/refresh",
-            json={"access_token": "test-token"},  # noqa: S106
-        )
-        requests_mock.post(
-            f"{client.server}/v1/agents/data/test_agent",
-            json={"job_id": ""},
-        )
-
-        # Cookies are empty, so post_agent_data should be called
-        assert not client.session.cookies
-        client._update_session_auth()
-
-        # Verify the post to agent data was made for cookie refresh
-        agent_data_calls = [
-            request
-            for request in requests_mock.request_history
-            if request.method == "POST"
-            and "/v1/agents/data/test_agent" in request.url
+        # Second access returns the cached token without re-fetching
+        assert client.access_token == first_access_token
+        refresh_calls = [
+            r
+            for r in requests_mock.request_history
+            if "/v1/oauth2/refresh" in r.url
         ]
-        assert len(agent_data_calls) == 1
+        assert len(refresh_calls) == 1
 
-    def test_update_session_auth_skips_cookie_refresh(
-        self, client, requests_mock, tmp_path
-    ):
-        """Test session skips cookie refresh when cookies already exist."""
-        token_file = tmp_path / "refresh_token"
-        token_file.write_text(json.dumps({"refresh_token": "valid-token"}))
-        client.config["token_file"] = str(token_file)
-
-        requests_mock.post(
-            f"{client.server}/v1/oauth2/refresh",
-            json={"access_token": "test-token"},  # noqa: S106
-        )
-
-        # Pre-populate session cookies so post_agent_data is skipped
-        client.session.cookies.set("session", "existing-cookie")
-        client._update_session_auth()
-
-        # Verify no post to agent data was made
-        agent_data_calls = [
-            request
-            for request in requests_mock.request_history
-            if request.method == "POST"
-            and "/v1/agents/data/test_agent" in request.url
-        ]
-        assert len(agent_data_calls) == 0
+        # After clearing the cache, next access fetches a fresh token
+        del client.access_token
+        assert client.access_token == second_access_token
 
     @pytest.mark.parametrize(
         "log_type", [LogType.STANDARD_OUTPUT, LogType.SERIAL_OUTPUT]

--- a/agent/tests/test_client.py
+++ b/agent/tests/test_client.py
@@ -739,7 +739,7 @@ class TestClient:
             "job_queue": "test_queue",
         }
         # Similarly two calls to the job endpoint
-        # The first call for a expired token, the second call after refreshing
+        # The first call for an expired token, the second call after refreshing
         requests_mock.get(
             f"{client.server}/v1/job",
             [
@@ -763,7 +763,7 @@ class TestClient:
             == f"Bearer {refreshed_token}"
         )
 
-        # Addionally, verify that the retried request matches the original
+        # Additionally, verify that the retried request matches the original
         # Only difference should be the Authorization header
         assert job_requests[0].url == job_requests[1].url
         assert job_requests[0].method == job_requests[1].method

--- a/agent/tests/test_client.py
+++ b/agent/tests/test_client.py
@@ -710,3 +710,143 @@ class TestClient:
             log_data="output_log_data",
         )
         assert client.post_log(job_id, log_input, log_type) is False
+
+    def test_session_retries_on_expired_token(
+        self, client, requests_mock, tmp_path
+    ):
+        """Test that the client retries on expired access token."""
+        token_file = tmp_path / "refresh_token"
+        token_file.write_text(json.dumps({"refresh_token": "valid-token"}))
+        client.config["token_file"] = str(token_file)
+
+        first_token = "first-access-token"  # noqa: S105
+        refreshed_token = "refreshed-access-token"  # noqa: S105
+
+        # There should be exactly two calls to the refresh endpoint
+        requests_mock.post(
+            f"{client.server}/v1/oauth2/refresh",
+            [
+                {"json": {"access_token": first_token}},
+                {"json": {"access_token": refreshed_token}},
+            ],
+        )
+        requests_mock.get(
+            f"{client.server}/v1/agents/data/test_agent",
+            json={"restricted_to": {}},
+        )
+        fake_job_data = {
+            "job_id": str(uuid.uuid1()),
+            "job_queue": "test_queue",
+        }
+        # Similarly two calls to the job endpoint
+        # The first call for a expired token, the second call after refreshing
+        requests_mock.get(
+            f"{client.server}/v1/job",
+            [
+                {"status_code": HTTPStatus.UNAUTHORIZED},
+                {"json": fake_job_data},
+            ],
+        )
+
+        result = client.check_jobs()
+        assert result == fake_job_data
+
+        job_requests = [
+            req
+            for req in requests_mock.request_history
+            if "/v1/job" in req.url
+        ]
+        assert len(job_requests) == 2
+        # Verify that the second request to /v1/job used the refreshed token
+        assert (
+            job_requests[1].headers.get("Authorization")
+            == f"Bearer {refreshed_token}"
+        )
+
+        # Addionally, verify that the retried request matches the original
+        # Only difference should be the Authorization header
+        assert job_requests[0].url == job_requests[1].url
+        assert job_requests[0].method == job_requests[1].method
+        assert (
+            job_requests[0].headers.get("Authorization")
+            != job_requests[1].headers.get("Authorization")
+        )  # fmt: off
+
+    def test_session_does_not_retry_if_already_retried(
+        self, client, requests_mock, tmp_path
+    ):
+        """Test that the client does not retry if already retried once."""
+        token_file = tmp_path / "refresh_token"
+        token_file.write_text(json.dumps({"refresh_token": "valid-token"}))
+        client.config["token_file"] = str(token_file)
+
+        requests_mock.post(
+            f"{client.server}/v1/oauth2/refresh",
+            json={"access_token": "fake-access-token"},
+        )
+        requests_mock.get(
+            f"{client.server}/v1/agents/data/test_agent",
+            json={"restricted_to": {}},
+        )
+        # Always returns 401 — retry should not loop
+        requests_mock.get(
+            f"{client.server}/v1/job",
+            status_code=HTTPStatus.UNAUTHORIZED,
+        )
+
+        result = client.check_jobs()
+        assert result is None
+
+        job_requests = [
+            req
+            for req in requests_mock.request_history
+            if "/v1/job" in req.url
+        ]
+        # Initial request + one retry
+        assert len(job_requests) == 2
+
+    def test_session_skips_retry_if_token_refresh_fails(
+        self, client, requests_mock, tmp_path
+    ):
+        """Test that no retry is made when token refresh fails on 401.
+
+        If the server returns 401 and the token refresh also fails,
+        _handle_token_refresh should return the original 401 without
+        attempting a retry (the `if not self.access_token` guard).
+        """
+        token_file = tmp_path / "refresh_token"
+        token_file.write_text(json.dumps({"refresh_token": "valid-token"}))
+        client.config["token_file"] = str(token_file)
+
+        # The second call attempting to refresh the access token should fail
+        # given the refresh token is invalid
+        requests_mock.post(
+            f"{client.server}/v1/oauth2/refresh",
+            [
+                {"json": {"access_token": "initial-token"}},
+                {
+                    "status_code": HTTPStatus.BAD_REQUEST,
+                    "json": {"message": "Refresh token expired"},
+                },
+            ],
+        )
+        requests_mock.get(
+            f"{client.server}/v1/agents/data/test_agent",
+            json={"restricted_to": {}},
+        )
+        requests_mock.get(
+            f"{client.server}/v1/job",
+            status_code=HTTPStatus.UNAUTHORIZED,
+        )
+
+        result = client.check_jobs()
+        assert result is None
+
+        job_requests = [
+            req
+            for req in requests_mock.request_history
+            if "/v1/job" in req.url
+        ]
+
+        # No retry should have been attempted
+        assert len(job_requests) == 1


### PR DESCRIPTION
## Description
This PR adds authentication header to all requests by using a shared requests.Session. 

Implementation:

1. Uses the `__call__` method from `AuthBase` to add the access token as authorization header
2. Adds this header to the `session.auth` object 
3. Caches the access token (JWT token) so it can be reused with the same session to reduce network calls. 
4. On access token expiration, it automatically handles token expiration by refreshing the access token and reattempting the same request that initially failed. 
5. session cookies are now implicit, this happens at agent registration and is guaranteed to be kept given the agent now uses the same session for all requests. 
6. Also reduces updating the refresh token to 3 days given the expiration is now 6 days server side

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-1234](https://warthogs.atlassian.net/browse/CERTTF-1234)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Existing unit tests are passing
session.cookies unit tests are cleaned up given this is now implicit, no cookies refresh is happening agent side.
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-1234]: https://warthogs.atlassian.net/browse/CERTTF-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ