### PR TITLE
Fix shell command filter status in tutorial

### DIFF
--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -120,7 +120,7 @@ Run the following command in the terminal to retrieve the available job queues t
 .. code-block:: shell
 
   $ testflinger list-agents \
-  --filter-status=online,^provision,^reserve,^testing \
+  --filter-status=online,^provision,^reserve,^test \
   --filter-provision-type=maas \
   --filter-queue "intel" \
   --fields name,status,queues

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -122,7 +122,7 @@ Run the following command in the terminal to retrieve the available job queues t
   $ testflinger list-agents \
   --filter-status=online,^provision,^reserve,^test \
   --filter-provision-type=maas \
-  --filter-queue "intel" \
+  --filter-queues "intel" \
   --fields name,status,queues
 
 If the connection is successful, a list of agents and their respective job queues is returned:


### PR DESCRIPTION
Resolves https://github.com/canonical/testflinger/issues/1112

## Description

changes "^testing" to "^test"

## Resolved issues

Resolves #1112 

## Documentation

Fixes incorrect tutorial command.

## Web service API changes

N/A

## Tests

N/A