### PR TITLE
feat(server/cli): add email for the "owner" of a client id

### DIFF
--- a/cli/testflinger_cli/admin.py
+++ b/cli/testflinger_cli/admin.py
@@ -129,6 +129,13 @@ class TestflingerAdminCLI:
             choices=[role.value for role in ServerRoles],
         )
         parser.add_argument(
+            "--owner",
+            help=(
+                "The owner of the client_id. "
+                "Only applicable for non-OIDC clients."
+            ),
+        )
+        parser.add_argument(
             "--json", help="Optional JSON data with client_permissions"
         )
         self.main_cli._add_auth_args(parser)
@@ -253,6 +260,7 @@ class TestflingerAdminCLI:
                 "max_priority": "max_priority",
                 "max_reservation_time": "max_reservation",
                 "role": "role",
+                "owner": "owner",
             }
 
             json_data = {
@@ -293,6 +301,7 @@ class TestflingerAdminCLI:
                 # Failure reason is clearly stated in msg from server
                 # Unprocessable entity: Schema Validation
                 # Bad Request: Missing client secret for new client
+                # Bad Request: Cannot add owner to OIDC client id
                 # Forbidden: User is not entitled to modify account
                 logger.error(exc.msg)
             else:

--- a/cli/testflinger_cli/admin.py
+++ b/cli/testflinger_cli/admin.py
@@ -129,9 +129,9 @@ class TestflingerAdminCLI:
             choices=[role.value for role in ServerRoles],
         )
         parser.add_argument(
-            "--owner",
+            "--email",
             help=(
-                "The owner of the client_id. "
+                "The email associated with the client_id. "
                 "Only applicable for non-OIDC clients."
             ),
         )
@@ -260,7 +260,7 @@ class TestflingerAdminCLI:
                 "max_priority": "max_priority",
                 "max_reservation_time": "max_reservation",
                 "role": "role",
-                "owner": "owner",
+                "email": "email",
             }
 
             json_data = {
@@ -301,7 +301,7 @@ class TestflingerAdminCLI:
                 # Failure reason is clearly stated in msg from server
                 # Unprocessable entity: Schema Validation
                 # Bad Request: Missing client secret for new client
-                # Bad Request: Cannot add owner to OIDC client id
+                # Bad Request: Cannot add email to OIDC client id
                 # Forbidden: User is not entitled to modify account
                 logger.error(exc.msg)
             else:

--- a/cli/tests/test_admin_cli.py
+++ b/cli/tests/test_admin_cli.py
@@ -527,3 +527,39 @@ def test_client_id_missing_from_permissions(auth_fixture):
     with pytest.raises(SystemExit) as exc:
         testflinger_cli.TestflingerCli().run()
     assert "Error: client_id cannot be empty" in str(exc.value)
+
+
+def test_create_client_permissions_with_email_argument(
+    auth_fixture, capsys, requests_mock
+):
+    """Validate that email is sent in the PUT request body."""
+    auth_fixture(ServerRoles.ADMIN)
+    fake_client_id = "test-client"
+
+    sys.argv = [
+        "",
+        "admin",
+        "set",
+        "client-permissions",
+        "--testflinger-client-id",
+        fake_client_id,
+        "--testflinger-client-secret",
+        "client-secret",
+        "--email",
+        "owner@example.com",
+    ]
+
+    requests_mock.get(
+        f"{URL}/v1/client-permissions/{fake_client_id}",
+        status_code=HTTPStatus.NOT_FOUND,
+    )
+    put_mock = requests_mock.put(
+        f"{URL}/v1/client-permissions/{fake_client_id}",
+        status_code=HTTPStatus.OK,
+        text=f"Created permissions for client '{fake_client_id}'",
+    )
+    tfcli = testflinger_cli.TestflingerCli()
+    tfcli.run()
+    std = capsys.readouterr()
+    assert f"Created permissions for client '{fake_client_id}'" in std.out
+    assert put_mock.last_request.json()["email"] == "owner@example.com"

--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -110,6 +110,10 @@
           "client_secret": {
             "type": "string"
           },
+          "email": {
+            "format": "email",
+            "type": "string"
+          },
           "max_priority": {
             "additionalProperties": {
               "type": "integer"
@@ -123,6 +127,7 @@
             "type": "object"
           },
           "role": {
+            "default": "contributor",
             "enum": [
               "admin",
               "manager",
@@ -145,6 +150,11 @@
             "type": "array"
           },
           "client_id": {
+            "type": "string"
+          },
+          "email": {
+            "format": "email",
+            "nullable": true,
             "type": "string"
           },
           "max_priority": {

--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -127,7 +127,6 @@
             "type": "object"
           },
           "role": {
-            "default": "contributor",
             "enum": [
               "admin",
               "manager",

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -42,6 +42,7 @@ PERMISSIONS_FIELDS = frozenset(
         "allowed_queues",
         "max_reservation_time",
         "client_id",
+        "owner",
     }
 )
 

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -42,7 +42,7 @@ PERMISSIONS_FIELDS = frozenset(
         "allowed_queues",
         "max_reservation_time",
         "client_id",
-        "owner",
+        "email",
     }
 )
 

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -618,7 +618,7 @@ class ClientPermissionsIn(Schema):
         validate=OneOf([role.value for role in ServerRoles]),
         load_default=ServerRoles.CONTRIBUTOR.value,
     )
-    owner = fields.String(required=False)
+    email = fields.Email(required=False)
 
 
 class ClientPermissionsOut(Schema):
@@ -638,7 +638,7 @@ class ClientPermissionsOut(Schema):
     role = fields.String(
         required=True, dump_default=ServerRoles.CONTRIBUTOR.value
     )
-    owner = fields.String(required=False, allow_none=True)
+    email = fields.Email(required=False, allow_none=True)
 
 
 class SecretIn(Schema):

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -614,9 +614,7 @@ class ClientPermissionsIn(Schema):
         required=False,
     )
     role = fields.String(
-        required=False,
-        validate=OneOf([role.value for role in ServerRoles]),
-        load_default=ServerRoles.CONTRIBUTOR.value,
+        required=False, validate=OneOf([role.value for role in ServerRoles])
     )
     email = fields.Email(required=False)
 

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -614,8 +614,11 @@ class ClientPermissionsIn(Schema):
         required=False,
     )
     role = fields.String(
-        required=False, validate=OneOf([role.value for role in ServerRoles])
+        required=False,
+        validate=OneOf([role.value for role in ServerRoles]),
+        load_default=ServerRoles.CONTRIBUTOR.value,
     )
+    owner = fields.String(required=False)
 
 
 class ClientPermissionsOut(Schema):
@@ -632,7 +635,10 @@ class ClientPermissionsOut(Schema):
         fields.String(), required=True, allow_none=True
     )
     max_reservation_time = fields.Dict(required=True, allow_none=True)
-    role = fields.String(required=True)
+    role = fields.String(
+        required=True, dump_default=ServerRoles.CONTRIBUTOR.value
+    )
+    owner = fields.String(required=False, allow_none=True)
 
 
 class SecretIn(Schema):

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -1305,6 +1305,11 @@ def set_client_permissions(client_id: str, json_data: dict) -> str:
 
     client_secret = json_data.pop("client_secret", None)
     permissions = database.get_client_permissions(client_id) or {}
+    if "owner" in json_data and permissions.get("sub"):
+        # Do not allow adding an owner to a OIDC client id
+        abort(
+            HTTPStatus.BAD_REQUEST, "Error: Cannot add owner to OIDC client id"
+        )
     client_exist = bool(permissions)
     # Default role for backward compatibility
     current_role = permissions.get("role", ServerRoles.CONTRIBUTOR)

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -1305,10 +1305,10 @@ def set_client_permissions(client_id: str, json_data: dict) -> str:
 
     client_secret = json_data.pop("client_secret", None)
     permissions = database.get_client_permissions(client_id) or {}
-    if "owner" in json_data and permissions.get("sub"):
-        # Do not allow adding an owner to a OIDC client id
+    if "email" in json_data and permissions.get("sub"):
+        # Do not allow adding an email to an OIDC client id
         abort(
-            HTTPStatus.BAD_REQUEST, "Error: Cannot add owner to OIDC client id"
+            HTTPStatus.BAD_REQUEST, "Error: Cannot add email to OIDC client id"
         )
     client_exist = bool(permissions)
     # Default role for backward compatibility

--- a/server/tests/test_v1_authorization.py
+++ b/server/tests/test_v1_authorization.py
@@ -23,6 +23,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
+import bcrypt
 import jwt
 from testflinger_common.enums import ServerRoles
 
@@ -1386,3 +1387,117 @@ def test_refresh_token_last_accessed_update(mongo_app_with_permissions):
     last_accessed_after = token_entry_after["last_accessed"]
 
     assert last_accessed_after > last_accessed_before
+
+
+def test_add_client_permissions_with_email(mongo_app_with_permissions):
+    """Test that an email can be added to a regular (non-OIDC) client."""
+    app, mongo, admin_client_id, client_key, _ = mongo_app_with_permissions
+    token = get_access_token(app, admin_client_id, client_key)
+
+    client_id = "test-client"
+    client_permissions = {
+        "client_secret": "my-secret-password",
+        "max_priority": {},
+        "max_reservation_time": {},
+        "role": ServerRoles.CONTRIBUTOR,
+        "email": "owner@example.com",
+    }
+
+    output = app.put(
+        f"/v1/client-permissions/{client_id}",
+        json=client_permissions,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert output.status_code == HTTPStatus.OK
+
+    # Verify email could be retrieved from the database
+    client_entry = mongo.client_permissions.find_one({"client_id": client_id})
+    assert client_entry["email"] == "owner@example.com"
+
+    # Verify email is returned by the GET endpoint
+    get_output = app.get(
+        f"/v1/client-permissions/{client_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert get_output.status_code == HTTPStatus.OK
+    assert get_output.json["email"] == "owner@example.com"
+
+def test_set_invalid_email_format_rejected(mongo_app_with_permissions):
+    """Test that setting an invalid email on a regular client is rejected."""
+    app, mongo, admin_client_id, client_key, _ = mongo_app_with_permissions
+    token = get_access_token(app, admin_client_id, client_key)
+
+    client_id = "test-client"
+    client_permissions = {
+        "client_secret": "my-secret-password",
+        "max_priority": {},
+        "max_reservation_time": {},
+        "role": ServerRoles.CONTRIBUTOR,
+        "email": "not-an-email",
+    }
+
+    output = app.put(
+        f"/v1/client-permissions/{client_id}",
+        json=client_permissions,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Schema validation should reject and return 422 Unprocessable Entity
+    assert output.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert "Validation error" in output.json["message"]
+
+def test_set_email_on_oidc_client_rejected(mongo_app_with_permissions):
+    """Test that adding an email to an OIDC client is rejected."""
+    app, mongo, admin_client_id, client_key, _ = mongo_app_with_permissions
+    token = get_access_token(app, admin_client_id, client_key)
+
+    oidc_client_id = "test@example.com"
+    mongo.client_permissions.insert_one(
+        {
+            "client_id": oidc_client_id,
+            "sub": "oidc-subject-identifier",
+            "role": ServerRoles.CONTRIBUTOR,
+            "max_priority": {},
+            "allowed_queues": [],
+            "max_reservation_time": {},
+        }
+    )
+
+    output = app.put(
+        f"/v1/client-permissions/{oidc_client_id}",
+        json={"email": "new@example.com"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert output.status_code == HTTPStatus.BAD_REQUEST
+    assert "Cannot add email to OIDC client id" in output.json["message"]
+
+
+def test_email_included_in_jwt_permissions(mongo_app_with_permissions):
+    """Test that a client's email is encoded into the issued JWT."""
+    app, mongo, _, _, _ = mongo_app_with_permissions
+
+    client_id = "test_client_email_jwt"
+    client_key = "test_key"
+    client_key_hash = bcrypt.hashpw(
+        client_key.encode("utf-8"), bcrypt.gensalt()
+    ).decode("utf-8")
+    mongo.client_permissions.insert_one(
+        {
+            "client_id": client_id,
+            "client_secret_hash": client_key_hash,
+            "role": ServerRoles.CONTRIBUTOR,
+            "max_priority": {},
+            "allowed_queues": [],
+            "max_reservation_time": {},
+            "email": "test@example.com",
+        }
+    )
+
+    token = get_access_token(app, client_id, client_key)
+    decoded = jwt.decode(
+        token,
+        os.environ.get("JWT_SIGNING_KEY"),
+        algorithms="HS256",
+        options={"require": ["exp", "iat", "sub", "permissions"]},
+    )
+    assert decoded["permissions"]["email"] == "test@example.com"

--- a/server/tests/test_v1_authorization.py
+++ b/server/tests/test_v1_authorization.py
@@ -1422,6 +1422,7 @@ def test_add_client_permissions_with_email(mongo_app_with_permissions):
     assert get_output.status_code == HTTPStatus.OK
     assert get_output.json["email"] == "owner@example.com"
 
+
 def test_set_invalid_email_format_rejected(mongo_app_with_permissions):
     """Test that setting an invalid email on a regular client is rejected."""
     app, mongo, admin_client_id, client_key, _ = mongo_app_with_permissions
@@ -1445,6 +1446,7 @@ def test_set_invalid_email_format_rejected(mongo_app_with_permissions):
     # Schema validation should reject and return 422 Unprocessable Entity
     assert output.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert "Validation error" in output.json["message"]
+
 
 def test_set_email_on_oidc_client_rejected(mongo_app_with_permissions):
     """Test that adding an email to an OIDC client is rejected."""


### PR DESCRIPTION
## Description
With the introduction of OIDC accounts, we now have a concept of "service" accounts or credentials-based client-ids. In order to map this to the "owner" of this account, we need to add the email as an optional parameter to add for client based accounts. 

OIDC accounts should not add this "email" field given this is provided by the OIDC provider. 

For convenience, this also loads and dumps the defaults for a client-id.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
[CERTTF-1265](https://warthogs.atlassian.net/browse/CERTTF-1265)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
NA
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
NA
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-1265]: https://warthogs.atlassian.net/browse/CERTTF-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ