### PR TITLE
Fix default values kvm connector

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -201,6 +201,8 @@ class ZapperConnector(ABC, DefaultDevice):
         kwargs["cid"] = self.config.get("env", {}).get("CID")
         kwargs["device_ip"] = self.config["device_ip"]
         # Keep caller-provided script values and only fall back to config.
+        # When the connector is run directly without the Testflinger server,
+        # job JSON can provide script overrides in the provisioning payload.
         kwargs.setdefault("reboot_script", self.config["reboot_script"])
         kwargs.setdefault("poweron_script", self.config.get("poweron_script"))
         kwargs.setdefault(

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -202,9 +202,7 @@ class ZapperConnector(ABC, DefaultDevice):
         kwargs.setdefault("cid", self.config.get("env", {}).get("CID"))
         kwargs.setdefault("device_ip", self.config["device_ip"])
         kwargs.setdefault("reboot_script", self.config["reboot_script"])
-        kwargs.setdefault(
-            "poweron_script", self.config.get("poweron_script")
-        )
+        kwargs.setdefault("poweron_script", self.config.get("poweron_script"))
         kwargs.setdefault(
             "poweroff_script", self.config.get("poweroff_script")
         )

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -196,11 +196,11 @@ class ZapperConnector(ABC, DefaultDevice):
         is present, the image is uploaded via the ``/multipart``
         endpoint; otherwise the request is sent as plain JSON.
         """
-        # Keep caller-provided values (e.g. from job_data) and only
-        # fall back to connector config when a key is missing.
-        kwargs.setdefault("agent_name", self.config["agent_name"])
-        kwargs.setdefault("cid", self.config.get("env", {}).get("CID"))
-        kwargs.setdefault("device_ip", self.config["device_ip"])
+        # Always enforce identity fields from connector config.
+        kwargs["agent_name"] = self.config["agent_name"]
+        kwargs["cid"] = self.config.get("env", {}).get("CID")
+        kwargs["device_ip"] = self.config["device_ip"]
+        # Keep caller-provided script values and only fall back to config.
         kwargs.setdefault("reboot_script", self.config["reboot_script"])
         kwargs.setdefault("poweron_script", self.config.get("poweron_script"))
         kwargs.setdefault(

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/__init__.py
@@ -196,15 +196,17 @@ class ZapperConnector(ABC, DefaultDevice):
         is present, the image is uploaded via the ``/multipart``
         endpoint; otherwise the request is sent as plain JSON.
         """
-        kwargs.update(
-            {
-                "agent_name": self.config["agent_name"],
-                "cid": self.config.get("env", {}).get("CID"),
-                "device_ip": self.config["device_ip"],
-                "reboot_script": self.config["reboot_script"],
-                "poweron_script": self.config.get("poweron_script"),
-                "poweroff_script": self.config.get("poweroff_script"),
-            }
+        # Keep caller-provided values (e.g. from job_data) and only
+        # fall back to connector config when a key is missing.
+        kwargs.setdefault("agent_name", self.config["agent_name"])
+        kwargs.setdefault("cid", self.config.get("env", {}).get("CID"))
+        kwargs.setdefault("device_ip", self.config["device_ip"])
+        kwargs.setdefault("reboot_script", self.config["reboot_script"])
+        kwargs.setdefault(
+            "poweron_script", self.config.get("poweron_script")
+        )
+        kwargs.setdefault(
+            "poweroff_script", self.config.get("poweroff_script")
         )
         payload = {
             "method": self.PROVISION_METHOD,

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper/tests/test_zapper.py
@@ -400,6 +400,24 @@ class TestZapperConnectorRun:
             connector.ZAPPER_READ_TIMEOUT,
         )
 
+    def test_run_preserves_job_reboot_script(
+        self, mocker, connector, mock_post
+    ):
+        """Test that a job-provided reboot_script is not overridden
+        by connector config defaults.
+        """
+        mock_get = mocker.patch("requests.get")
+        mock_sse = self._make_sse([])
+        mock_status = Mock()
+        mock_status.raise_for_status = Mock()
+        mock_status.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [mock_sse, mock_status]
+
+        connector._run(reboot_script=["job-cmd"])
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["kwargs"]["reboot_script"] == ["job-cmd"]
+
     def test_run_streams_sse_log_lines(
         self, mocker, connector, mock_post, caplog
     ):

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/__init__.py
@@ -129,6 +129,8 @@ class DeviceConnector(ZapperConnector):
         "live_image",
         "ubuntu_sso_email",
         "robot_retries",
+        "reboot_script",
+        "poweron_script",
     )
 
     def _validate_configuration(

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -245,6 +245,44 @@ class ZapperKVMConnectorTests(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertDictEqual(kwargs, expected)
 
+    def test_validate_configuration_w_reboot_script_override(self):
+        """Test reboot_script can be passed from job provision_data.
+
+        This allows job-level reboot sequence to override connector config
+        defaults at payload build time.
+        """
+        connector = DeviceConnector({"control_host": "zapper-host"})
+        connector.job_data = {
+            "job_queue": "queue",
+            "provision_data": {
+                "url": "http://example.com/image.iso",
+                "robot_tasks": [
+                    "job.robot",
+                ],
+                "reboot_script": [
+                    "zapper hid press_and_release Escape",
+                ],
+            },
+        }
+
+        connector._get_autoinstall_conf = Mock()
+        connector._read_ssh_key = Mock(return_value="mykey")
+        args, kwargs = connector._validate_configuration()
+
+        expected = {
+            "url": "http://example.com/image.iso",
+            "username": "ubuntu",
+            "password": "ubuntu",
+            "autoinstall_conf": connector._get_autoinstall_conf.return_value,
+            "robot_tasks": ["job.robot"],
+            "authorized_keys": ["mykey"],
+            "reboot_script": [
+                "zapper hid press_and_release Escape",
+            ],
+        }
+        self.assertEqual(args, ())
+        self.assertDictEqual(kwargs, expected)
+
     def test_validate_configuration_alloem(self):
         """Test whether the validate_configuration function returns
         the expected data merging the relevant bits from conf and job

--- a/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/zapper_kvm/tests/test_zapper_kvm.py
@@ -262,6 +262,9 @@ class ZapperKVMConnectorTests(unittest.TestCase):
                 "reboot_script": [
                     "zapper hid press_and_release Escape",
                 ],
+                "poweron_script": [
+                    "zapper poweron DUT",
+                ],
             },
         }
 
@@ -278,6 +281,9 @@ class ZapperKVMConnectorTests(unittest.TestCase):
             "authorized_keys": ["mykey"],
             "reboot_script": [
                 "zapper hid press_and_release Escape",
+            ],
+            "poweron_script": [
+                "zapper poweron DUT",
             ],
         }
         self.assertEqual(args, ())


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR fixes argument precedence for kvm provisioning payloads so job-level values are not overwritten by connector config defaults.

What changed
In base controller connector, switched payload merge to `setdefault` so caller/job values win.
In kvm, forward `reboot_script` and `poweron_script` from `provision_data`
Added regression tests for both.


## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

Related to https://warthogs.atlassian.net/browse/ZAP-1505?search_id=f42612af-e91e-4230-9504-6236f1ee4253

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->

before:
```
$ DISABLE_CONTROL_HOST_POWERCYCLE=1 testflinger-device-connector CONTROLLER_kvm provision -c default-hp.yaml default-hp-test.json 
...
2026-07-13 20:36:46,304 hp-zbook-fury-16-g9-mobile-workstation-pc-c30089 INFO: DEVICE CONNECTOR: [CONTROLLER] Arguments for KVM provisioning: {'url': 'https://tel-image-cache.canonical.com/oem-share/somerville/Platforms/jellyfish-edge-alloem-init/dell-bto-jammy-jellyfish-edge-alloem-init-X180-20250411-28.iso', 'username': 'ubuntu', 'password': 'ubuntu', 'autoinstall_conf': None, 'robot_tasks': ['common/camera_kvm/__init__.robot', 'hp/bios/boot_from_usb.robot', 'hp/oem/jammy/oem_usb.robot', 'common/oem/jammy/wait_reboot.robot'], 'authorized_keys': [...], 'robot_retries': 1, 'agent_name': 'hp-zbook-fury-16-g9-mobile-workstation-pc-c30089', 'cid': '202203-30089', 'device_ip': '10.102.165.92', 'reboot_script': ['snmpset -c private -v2c 10.102.197.155 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.2 i 0', 'sleep 30', 'snmpset -c private-v2c 10.102.197.155 .1.3.6.1.4.1.13742.6.4.1.2.1.2.1.2 i 1'], 'poweron_script': None, 'poweroff_script': None, 'boot_binary': '/tmp/tmpsnve_4ir_default-user-data'}
```

after
```
$ DISABLE_CONTROL_HOST_POWERCYCLE=1 testflinger-device-connector CONTROLLER_kvm provision -c default-hp.yaml default-hp-test.json 
...
2026-07-13 20:37:37,059 hp-zbook-fury-16-g9-mobile-workstation-pc-c30089 INFO: DEVICE CONNECTOR: GET http://10.102.245.92:8000/api/v1/provision/20b695ea-84b9-4a46-a85c-1f30da71e306/logs
2026-07-13 20:37:37,677 hp-zbook-fury-16-g9-mobile-workstation-pc-c30089 INFO: DEVICE CONNECTOR: [CONTROLLER] Arguments for KVM provisioning: {'url': 'https://tel-image-cache.canonical.com/oem-share/somerville/Platforms/jellyfish-edge-alloem-init/dell-bto-jammy-jellyfish-edge-alloem-init-X180-20250411-28.iso', 'username': 'ubuntu', 'password': 'ubuntu', 'autoinstall_conf': None, 'robot_tasks': ['common/camera_kvm/__init__.robot', 'hp/bios/boot_from_usb.robot', 'hp/oem/jammy/oem_usb.robot', 'common/oem/jammy/wait_reboot.robot'], 'authorized_keys': ['...'], 'robot_retries': 1, 'reboot_script': ['CONTROLLER hid press_and_release Control_L Alt_L Delete', 'CONTROLLER hid press_and_release Escape', 'CONTROLLER hid press_and_release Alt_L Print b'], 'agent_name': 'hp-zbook-fury-16-g9-mobile-workstation-pc-c30089', 'cid': '202203-30089', 'device_ip': '10.102.165.92', 'poweron_script': None, 'poweroff_script': None, 'boot_binary': '/tmp/tmpi7sxzs4k_default-user-data'}
```