### PR TITLE
feat: add labeled links to agents

### DIFF
--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -123,6 +123,7 @@ class TestflingerAgent:
         identifier = self.client.config.get("identifier")
         location = self.client.config.get("location", "")
         provision_type = self.client.config.get("provision_type", "")
+        links = self.client.config.get("links", {})
         queues = self.client.config.get("job_queues", [])
 
         agent_data = {
@@ -132,6 +133,8 @@ class TestflingerAgent:
         }
         if identifier:
             agent_data["identifier"] = identifier
+        if links:
+            agent_data["links"] = links
 
         self.client.post_agent_data(agent_data)
 

--- a/agent/src/testflinger_agent/schema.py
+++ b/agent/src/testflinger_agent/schema.py
@@ -41,6 +41,7 @@ SCHEMA_V1 = {
     voluptuous.Required("reserve_command", default=""): str,
     voluptuous.Required("cleanup_command", default=""): str,
     voluptuous.Optional("provision_type"): str,
+    voluptuous.Optional("links"): {str: str},
     voluptuous.Optional("global_timeout"): int,
     voluptuous.Optional("output_timeout"): int,
     voluptuous.Optional("advertised_queues"): dict,

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -505,6 +505,10 @@ class TestClient:
 
     def test_post_agent_data(self, agent):
         # Make sure we post the initial agent data
+        self.config["links"] = {
+            "c3": "https://example.com/c3",
+            "product": "https://example.com/product",
+        }
         with patch.object(
             testflinger_agent.client.TestflingerClient, "post_agent_data"
         ) as mock_post_agent_data:
@@ -515,6 +519,7 @@ class TestClient:
                     "queues": self.config["job_queues"],
                     "location": self.config["location"],
                     "provision_type": self.config["provision_type"],
+                    "links": self.config["links"],
                 }
             )
 

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -26,6 +26,8 @@ identifier: 12345-123456
 polling_interval: 10
 server_address: 127.0.0.1:8000
 location: earth
+links:
+    product: https://example.com/product
 job_queues:
     - test
 """
@@ -48,6 +50,9 @@ class ConfigTest(TestCase):
             config.write(GOOD_CONFIG)
         config = testflinger_agent.load_config(self.configfile)
         self.assertEqual("test01", config.get("agent_id"))
+        self.assertEqual(
+            {"product": "https://example.com/product"}, config.get("links")
+        )
 
     def test_config_bad(self):
         with open(self.configfile, "w") as config:

--- a/docs/reference/testflinger-agent-conf.rst
+++ b/docs/reference/testflinger-agent-conf.rst
@@ -54,6 +54,8 @@ The following configuration options are supported by the Testflinger Agent:
       - Command to run for the cleanup phase
     * - ``provision_type``
       - (Optional) type of device connector used. This is sometimes useful when templating the call to the external device-agent command, but is not required. For the list of supported provision types, see :doc:`device-connector-types`.
+    * - ``links``
+      - (Optional) mapping of labels to URLs shown on the agent detail page, for example ``c3`` or ``product`` links.
 
 Example configuration
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -81,3 +83,6 @@ Example configuration
   reserve_command: testflinger-device-connector muxpi reserve -c /path/to/default.yaml testflinger.json
   cleanup_command: echo Consider removing containers or other necessary cleanup steps here
   provision_type: muxpi
+  links:
+      c3: https://example.com/certification-inventory/rpi-example
+      product: https://example.com/products/rpi-example

--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -31,6 +31,13 @@
           "location": {
             "type": "string"
           },
+          "links": {
+            "additionalProperties": {
+              "format": "uri",
+              "type": "string"
+            },
+            "type": "object"
+          },
           "log": {
             "items": {
               "type": "string"
@@ -63,6 +70,13 @@
           },
           "location": {
             "type": "string"
+          },
+          "links": {
+            "additionalProperties": {
+              "format": "uri",
+              "type": "string"
+            },
+            "type": "object"
           },
           "name": {
             "type": "string"

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -56,6 +56,9 @@ class AgentIn(Schema):
     log = fields.List(fields.String(), required=False)
     provision_type = fields.String(required=False)
     queues = fields.List(fields.String(), required=False)
+    links = fields.Dict(
+        keys=fields.String(), values=fields.URL(), required=False
+    )
     state = fields.String(required=False)
     comment = fields.String(required=False)
 
@@ -66,6 +69,9 @@ class AgentOut(Schema):
     name = fields.String(required=True)
     state = fields.String(required=False)
     queues = fields.List(fields.String(), required=False)
+    links = fields.Dict(
+        keys=fields.String(), values=fields.URL(), required=False
+    )
     location = fields.String(required=False)
     provision_type = fields.String(required=False)
     job_id = fields.String(required=False)

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -736,6 +736,7 @@ def agents_post(agent_name, json_data):
         "state": string, # State the device is in
         "queues": array[string], # Queues the device is listening on
         "location": string, # Location of the device
+        "links": object, # Labeled URLs with more device information
         "job_id": string, # Job ID the device is running, if any
         "log": array[string], # push and keep only the last 100 lines
     }

--- a/server/src/testflinger/templates/agent_detail.html
+++ b/server/src/testflinger/templates/agent_detail.html
@@ -25,6 +25,20 @@
         <th scope="row">Comment</th>
         <td>{{ agent.comment }}</td>
       </tr>
+      {% if agent.links %}
+        <tr>
+          <th scope="row">Links</th>
+          <td>
+            <ul>
+              {% for label, url in agent.links.items() %}
+                <li>
+                  <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ label }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          </td>
+        </tr>
+      {% endif %}
       <tr>
         <th scope="row">Last updated</th>
         <td>{{ agent.updated_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -1319,6 +1319,7 @@ def test_get_agents_data(mongo_app, agent_auth_header):
         "state": "provision",
         "queues": ["q1", "q2"],
         "location": "here",
+        "links": {"product": "https://example.com/product"},
     }
     output = app.post(
         f"/v1/agents/data/{agent_name}",

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -154,6 +154,7 @@ def test_agent_detail_with_restricted_to(testapp):
     mongo.db.agents.insert_one(
         {
             "name": "agent1",
+            "links": {"product": "https://example.com/product"},
             "queues": ["queue1", "queue2"],
             "updated_at": datetime.now(tz=timezone.utc),
         }
@@ -167,6 +168,8 @@ def test_agent_detail_with_restricted_to(testapp):
 
     html = str(response)
     assert "(restricted to: test-client-id)" in html
+    assert 'href="https://example.com/product"' in html
+    assert ">product</a>" in html
 
 
 def test_agent_detail_with_non_advertised_queue(testapp):


### PR DESCRIPTION
## What changed

- add an optional `links` mapping to agent configuration and registration payloads;
- expose validated labeled URLs through the agent API schemas and OpenAPI document;
- render the links on the agent detail page with safe external-link attributes;
- document the configuration and cover the agent, API, and rendered view paths.

## Why

Agents can report location and provision metadata, but there was no structured field for related inventory, product, BMC, or certification pages. A label-to-URL mapping keeps those use cases extensible without adding a separate field for every system.

Closes #794

## Validation

- `uv run pytest -q tests/test_views.py tests/test_v1.py -k "agent_detail or get_agents_data"` - 5 passed
- targeted agent and server `ruff check` - passed
- `djlint --check` for `agent_detail.html` - passed
- agent config-schema smoke test - passed
- OpenAPI JSON parse and `git diff --check` - passed

The complete agent runtime test module imports the Unix-only `fcntl` module, so it cannot collect on this Windows checkout; the modified agent files pass Ruff and the schema path was exercised directly.
