### PR TITLE
fix: revert collMod given it requires dbAdmin permissions

### DIFF
--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -26,7 +26,7 @@ from testflinger_common.enums import ServerRoles
 
 # Constants for TTL indexes
 REFRESH_TOKEN_IDEL_EXPIRATION = 60 * 60 * 24 * 90  # 90 days
-DEFAULT_EXPIRATION = 60 * 60 * 24 * 14  # 14 days
+DEFAULT_EXPIRATION = 60 * 60 * 24 * 7  # 7 days
 OUTPUT_EXPIRATION = 60 * 60 * 4  # 4 hours
 ACCOUNT_DELETE_EXPIRATION = 60 * 60 * 24 * 90  # 90 days
 
@@ -78,57 +78,44 @@ def setup_mongodb(application):
     create_indexes()
 
 
-def _ensure_ttl_index(collection, field: str, expire_after_seconds: int):
-    """Ensure a TTL index on ``field`` has the correct expiration.
-
-    - Creates the index if it does not exist.
-    - Does nothing if the index already exists with the same expiration.
-    - Uses ``collMod`` to update the expiration when the index exists with a
-      different value, avoiding ``IndexOptionsConflict`` errors on startup.
-    """
-    key_pattern = [(field, 1)]
-    for index_info in collection.index_information().values():
-        if index_info.get("key") == key_pattern:
-            if index_info.get("expireAfterSeconds") == expire_after_seconds:
-                return
-            collection.database.command(
-                "collMod",
-                collection.name,
-                index={
-                    "keyPattern": {field: 1},
-                    "expireAfterSeconds": expire_after_seconds,
-                },
-            )
-            return
-    collection.create_index(field, expireAfterSeconds=expire_after_seconds)
-
-
 def create_indexes():
     """Initialize collections and indexes in case they don't exist already."""
-    # Automatically expire jobs after 14 days if nothing runs them
-    _ensure_ttl_index(mongo.db.jobs, "created_at", DEFAULT_EXPIRATION)
+    # Automatically expire jobs after 7 days if nothing runs them
+    mongo.db.jobs.create_index(
+        "created_at", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
 
     # Remove output 4 hours after the last entry if nothing polls for it
-    _ensure_ttl_index(mongo.db.output, "updated_at", OUTPUT_EXPIRATION)
+    mongo.db.output.create_index(
+        "updated_at", expireAfterSeconds=OUTPUT_EXPIRATION
+    )
 
-    # Remove logs after 14 days
-    _ensure_ttl_index(mongo.db.logs, "updated_at", DEFAULT_EXPIRATION)
+    # Remove logs after 7 days
+    mongo.db.logs.create_index(
+        "updated_at", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
 
-    # Remove artifacts after 14 days
-    _ensure_ttl_index(mongo.db["fs.chunks"], "uploadDate", DEFAULT_EXPIRATION)
-    _ensure_ttl_index(mongo.db["fs.files"], "uploadDate", DEFAULT_EXPIRATION)
+    # Remove artifacts after 7 days
+    mongo.db["fs.chunks"].create_index(
+        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
+    mongo.db["fs.files"].create_index(
+        "uploadDate", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
 
-    # Remove agents that haven't checked in for 14 days
-    _ensure_ttl_index(mongo.db.agents, "updated_at", DEFAULT_EXPIRATION)
+    # Remove agents that haven't checked in for 7 days
+    mongo.db.agents.create_index(
+        "updated_at", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
 
-    # Remove advertised queues that haven't updated in over 14 days
-    _ensure_ttl_index(mongo.db.queues, "updated_at", DEFAULT_EXPIRATION)
+    # Remove advertised queues that haven't updated in over 7 days
+    mongo.db.queues.create_index(
+        "updated_at", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
 
     # Remove refresh tokens that haven't been accessed over 90 days
-    _ensure_ttl_index(
-        mongo.db.refresh_tokens,
-        "last_accessed",
-        REFRESH_TOKEN_IDEL_EXPIRATION,
+    mongo.db.refresh_tokens.create_index(
+        "last_accessed", expireAfterSeconds=REFRESH_TOKEN_IDEL_EXPIRATION
     )
 
     # Remove OIDC device codes after the defined expiration time

--- a/server/tests/test_database.py
+++ b/server/tests/test_database.py
@@ -23,7 +23,6 @@ from mongomock.gridfs import enable_gridfs_integration
 
 from testflinger.database import (
     DEFAULT_EXPIRATION,
-    _ensure_ttl_index,
     create_indexes,
     retrieve_file,
     save_file,
@@ -108,56 +107,3 @@ def test_create_indexes_gridfs_collections(mock_mongo):
     assert chunks_ttl.get("expireAfterSeconds") == DEFAULT_EXPIRATION
     assert files_ttl is not None
     assert files_ttl.get("expireAfterSeconds") == DEFAULT_EXPIRATION
-
-
-@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
-def test_ensure_ttl_index_creates_index(mock_mongo):
-    """Test _ensure_ttl_index creates a TTL index when none exists."""
-    collection = mock_mongo.db.test_col
-    _ensure_ttl_index(collection, "created_at", DEFAULT_EXPIRATION)
-
-    indexes = collection.index_information()
-    ttl_index = next(
-        (
-            info
-            for info in indexes.values()
-            if info.get("key") == [("created_at", 1)]
-        ),
-        None,
-    )
-    assert ttl_index is not None
-    assert ttl_index.get("expireAfterSeconds") == DEFAULT_EXPIRATION
-
-
-@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
-def test_ensure_ttl_index_no_op_when_unchanged(mock_mongo):
-    """Test _ensure_ttl_index does nothing when the TTL already matches."""
-    collection = mock_mongo.db.test_col
-    collection.create_index(
-        "created_at", expireAfterSeconds=DEFAULT_EXPIRATION
-    )
-
-    with patch.object(collection, "create_index") as mock_create:
-        with patch.object(collection.database, "command") as mock_command:
-            _ensure_ttl_index(collection, "created_at", DEFAULT_EXPIRATION)
-
-    mock_create.assert_not_called()
-    mock_command.assert_not_called()
-
-
-@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
-def test_ensure_ttl_index_uses_collmod_when_ttl_changed(mock_mongo):
-    """Test _ensure_ttl_index updates via collMod when the TTL differs."""
-    collection = mock_mongo.db.test_col
-    old_ttl = DEFAULT_EXPIRATION // 2
-    collection.create_index("created_at", expireAfterSeconds=old_ttl)
-
-    new_ttl = DEFAULT_EXPIRATION
-    with patch.object(collection.database, "command") as mock_command:
-        _ensure_ttl_index(collection, "created_at", new_ttl)
-
-    mock_command.assert_called_once_with(
-        "collMod",
-        collection.name,
-        index={"keyPattern": {"created_at": 1}, "expireAfterSeconds": new_ttl},
-    )


### PR DESCRIPTION
## Description
dbAdmin is required for collMod, we would need a different approach
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
This also reverts the tests. All other should pass
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
