### PR TITLE
Improve subcommand error help text, CERTTF-917

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -201,7 +201,7 @@ class TestflingerCli:
 
     def _register_subparser(self, parser, subcommand_name):
         """Register a subparser for better error messages."""
-        parser.prog = f"testflinger {subcommand_name}"
+        parser.prog = f"{self.main_parser.prog} {subcommand_name}"
         self.main_parser.subparsers_dict[subcommand_name] = parser
         return parser
 

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -65,6 +65,35 @@ from testflinger_cli.status_line import StatusLine
 
 logger = logging.getLogger(__name__)
 
+
+class SubcommandAwareParser(ArgumentParser):
+    """ArgumentParser that shows subcommand help on error."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.subparsers_dict = {}
+
+    def error(self, message):
+        """Show subcommand-specific help if applicable."""
+        # Check if a subcommand was specified
+        # Look through sys.argv to find a subcommand (skip flags/options)
+        i = 1
+        while i < len(sys.argv):
+            arg = sys.argv[i]
+            if arg in self.subparsers_dict:
+                # Show subcommand-specific help
+                self.subparsers_dict[arg].print_help()
+                self.exit(2, f"{self.prog}: error: {message}\n")
+            # Skip option values (if current arg is a flag with a value)
+            if arg.startswith("-") and "=" not in arg:
+                # Check if this flag takes a value
+                if i + 1 < len(sys.argv) and not sys.argv[i + 1].startswith("-"):
+                    i += 1  # Skip the next arg (it's the flag's value)
+            i += 1
+        # Fall back to main parser help
+        super().error(message)
+
+
 # Make it easier to run from a checkout
 basedir = os.path.abspath(os.path.join(__file__, ".."))
 if os.path.exists(os.path.join(basedir, "setup.py")):
@@ -170,9 +199,16 @@ class TestflingerCli:
             return
         self.args.func()
 
+    def _register_subparser(self, parser, subcommand_name):
+        """Register a subparser for better error messages."""
+        parser.prog = f"testflinger {subcommand_name}"
+        self.main_parser.subparsers_dict[subcommand_name] = parser
+        return parser
+
     def get_args(self):
         """Handle command line arguments."""
-        parser = ArgumentParser()
+        parser = SubcommandAwareParser()
+        self.main_parser = parser  # Store for use in _register_subparser
         parser.add_argument(
             "-c",
             "--configfile",
@@ -212,6 +248,9 @@ class TestflingerCli:
             self.args = parser.parse_args()
         except SnapPrivateFileError as exc:
             parser.error(exc)
+        except SystemExit:
+            # Re-raise to let argparse handle errors, but with better help
+            raise
         self.help = parser.format_help()
 
         # Early validation of credentials
@@ -240,6 +279,7 @@ class TestflingerCli:
             "artifacts",
             help="Download a tarball of artifacts saved for a specified job",
         )
+        self._register_subparser(parser, "artifacts")
         parser.set_defaults(func=self.artifacts)
         parser.add_argument(
             "--filename", type=helpers.parse_filename, default="artifacts.tgz"
@@ -253,6 +293,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "cancel", help="Tell the server to cancel a specified JOB_ID"
         )
+        self._register_subparser(parser, "cancel")
         parser.set_defaults(func=self.cancel)
         parser.add_argument("job_id").completer = partial(
             autocomplete.job_ids_completer, history=self.history
@@ -263,6 +304,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "config", help="Get or set configuration options"
         )
+        self._register_subparser(parser, "config")
         parser.set_defaults(func=self.configure)
         parser.add_argument("setting", nargs="?", help="setting=value")
 
@@ -271,6 +313,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "jobs", help="List the previously started test jobs"
         )
+        self._register_subparser(parser, "jobs")
         parser.set_defaults(func=self.jobs)
         parser.add_argument(
             "--status",
@@ -285,6 +328,7 @@ class TestflingerCli:
             "list-queues",
             help="List the advertised queues on the Testflinger server",
         )
+        self._register_subparser(parser, "list-queues")
         parser.set_defaults(func=self.list_queues)
         parser.add_argument(
             "--json", action="store_true", help="Print output in JSON format"
@@ -296,6 +340,7 @@ class TestflingerCli:
             "login",
             help="Authenticate with server",
         )
+        self._register_subparser(parser, "login")
         parser.set_defaults(func=self.login)
         self._add_auth_args(parser)
 
@@ -341,6 +386,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "poll", help="Poll for output from a job until it is complete"
         )
+        self._register_subparser(parser, "poll")
         parser.set_defaults(func=self.poll_output)
         self._add_poll_args_generic(parser)
 
@@ -350,6 +396,7 @@ class TestflingerCli:
             "poll-serial",
             help="Poll for serial output from a job until it is complete",
         )
+        self._register_subparser(parser, "poll-serial")
         parser.set_defaults(func=self.poll_serial)
         self._add_poll_args_generic(parser)
 
@@ -358,6 +405,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "reserve", help="Install and reserve a system"
         )
+        self._register_subparser(parser, "reserve")
         parser.set_defaults(func=self.reserve)
         parser.add_argument(
             "--dry-run",
@@ -406,6 +454,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "status", help="Show the status of a specified JOB_ID"
         )
+        self._register_subparser(parser, "status")
         parser.set_defaults(func=self.status)
         parser.add_argument("job_id").completer = partial(
             autocomplete.job_ids_completer, history=self.history
@@ -416,6 +465,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "agent-status", help="Show the status of a specified agent"
         )
+        self._register_subparser(parser, "agent-status")
         parser.set_defaults(func=self.agent_status)
         parser.add_argument("agent_name")
         parser.add_argument(
@@ -520,6 +570,7 @@ class TestflingerCli:
             "queue-status",
             help="Show the status of the agents in a specified queue",
         )
+        self._register_subparser(parser, "queue-status")
         parser.set_defaults(func=self.queue_status)
         parser.add_argument("queue_name")
         parser.add_argument(
@@ -537,6 +588,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "results", help="Get results JSON for a complete JOB_ID"
         )
+        self._register_subparser(parser, "results")
         parser.set_defaults(func=self.results)
         parser.add_argument("job_id").completer = partial(
             autocomplete.job_ids_completer, history=self.history
@@ -547,6 +599,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "show", help="Show the requested job JSON for a specified JOB_ID"
         )
+        self._register_subparser(parser, "show")
         parser.set_defaults(func=self.show)
         parser.add_argument("job_id").completer = partial(
             autocomplete.job_ids_completer, history=self.history
@@ -562,6 +615,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "submit", help="Submit a new test job to the server"
         )
+        self._register_subparser(parser, "submit")
         parser.set_defaults(func=self.submit)
         parser.add_argument("--poll", "-p", action="store_true")
         parser.add_argument("--quiet", "-q", action="store_true")
@@ -586,6 +640,7 @@ class TestflingerCli:
         parser = subparsers.add_parser(
             "secret", help="Manage secrets. Requires authentication"
         )
+        self._register_subparser(parser, "secret")
         secret_subparser = parser.add_subparsers(
             dest="secret_command", required=True
         )

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -84,10 +84,11 @@ class SubcommandAwareParser(ArgumentParser):
                 # Show subcommand-specific help
                 self.subparsers_dict[arg].print_help()
                 self.exit(2, f"{self.prog}: error: {message}\n")
-            # Skip option values (if current arg is a flag with a value)
+            # Skip option values only for flags that consume an argument
             if arg.startswith("-") and "=" not in arg:
-                # Check if this flag takes a value
-                if i + 1 < len(sys.argv) and not sys.argv[i + 1].startswith("-"):
+                action = self._option_string_actions.get(arg)
+                # nargs==0 means the flag takes no value (e.g. store_true)
+                if action is not None and action.nargs != 0:
                     i += 1  # Skip the next arg (it's the flag's value)
             i += 1
         # Fall back to main parser help
@@ -482,6 +483,7 @@ class TestflingerCli:
             help="List agents with optional filtering",
             formatter_class=RawTextHelpFormatter,
         )
+        self._register_subparser(parser, "list-agents")
         parser.set_defaults(func=self.list_agents)
         subgroup = parser.add_mutually_exclusive_group()
         subgroup.add_argument(

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -84,10 +84,12 @@ class SubcommandAwareParser(ArgumentParser):
                 # Show subcommand-specific help
                 self.subparsers_dict[arg].print_help()
                 self.exit(2, f"{self.prog}: error: {message}\n")
-            # Skip option values only for flags that consume an argument
+            # Skip option values only for flags that consume an argument.
+            # store_true/store_false/store_const/count have nargs=0 and take no
+            # following value; all other actions have nargs=None or an integer,
+            # which are != 0 in Python and therefore correctly trigger a skip.
             if arg.startswith("-") and "=" not in arg:
                 action = self._option_string_actions.get(arg)
-                # nargs==0 means the flag takes no value (e.g. store_true)
                 if action is not None and action.nargs != 0:
                     i += 1  # Skip the next arg (it's the flag's value)
             i += 1

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -2719,3 +2719,97 @@ def test_jobs_no_trailing_blank_line(capsys):
     )
     # The last meaningful line should contain the most recently submitted job.
     assert job_ids[1] in lines[-2]
+
+
+class TestSubcommandAwareParser:
+    """Tests for SubcommandAwareParser error-handling behavior."""
+
+    def _make_parser(self):
+        """Return a minimal SubcommandAwareParser with a 'submit' subcommand."""
+        parser = testflinger_cli.SubcommandAwareParser(prog="testflinger")
+        parser.add_argument("-d", "--debug", action="store_true")
+        parser.add_argument("--server")
+        sub = parser.add_subparsers()
+        sub_parser = sub.add_parser("submit", help="Submit a test job")
+        parser.subparsers_dict["submit"] = sub_parser
+        return parser
+
+    def test_error_shows_subcommand_help_when_subcommand_present(self, capsys):
+        """error() displays subcommand help and exits 2 when subcommand is in argv."""
+        parser = self._make_parser()
+        with patch("sys.argv", ["testflinger", "submit", "--bad-arg"]):
+            with pytest.raises(SystemExit) as exc:
+                parser.error("unrecognized arguments: --bad-arg")
+        assert exc.value.code == 2
+        captured = capsys.readouterr()
+        # Subcommand help should mention the subcommand name
+        assert "submit" in captured.out
+
+    def test_error_fallback_to_main_help_when_no_subcommand(self, capsys):
+        """error() falls back to main parser behaviour when no subcommand is found."""
+        parser = self._make_parser()
+        with patch("sys.argv", ["testflinger", "--unknown-flag"]):
+            with pytest.raises(SystemExit) as exc:
+                parser.error("unrecognized arguments: --unknown-flag")
+        assert exc.value.code == 2
+        # Main parser error is written to stderr by argparse
+        captured = capsys.readouterr()
+        assert "testflinger" in captured.err
+
+    def test_error_with_store_true_flag_before_subcommand(self, capsys):
+        """A store_true flag (-d/--debug) before a subcommand must not prevent
+        the subcommand from being detected in error()."""
+        parser = self._make_parser()
+        # '-d' is store_true; it must not consume 'submit' as its value
+        with patch("sys.argv", ["testflinger", "-d", "submit", "--bad-arg"]):
+            with pytest.raises(SystemExit) as exc:
+                parser.error("unrecognized arguments: --bad-arg")
+        assert exc.value.code == 2
+        captured = capsys.readouterr()
+        assert "submit" in captured.out
+
+    def test_error_with_value_taking_flag_before_subcommand(self, capsys):
+        """A flag that takes a value (--server URL) before a subcommand must
+        have its value skipped so the subcommand is still detected."""
+        parser = self._make_parser()
+        with patch(
+            "sys.argv",
+            ["testflinger", "--server", "http://example.com", "submit", "--bad-arg"],
+        ):
+            with pytest.raises(SystemExit) as exc:
+                parser.error("unrecognized arguments: --bad-arg")
+        assert exc.value.code == 2
+        captured = capsys.readouterr()
+        assert "submit" in captured.out
+
+
+def test_all_subcommands_registered_in_subparsers_dict():
+    """All top-level subcommands, including list-agents, must be registered
+    in subparsers_dict so they can show targeted help on argument errors."""
+    sys.argv = ["", "status", "dummy-job-id"]
+    tfcli = testflinger_cli.TestflingerCli()
+    registered = set(tfcli.main_parser.subparsers_dict.keys())
+    expected_subcommands = {
+        "artifacts",
+        "cancel",
+        "config",
+        "jobs",
+        "list-agents",
+        "list-queues",
+        "login",
+        "poll",
+        "poll-serial",
+        "reserve",
+        "status",
+        "agent-status",
+        "queue-status",
+        "results",
+        "show",
+        "submit",
+        "secret",
+    }
+    missing = expected_subcommands - registered
+    assert not missing, (
+        f"Subcommands not registered in subparsers_dict: {missing}. "
+        "These subcommands cannot show targeted help on argument errors."
+    )

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -2757,8 +2757,7 @@ class TestSubcommandAwareParser:
         assert "testflinger" in captured.err
 
     def test_error_with_store_true_flag_before_subcommand(self, capsys):
-        """A store_true flag (-d/--debug) before a subcommand must not prevent
-        the subcommand from being detected in error()."""
+        """A store_true flag before a subcommand must not prevent subcommand detection in error()."""
         parser = self._make_parser()
         # '-d' is store_true; it must not consume 'submit' as its value
         with patch("sys.argv", ["testflinger", "-d", "submit", "--bad-arg"]):


### PR DESCRIPTION
## Description

Updated the mechanism by which the sub parsers are able to provide help by determining if a subcommand is in use, so that rather than provide the overall help, the individual subcommand can present it's help instead.

## Resolved issues

Resolves CERTTF-917

## Documentation

This improves the help when invalid args are used mid-way

## Web service API changes

N/A

## Tests

Manual testing only, review help text and command line behavior.