### PR TITLE
ci: use github-hosted runners

### DIFF
--- a/.github/workflows/agent-host-charm-check-libs.yml
+++ b/.github/workflows/agent-host-charm-check-libs.yml
@@ -16,13 +16,13 @@ concurrency:
 jobs:
   build:
     name: Check charm libraries
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write  # necessary to add label
+      pull-requests: write # necessary to add label
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/agent-host-charm-release.yml
+++ b/.github/workflows/agent-host-charm-release.yml
@@ -26,15 +26,15 @@ concurrency:
 jobs:
   agent-build-and-push-charm:
     name: Build and Push Charm
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     permissions:
-      actions: read  # necessary to get the runner information
-      contents: write  # necessary to create tag(s)
-      packages: write  # necessary to upload image
+      actions: read # necessary to get the runner information
+      contents: write # necessary to create tag(s)
+      packages: write # necessary to upload image
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Upload charm to charmhub
@@ -68,16 +68,16 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          scan-type: 'fs'
-          scan-ref: 'unpacked-charm'
+          scan-type: "fs"
+          scan-ref: "unpacked-charm"
           exit-code: 1
-          format: 'sarif'
+          format: "sarif"
           vuln-type: library
-          output: 'testflinger-agent-host-trivy-results.sarif'
+          output: "testflinger-agent-host-trivy-results.sarif"
           # By default, SARIF format enforces output of all vulnerabilities regardless of configured severities.
-          severity: 'UNKNOWN,LOW,MEDIUM,CRITICAL,HIGH'
+          severity: "UNKNOWN,LOW,MEDIUM,CRITICAL,HIGH"
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
-          sarif_file: 'testflinger-agent-host-trivy-results.sarif'
+          sarif_file: "testflinger-agent-host-trivy-results.sarif"
           wait-for-processing: "true"

--- a/.github/workflows/agent-tox.yml
+++ b/.github/workflows/agent-tox.yml
@@ -34,7 +34,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python
@@ -87,10 +87,10 @@ jobs:
     defaults:
       run:
         working-directory: agent/charms/testflinger-agent-host-charm
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python

--- a/.github/workflows/server-charm-check-libs.yml
+++ b/.github/workflows/server-charm-check-libs.yml
@@ -15,13 +15,13 @@ concurrency:
 jobs:
   build:
     name: Check charm libraries
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write  # necessary to add label
+      pull-requests: write # necessary to add label
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/server-charm-release.yml
+++ b/.github/workflows/server-charm-release.yml
@@ -29,11 +29,11 @@ env:
 jobs:
   build-and-push-charm:
     name: Build and Push Charm
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     permissions:
-      actions: read  # necessary to read runner information
-      contents: write  # necessary to create tag(s)
-      packages: write  # necessary to create push image
+      actions: read # necessary to read runner information
+      contents: write # necessary to create tag(s)
+      packages: write # necessary to create push image
 
     env:
       IMAGE_NAME: ${{ github.repository }}
@@ -48,7 +48,7 @@ jobs:
               mirrors = ["https://github-runner-dockerhub-cache.canonical.com:5000"]
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -111,16 +111,16 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          scan-type: 'fs'
-          scan-ref: 'unpacked-charm'
+          scan-type: "fs"
+          scan-ref: "unpacked-charm"
           exit-code: 1
-          format: 'sarif'
+          format: "sarif"
           vuln-type: library
-          output: 'testflinger-k8s-trivy-results.sarif'
+          output: "testflinger-k8s-trivy-results.sarif"
           # By default, SARIF format enforces output of all vulnerabilities regardless of configured severities.
-          severity: 'UNKNOWN,LOW,MEDIUM,CRITICAL,HIGH'
+          severity: "UNKNOWN,LOW,MEDIUM,CRITICAL,HIGH"
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
-          sarif_file: 'testflinger-k8s-trivy-results.sarif'
+          sarif_file: "testflinger-k8s-trivy-results.sarif"
           wait-for-processing: "true"

--- a/.github/workflows/server-tox.yml
+++ b/.github/workflows/server-tox.yml
@@ -30,7 +30,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python
@@ -95,10 +95,10 @@ jobs:
     defaults:
       run:
         working-directory: server/charm/
-    runs-on: [self-hosted, linux, jammy, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install uv and set up Python


### PR DESCRIPTION
## Description

- Based on org guidance, this PR moves all CI to GitHub-hosted runners
- Only TiCS workflows should need self-hosted runners

## Resolved issues

## Documentation

## Web service API changes

## Tests

- CI passes