### PR TITLE
fix(agent-charm): reauthenticate on secret change

### DIFF
--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -244,7 +244,7 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
 
         return content
 
-    def _update_refresh_token(self, event: ops.EventBase) -> bool:
+    def _update_refresh_token(self, event: ops.HookEvent) -> bool:
         """Update the refresh token if needed.
 
         This checks both if the refresh token is expired or if

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -188,9 +188,9 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         self.update_testflinger_repo()
         self.unit.status = ops.ActiveStatus()
 
-    def on_start(self, _):
+    def on_start(self, event: ops.StartEvent):
         """Start the service."""
-        if not self._update_refresh_token():
+        if not self._update_refresh_token(event=event):
             return
         self.unit.status = ops.ActiveStatus()
 
@@ -199,18 +199,18 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         secret = self.typed_config.credentials_secret
         if secret and event.secret.id == secret.id:
             logger.info("Credentials secret changed, re-authenticating")
-            if not self._update_refresh_token():
+            if not self._update_refresh_token(event=event):
                 return
             self.unit.status = ops.ActiveStatus()
 
-    def _on_update_status(self, _):
+    def _on_update_status(self, event: ops.UpdateStatusEvent):
         """Periodically check token expiration and re-authenticate if needed.
 
         update_status hook is triggered at an interval defined at the Juju
         model config so its not configurable by the charm application
         (default: 5 minutes).
         """
-        if not self._update_refresh_token():
+        if not self._update_refresh_token(event=event):
             return
         self.unit.status = ops.ActiveStatus()
 
@@ -244,12 +244,18 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
 
         return content
 
-    def _update_refresh_token(self) -> bool:
+    def _update_refresh_token(self, event: ops.EventBase) -> bool:
         """Update the refresh token if needed.
+
+        This checks both if the refresh token is expired or if
+        the credentials secret has changed. In case of the latter,
+        the refresh token will be updated regardless of its expiration status.
 
         :returns: True if update succeeded or not needed, False otherwise.
         """
-        if testflinger_client.token_update_needed():
+        if testflinger_client.token_update_needed() or isinstance(
+            event, ops.SecretChangedEvent
+        ):
             logger.info("Token update needed, attempting to refresh token")
             return self._authenticate_with_server()
         return True
@@ -273,7 +279,7 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         logger.info("Authentication with Testflinger server succeeded")
         return True
 
-    def on_config_changed(self, _):
+    def on_config_changed(self, event: ops.ConfigChangedEvent):
         """Handle on config changed event."""
         # Do not clear the status if we are already in a BlockedStatus
         if not isinstance(self.unit.status, ops.BlockedStatus):
@@ -292,7 +298,7 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         self.write_supervisor_service_files()
         supervisord.supervisor_update()
         supervisord.restart_agents()
-        if not self._update_refresh_token():
+        if not self._update_refresh_token(event=event):
             return
         self.unit.status = ops.ActiveStatus()
 

--- a/agent/charms/testflinger-agent-host-charm/src/charm.py
+++ b/agent/charms/testflinger-agent-host-charm/src/charm.py
@@ -254,7 +254,7 @@ class TestflingerAgentHostCharm(ops.charm.CharmBase):
         :returns: True if update succeeded or not needed, False otherwise.
         """
         if testflinger_client.token_update_needed() or isinstance(
-            event, ops.SecretChangedEvent
+            event, (ops.SecretChangedEvent, ops.ConfigChangedEvent)
         ):
             logger.info("Token update needed, attempting to refresh token")
             return self._authenticate_with_server()

--- a/agent/charms/testflinger-agent-host-charm/src/common.py
+++ b/agent/charms/testflinger-agent-host-charm/src/common.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import subprocess
+import tempfile
 from pathlib import Path
 
 from jinja2 import Template
@@ -57,10 +58,23 @@ def write_file(location: Path, contents: str, chmod: int = 0o644) -> None:
     :param contents: Contents to write to the file.
     :param chmod: File permission to set on the file.
     """
-    with open(location, "w", encoding="utf-8", errors="ignore") as out:
-        out.write(contents)
-    os.chown(location, 1000, 1000)
-    os.chmod(location, chmod)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        dir=location.parent,
+        delete=False,
+        encoding="utf-8",
+        errors="ignore",
+    ) as tmp:
+        tmp.write(contents)
+        tmp_path = Path(tmp.name)
+    try:
+        os.chown(tmp_path, 1000, 1000)
+        os.chmod(tmp_path, chmod)
+        os.replace(tmp_path, location)
+    except OSError:
+        # Clean up the temporary file if an error occurs
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def update_charm_scripts(config: TestflingerAgentConfig) -> None:

--- a/agent/charms/testflinger-agent-host-charm/src/common.py
+++ b/agent/charms/testflinger-agent-host-charm/src/common.py
@@ -93,5 +93,4 @@ def update_charm_scripts(config: TestflingerAgentConfig) -> None:
             virtual_env_path=VIRTUAL_ENV_PATH,
         )
         agent_file = usr_local_bin / tf_cmd_file.name
-        agent_file.write_text(rendered)
-        agent_file.chmod(0o775)
+        write_file(agent_file, rendered, chmod=0o775)

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -381,7 +381,12 @@ def test_config_changed_force_reauthentication(
 @patch("testflinger_client.authenticate")
 @patch("testflinger_client.token_update_needed", return_value=False)
 def test_events_does_not_trigger_authentication_when_token_valid(
-    mock_token_update_needed, mock_authenticate, event_name, ctx, state_in, secret
+    mock_token_update_needed,
+    mock_authenticate,
+    event_name,
+    ctx,
+    state_in,
+    secret,
 ):
     """Test that events do not trigger authentication if token is valid."""
     state = state_in(

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -347,15 +347,46 @@ def test_secret_change_force_reauthentication(
     mock_authenticate.assert_called_once()
 
 
+@patch("testflinger_client.authenticate", return_value=True)
+@patch("testflinger_client.token_update_needed", return_value=False)
+@patch("charm.supervisord.restart_agents")
+@patch("charm.supervisord.supervisor_update")
+@patch("charm.TestflingerAgentHostCharm.write_supervisor_service_files")
+@patch("charm.update_charm_scripts")
+@patch("charm.copy_ssh_keys")
+@patch("charm.charm_utils.update_config_files")
+def test_config_changed_force_reauthentication(
+    mock_update_config,
+    mock_copy_ssh,
+    mock_update_scripts,
+    mock_write_supervisor,
+    mock_supervisor_update,
+    mock_restart,
+    mock_token_update_needed,
+    mock_authenticate,
+    ctx,
+    state_in,
+    secret,
+):
+    """Test config_changed reauthenticates even if token is not expired."""
+    state = state_in(
+        config={"credentials-secret": secret.id},
+        secrets=[secret],
+    )
+    ctx.run(ctx.on.config_changed(), state=state)
+    mock_authenticate.assert_called_once()
+
+
+@pytest.mark.parametrize("event_name", ["start", "update_status"])
 @patch("testflinger_client.authenticate")
 @patch("testflinger_client.token_update_needed", return_value=False)
 def test_events_does_not_trigger_authentication_when_token_valid(
-    mock_token_update_needed, mock_authenticate, ctx, state_in, secret
+    mock_token_update_needed, mock_authenticate, event_name, ctx, state_in, secret
 ):
     """Test that events do not trigger authentication if token is valid."""
     state = state_in(
         config={"credentials-secret": secret.id},
         secrets=[secret],
     )
-    ctx.run(ctx.on.update_status(), state=state)
+    ctx.run(getattr(ctx.on, event_name)(), state=state)
     mock_authenticate.assert_not_called()

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -331,3 +331,31 @@ def test_config_changed_does_not_clear_blocked_status(
     messages = [call.args[0] for call in mock_maintenance.call_args_list]
     assert "Handling config_changed hook" not in messages
     assert isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+@patch("testflinger_client.authenticate", return_value=True)
+@patch("testflinger_client.token_update_needed", return_value=False)
+def test_secret_change_force_reauthentication(
+    mock_token_update_needed, mock_authenticate, ctx, state_in, secret
+):
+    """Test secret change reauthenticated even if token is not expired."""
+    state = state_in(
+        config={"credentials-secret": secret.id},
+        secrets=[secret],
+    )
+    ctx.run(ctx.on.secret_changed(secret), state=state)
+    mock_authenticate.assert_called_once()
+
+
+@patch("testflinger_client.authenticate")
+@patch("testflinger_client.token_update_needed", return_value=False)
+def test_events_does_not_trigger_authentication_when_token_valid(
+    mock_token_update_needed, mock_authenticate, ctx, state_in, secret
+):
+    """Test that events do not trigger authentication if token is valid."""
+    state = state_in(
+        config={"credentials-secret": secret.id},
+        secrets=[secret],
+    )
+    ctx.run(ctx.on.update_status(), state=state)
+    mock_authenticate.assert_not_called()

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_charm.py
@@ -338,7 +338,7 @@ def test_config_changed_does_not_clear_blocked_status(
 def test_secret_change_force_reauthentication(
     mock_token_update_needed, mock_authenticate, ctx, state_in, secret
 ):
-    """Test secret change reauthenticated even if token is not expired."""
+    """Test secret change reauthenticates even if token is not expired."""
     state = state_in(
         config={"credentials-secret": secret.id},
         secrets=[secret],

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_common.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_common.py
@@ -3,8 +3,11 @@
 """Unit tests for common module."""
 
 import base64
+import stat
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
 
 import common
 from config import TestflingerAgentConfig
@@ -58,3 +61,50 @@ def test_update_charm_scripts(
     mock_script.read_text.assert_called_once()
     mock_write_text.assert_called_once()
     mock_chmod.assert_called_once_with(0o775)
+
+
+@patch("os.chown")
+def test_write_file_creates_with_correct_content(mock_chown, tmp_path):
+    """Test write_file writes the correct content to the target file."""
+    target = tmp_path / "test.txt"
+    common.write_file(target, "hello world")
+    assert target.read_text() == "hello world"
+
+
+@patch("os.chown")
+def test_write_file_sets_correct_permissions_and_ownership(
+    mock_chown, tmp_path
+):
+    """Test write_file applies the given chmod and sets proper ownership."""
+    target = tmp_path / "test.txt"
+    mode = 0o600
+    common.write_file(target, "content", chmod=mode)
+    assert stat.S_IMODE(target.stat().st_mode) == mode
+    # ubuntu:ubuntu is uid:gid 1000:1000
+    mock_chown.assert_called_once_with(ANY, 1000, 1000)
+
+
+@patch("os.replace")
+@patch("os.chown")
+def test_write_file_is_atomic(mock_chown, mock_replace, tmp_path):
+    """Test write_file uses os.replace for an atomic swap."""
+    target = tmp_path / "test.txt"
+    common.write_file(target, "content")
+    tmp_file, dest = mock_replace.call_args[0]
+    assert Path(tmp_file).parent == target.parent
+    assert dest == target
+
+
+@patch("os.replace", side_effect=OSError)
+@patch("os.chown")
+def test_write_file_handles_oserror_and_cleans_up(
+    mock_chown, mock_replace, tmp_path
+):
+    """Test write_file cleans up temporary file on OSError."""
+    target = tmp_path / "test.txt"
+    with pytest.raises(OSError):
+        common.write_file(target, "content")
+
+    # Ensure the temporary file is cleaned up
+    temp_files = list(tmp_path.glob("tmp*"))
+    assert len(temp_files) == 0

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_common.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_common.py
@@ -41,12 +41,11 @@ def test_copy_ssh_keys(mock_write_file, mock_chmod, mock_chown):
     assert mock_write_file.call_count == 3
 
 
-@patch("common.Path.chmod")
-@patch("common.Path.write_text")
+@patch("common.write_file")
 @patch("common.Path.iterdir")
 @patch("common.Path.read_text")
 def test_update_charm_scripts(
-    mock_read_text, mock_iterdir, mock_write_text, mock_chmod
+    mock_read_text, mock_iterdir, mock_write_file
 ):
     """Test update_charm_scripts renders and writes templates."""
     mock_script = MagicMock(spec=Path)
@@ -59,8 +58,9 @@ def test_update_charm_scripts(
     common.update_charm_scripts(config)
 
     mock_script.read_text.assert_called_once()
-    mock_write_text.assert_called_once()
-    mock_chmod.assert_called_once_with(0o775)
+    mock_write_file.assert_called_once()
+    _, _, kwargs = mock_write_file.mock_calls[0]
+    assert kwargs.get("chmod") == 0o775
 
 
 @patch("os.chown")

--- a/agent/charms/testflinger-agent-host-charm/tests/unit/test_common.py
+++ b/agent/charms/testflinger-agent-host-charm/tests/unit/test_common.py
@@ -44,9 +44,7 @@ def test_copy_ssh_keys(mock_write_file, mock_chmod, mock_chown):
 @patch("common.write_file")
 @patch("common.Path.iterdir")
 @patch("common.Path.read_text")
-def test_update_charm_scripts(
-    mock_read_text, mock_iterdir, mock_write_file
-):
+def test_update_charm_scripts(mock_read_text, mock_iterdir, mock_write_file):
     """Test update_charm_scripts renders and writes templates."""
     mock_script = MagicMock(spec=Path)
     mock_script.name = "test-script"


### PR DESCRIPTION
## Description
The authentication with the testflinger server needs to be updated whenever any potential reference to the Juju secret changes. This can be done whenever there is any "on_secret_changed" (the value of the secret was modified) or "config_changed" (potentially, the secret config option changed)

There is currently a bug where if `on_secret_changed` was fired, the authentication won't be triggered as the only validation being made is to check if the secret is already expired. Potentially, the secret is still within the 3 days allowed to live, the authentication won't be refreshed. 

Additionally, this fixes in place write to atomic writes so its safer for file write operations. Instead of writing in place this creates a temporary file which then replaces the original atomically. 

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Resolves [CERTTF-1262](https://warthogs.atlassian.net/browse/CERTTF-1262)
Resolves #1163 
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests for both fixes
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->


[CERTTF-1262]: https://warthogs.atlassian.net/browse/CERTTF-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ