### PR TITLE
fix(server): reduce slowness when validating client_id and secret_key pair

### DIFF
--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -74,6 +74,9 @@ def validate_client_key_pair(client_id: str, client_key: str) -> dict | None:
     # OIDC-registered clients have no client_secret_hash since they
     # authenticate through the web flow, so reject credential-based logins
     secret_hash = (client_permissions_entry or {}).get("client_secret_hash")
+    # Increasing HASH_ROUNDS will slow down credential validation.
+    # This is more secure but performance may be impacted. If this is changed,
+    # make sure to choose a value that balances security and performance.
     if not secret_hash or not bcrypt.checkpw(
         client_key_bytes,
         secret_hash.encode("utf8"),

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -33,6 +33,7 @@ from testflinger.owasp import OWASPLogger
 
 DEFAULT_REFRESH_TOKEN_EXPIRATION = 6 * 24 * 60 * 60  # 6 days in seconds
 DEFAULT_ACCESS_TOKEN_EXPIRATION = 60 * 10  # 10 minutes
+HASH_ROUNDS = 8
 
 # Fields from client_permissions to include in the Testflinger JWT
 PERMISSIONS_FIELDS = frozenset(
@@ -52,7 +53,9 @@ def hash_secret(secret: str):
 
     :param secret: Secret to be hashed with bcrypt library
     """
-    return bcrypt.hashpw(secret.encode("utf-8"), bcrypt.gensalt()).decode()
+    return bcrypt.hashpw(
+        secret.encode("utf-8"), bcrypt.gensalt(rounds=HASH_ROUNDS)
+    ).decode()
 
 
 def validate_client_key_pair(client_id: str, client_key: str) -> dict | None:

--- a/server/tests/test_v1_authorization.py
+++ b/server/tests/test_v1_authorization.py
@@ -28,6 +28,7 @@ import jwt
 import pytest
 from testflinger_common.enums import ServerRoles
 
+from testflinger.api.auth import HASH_ROUNDS
 from testflinger.api.v1 import TESTFLINGER_ADMIN_ID
 from tests.utilities import (
     get_access_token,
@@ -729,6 +730,10 @@ def test_add_client_permissions(mongo_app_with_permissions, caplog):
     assert "client_secret" not in client_entry
     assert "client_secret_hash" in client_entry
     assert client_entry["client_secret_hash"] != clear_password
+
+    # Verify hash uses the expected cost factor
+    cost = int(client_entry["client_secret_hash"].split("$")[2])
+    assert cost == HASH_ROUNDS
 
     # Verify OWASP user_created event is logged
     assert f"user_created:{admin_client_id}" in caplog.text


### PR DESCRIPTION
## Description
Whenever user attempt to authenticate via credentials (client_id + secret_key), the server uses `bcrypt` to hash the provided secret key and compare it with the stored secret hash. By default, this is using 12 rounds which is very slow and can hold a single unit for up to 800ms on average as per Grafana data. This PR reduces the rounds to 8 which is still safe enough for this application while improving the response time (around 16x) from the server on this endpoint. 

This will require an all secret_key rotation but this is on plan anyway as we are introducing a self-rotation mechanism for users to rotate their credentials on certain expiration. Not an immediate solution but an improvement for new accounts
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
NA, QOL
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes

<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Extended one of the unit tests to check the number of rounds on the stored hashed
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
