### PR TITLE
Fix/auth tweaks

### DIFF
--- a/cli/testflinger_cli/auth.py
+++ b/cli/testflinger_cli/auth.py
@@ -296,8 +296,12 @@ class TestflingerCliAuth:
         return permissions.get("role", ServerRoles.CONTRIBUTOR)
 
     def monitor_for_refresh_token(self, current_refresh_token, interval):
-        # multiple client processes can benefit from the same new refresh
-        # token:
+        """Poll disk for a new refresh token acquired by another process.
+
+        :param current_refresh_token: baseline token to detect a replacement
+        :param interval: seconds to poll before giving up
+        :return: access token if a new refresh token was found, otherwise None
+        """
         next_check = time.monotonic() + interval
         while time.monotonic() < next_check:
             refresh_token = self.get_stored_refresh_token()
@@ -349,7 +353,9 @@ class TestflingerCliAuth:
         code_expiration = time.monotonic() + expires_in
         current_token = self.get_stored_refresh_token()
         while time.monotonic() < code_expiration:
-            if result := monitor_for_refresh_token(current_token, interval):
+            if result := self.monitor_for_refresh_token(
+                current_token, interval
+            ):
                 return result
             try:
                 response = requests.post(

--- a/cli/testflinger_cli/auth.py
+++ b/cli/testflinger_cli/auth.py
@@ -18,11 +18,14 @@
 
 import base64
 import configparser
+import re
+import sys
 import time
 import urllib.parse
 import webbrowser
 from functools import cached_property, wraps
 from http import HTTPStatus
+from pathlib import Path
 from typing import Optional
 
 import jwt
@@ -56,9 +59,51 @@ class TestflingerCliAuth:
         self.secret_key = secret_key
 
         # Refresh token relevant configuration
-        config_home = xdg_config_home()
-        config_home.mkdir(parents=True, exist_ok=True)
-        self.auth_config = config_home / "testflinger-cli-auth.conf"
+        self.config_home = xdg_config_home() / "testflinger-cli"
+        self.config_home.mkdir(parents=True, exist_ok=True)
+
+    @cached_property
+    def auth_config(self):
+        """Return the path to the auth config file that is in use."""
+        print("Establishing cached value for auth_config based on:")
+        print(f"server_url: {self.server_url}")
+        print(f"client_id: {self.client_id}")
+
+        # Also support multiple server combinations, staging and production,
+        # as each will have different refresh tokens
+        auth_config = self.config_home / self._safe_fs_name(self.server_url)
+
+        # When the client is known, we must only use refresh tokens that are
+        # also for that client_id.
+        if self.client_id:
+            auth_config /= self._safe_fs_name(self.client_id)
+        # When the client_id isn't known, we will try to use the last refresh
+        # token for that server. In turn that will resolve the client_id.
+
+        # This means that we can only differentiate which token to use based
+        # on the server, when no client_id is known. This means that we must
+        # save the config file for the server (always) and for the specific
+        # client_id (also) when available.
+
+        auth_config /= ("auth.conf")
+        print(f"The resulting auth_config:\n{auth_config}", file=sys.stderr)
+        auth_config.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with auth_config.open("r") as f:
+                for line in f:
+                    print(line)
+            config_file = configparser.ConfigParser()
+            config_file.read(auth_config)
+            print(vars(config_file))
+        except:
+            pass
+
+        return auth_config
+
+    @staticmethod
+    def _safe_fs_name(name_in: str) -> str:
+        """Return a folder name that is reduced to valid characters."""
+        return re.sub(r"([^a-zA-Z0-9_]+)", "_", name_in)
 
     def get_url(self, endpoint: str) -> str:
         """Construct the full URL for a given endpoint.
@@ -89,6 +134,7 @@ class TestflingerCliAuth:
         # 1. Attempt to authenticate with credentials from args or envvars
         # Higher priority to honor users intent when credentials present
         if self.client_id and self.secret_key:
+            print("authenticate #1")
             return self._authenticate_with_credentials()
 
         # 2. Authenticate with refresh token if available
@@ -97,6 +143,7 @@ class TestflingerCliAuth:
         token_expired: InvalidTokenError | None = None
         if refresh_token:
             try:
+                print("authenticate #2")
                 return self._authenticate_with_refresh_token(refresh_token)
             except InvalidTokenError as exc:
                 token_expired = exc
@@ -105,6 +152,7 @@ class TestflingerCliAuth:
         # This should fail gracefully if OIDC is not enabled on the server
         access_token = self._authenticate_with_oidc()
         if not access_token and token_expired:
+            print("authenticate #3")
             # If neither authentication method worked and refresh token invalid
             # raise the InvalidTokenError to force reauthentication
             raise token_expired
@@ -133,7 +181,8 @@ class TestflingerCliAuth:
             return None
         except requests.exceptions.Timeout as exc:
             raise NetworkError(
-                "Connection timed out while authenticating with credentials."
+                "Connection to testflinger server timed out while "
+                "authenticating with basic client_id+secret_key credentials."
             ) from exc
 
         # Store refresh token for persistent login
@@ -192,8 +241,10 @@ class TestflingerCliAuth:
         """
         config_file = configparser.ConfigParser()
         try:
+            print("get_stored_refresh_token")
             config_file.read(self.auth_config)
         except FileNotFoundError:
+            print(f"no stored refresh token in {self.auth_config}")
             return None
 
         # Set client_id from config file to keep token owner
@@ -205,17 +256,32 @@ class TestflingerCliAuth:
 
         :param refresh_token: refresh token to store in SNAP_USER_DATA
         """
-        config_file = configparser.ConfigParser()
-        config_file["AUTH"] = {
-            "client_id": self.client_id,
-            "refresh_token": refresh_token,
-        }
-        try:
-            with self.auth_config.open("w") as file:
-                config_file.write(file)
-        except (OSError, PermissionError):
-            # Ignore write errors as this might run as non snap
-            pass
+        if self.client_id and refresh_token:
+            config_file = configparser.ConfigParser()
+            config_file["AUTH"] = {
+                "client_id": self.client_id,
+                "refresh_token": refresh_token,
+            }
+            try:
+                orig = self.auth_config
+                print("store_refresh_token to ...")
+                print(f"{self.auth_config}")
+                with self.auth_config.open("w") as file:
+                    config_file.write(file)
+
+                # Note: if client_id wasn't part of that file path, we should
+                # write another client-id-pathed refresh file
+                del self.auth_config
+                if self.auth_config != orig:
+                    print("Also store_refresh_token based on client_id too!")
+                    print(f"{self.auth_config}")
+                    with self.auth_config.open("w") as file:
+                        config_file.write(file)
+            except (OSError, PermissionError):
+                # Ignore write errors as this might run as non snap
+                print ("why are we ignoring write errors?")
+                pass
+
 
     def clear_refresh_token(self):
         """Cleanup refresh_token if already expired or revoked."""
@@ -307,7 +373,8 @@ class TestflingerCliAuth:
 
         print(
             f"Please visit {verification_uri} and enter code "
-            f"{user_code} to login."
+            f"{user_code} to login.",
+            file=sys.stderr
         )
 
         # Attempt to launch the browser for the user to login

--- a/cli/testflinger_cli/auth.py
+++ b/cli/testflinger_cli/auth.py
@@ -25,7 +25,6 @@ import urllib.parse
 import webbrowser
 from functools import cached_property, wraps
 from http import HTTPStatus
-from pathlib import Path
 from typing import Optional
 
 import jwt
@@ -58,47 +57,16 @@ class TestflingerCliAuth:
         self.client_id = client_id
         self.secret_key = secret_key
 
-        # Refresh token relevant configuration
-        self.config_home = xdg_config_home() / "testflinger-cli"
-        self.config_home.mkdir(parents=True, exist_ok=True)
-
-    @cached_property
-    def auth_config(self):
-        """Return the path to the auth config file that is in use."""
-        print("Establishing cached value for auth_config based on:")
-        print(f"server_url: {self.server_url}")
-        print(f"client_id: {self.client_id}")
-
-        # Also support multiple server combinations, staging and production,
+        # Refresh token relevant configuration:
+        # Support multiple server connections, staging and production,
         # as each will have different refresh tokens
-        auth_config = self.config_home / self._safe_fs_name(self.server_url)
-
-        # When the client is known, we must only use refresh tokens that are
-        # also for that client_id.
-        if self.client_id:
-            auth_config /= self._safe_fs_name(self.client_id)
-        # When the client_id isn't known, we will try to use the last refresh
-        # token for that server. In turn that will resolve the client_id.
-
-        # This means that we can only differentiate which token to use based
-        # on the server, when no client_id is known. This means that we must
-        # save the config file for the server (always) and for the specific
-        # client_id (also) when available.
-
-        auth_config /= ("auth.conf")
-        print(f"The resulting auth_config:\n{auth_config}", file=sys.stderr)
-        auth_config.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with auth_config.open("r") as f:
-                for line in f:
-                    print(line)
-            config_file = configparser.ConfigParser()
-            config_file.read(auth_config)
-            print(vars(config_file))
-        except:
-            pass
-
-        return auth_config
+        # Don't use the schema, split on // and keep the right hand side
+        server = self._safe_fs_name(self.server_url.split("//")[-1])
+        self.auth_config = (
+            xdg_config_home() / "testflinger-cli" / server / "auth.conf"
+        )
+        # Ensure that the directory exists.
+        self.auth_config.parent.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
     def _safe_fs_name(name_in: str) -> str:
@@ -134,7 +102,6 @@ class TestflingerCliAuth:
         # 1. Attempt to authenticate with credentials from args or envvars
         # Higher priority to honor users intent when credentials present
         if self.client_id and self.secret_key:
-            print("authenticate #1")
             return self._authenticate_with_credentials()
 
         # 2. Authenticate with refresh token if available
@@ -143,7 +110,6 @@ class TestflingerCliAuth:
         token_expired: InvalidTokenError | None = None
         if refresh_token:
             try:
-                print("authenticate #2")
                 return self._authenticate_with_refresh_token(refresh_token)
             except InvalidTokenError as exc:
                 token_expired = exc
@@ -152,7 +118,6 @@ class TestflingerCliAuth:
         # This should fail gracefully if OIDC is not enabled on the server
         access_token = self._authenticate_with_oidc()
         if not access_token and token_expired:
-            print("authenticate #3")
             # If neither authentication method worked and refresh token invalid
             # raise the InvalidTokenError to force reauthentication
             raise token_expired
@@ -207,6 +172,9 @@ class TestflingerCliAuth:
             )
             response.raise_for_status()
             response_data = response.json()
+
+            # Note: Refresh does not beget refresh, only clean auth gives a
+            # refresh token
             return response_data["access_token"]
         except requests.exceptions.HTTPError as exc:
             if exc.response.status_code == HTTPStatus.BAD_REQUEST:
@@ -241,10 +209,8 @@ class TestflingerCliAuth:
         """
         config_file = configparser.ConfigParser()
         try:
-            print("get_stored_refresh_token")
             config_file.read(self.auth_config)
         except FileNotFoundError:
-            print(f"no stored refresh token in {self.auth_config}")
             return None
 
         # Set client_id from config file to keep token owner
@@ -263,25 +229,11 @@ class TestflingerCliAuth:
                 "refresh_token": refresh_token,
             }
             try:
-                orig = self.auth_config
-                print("store_refresh_token to ...")
-                print(f"{self.auth_config}")
                 with self.auth_config.open("w") as file:
                     config_file.write(file)
-
-                # Note: if client_id wasn't part of that file path, we should
-                # write another client-id-pathed refresh file
-                del self.auth_config
-                if self.auth_config != orig:
-                    print("Also store_refresh_token based on client_id too!")
-                    print(f"{self.auth_config}")
-                    with self.auth_config.open("w") as file:
-                        config_file.write(file)
             except (OSError, PermissionError):
                 # Ignore write errors as this might run as non snap
-                print ("why are we ignoring write errors?")
                 pass
-
 
     def clear_refresh_token(self):
         """Cleanup refresh_token if already expired or revoked."""
@@ -370,20 +322,31 @@ class TestflingerCliAuth:
         interval = init_data.get("interval", 5)
         expires_in = init_data.get("expires_in", 300)
         request_id = init_data["request_id"]
+        poll_url = self.get_url(f"/oidc/auth-poll/{request_id}")
 
         print(
             f"Please visit {verification_uri} and enter code "
             f"{user_code} to login.",
-            file=sys.stderr
+            file=sys.stderr,
         )
 
         # Attempt to launch the browser for the user to login
         webbrowser.open(verification_uri)
 
         code_expiration = time.monotonic() + expires_in
+        current_refresh_token = self.get_stored_refresh_token()
         while time.monotonic() < code_expiration:
-            time.sleep(interval)
-            poll_url = self.get_url(f"/oidc/auth-poll/{request_id}")
+            # multiple client processes can benefit from the same new refresh
+            # token:
+            next_check = time.monotonic() + interval
+            while time.monotonic() < next_check:
+                refresh_token = self.get_stored_refresh_token()
+                if refresh_token and refresh_token != current_refresh_token:
+                    # if we managed to find a newly-acquired refresh token on
+                    # disk we can exit this loop early and use the refresh
+                    # token instead
+                    return self._authenticate_with_refresh_token(refresh_token)
+                time.sleep(0.1)
             try:
                 response = requests.post(
                     poll_url, data={}, timeout=DEFAULT_AUTH_TIMEOUT

--- a/cli/testflinger_cli/auth.py
+++ b/cli/testflinger_cli/auth.py
@@ -57,16 +57,14 @@ class TestflingerCliAuth:
         self.client_id = client_id
         self.secret_key = secret_key
 
-        # Refresh token relevant configuration:
-        # Support multiple server connections, staging and production,
+        # Refresh token relevant configuration, supports multiple
+        # server connections, e.g.: staging and production,
         # as each will have different refresh tokens
-        # Don't use the schema, split on // and keep the right hand side
-        server = self._safe_fs_name(self.server_url.split("//")[-1])
+        parsed_url = urllib.parse.urlsplit(self.server_url)
+        server = self._safe_fs_name(parsed_url.hostname)
         self.auth_config = (
             xdg_config_home() / "testflinger-cli" / server / "auth.conf"
         )
-        # Ensure that the directory exists.
-        self.auth_config.parent.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
     def _safe_fs_name(name_in: str) -> str:
@@ -228,6 +226,8 @@ class TestflingerCliAuth:
                 "client_id": self.client_id,
                 "refresh_token": refresh_token,
             }
+            # Ensure that the directory exists.
+            self.auth_config.parent.mkdir(parents=True, exist_ok=True)
             try:
                 with self.auth_config.open("w") as file:
                     config_file.write(file)
@@ -295,6 +295,19 @@ class TestflingerCliAuth:
         # Default role for legacy client_ids is contributor
         return permissions.get("role", ServerRoles.CONTRIBUTOR)
 
+    def monitor_for_refresh_token(self, current_refresh_token, interval):
+        # multiple client processes can benefit from the same new refresh
+        # token:
+        next_check = time.monotonic() + interval
+        while time.monotonic() < next_check:
+            refresh_token = self.get_stored_refresh_token()
+            if refresh_token and refresh_token != current_refresh_token:
+                # if we managed to find a newly-acquired refresh token on
+                # disk we can exit this loop early and use the refresh
+                # token instead
+                return self._authenticate_with_refresh_token(refresh_token)
+            time.sleep(0.1)
+
     def _authenticate_with_oidc(self) -> str | None:
         """Authenticate using OIDC device flow."""
         auth_init_url = self.get_url("/oidc/auth-init")
@@ -334,19 +347,10 @@ class TestflingerCliAuth:
         webbrowser.open(verification_uri)
 
         code_expiration = time.monotonic() + expires_in
-        current_refresh_token = self.get_stored_refresh_token()
+        current_token = self.get_stored_refresh_token()
         while time.monotonic() < code_expiration:
-            # multiple client processes can benefit from the same new refresh
-            # token:
-            next_check = time.monotonic() + interval
-            while time.monotonic() < next_check:
-                refresh_token = self.get_stored_refresh_token()
-                if refresh_token and refresh_token != current_refresh_token:
-                    # if we managed to find a newly-acquired refresh token on
-                    # disk we can exit this loop early and use the refresh
-                    # token instead
-                    return self._authenticate_with_refresh_token(refresh_token)
-                time.sleep(0.1)
+            if result := monitor_for_refresh_token(current_token, interval):
+                return result
             try:
                 response = requests.post(
                     poll_url, data={}, timeout=DEFAULT_AUTH_TIMEOUT

--- a/cli/tests/test_cli_auth.py
+++ b/cli/tests/test_cli_auth.py
@@ -20,7 +20,7 @@ import json
 import sys
 import uuid
 from http import HTTPStatus
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -253,7 +253,7 @@ def test_multiple_login_clear_refresh_token(auth_fixture):
     assert initial_token != reauthenticated_token
 
 
-def test_refresh_token_expired(tmp_path, requests_mock, monkeypatch):
+def test_refresh_token_expired(tmp_path, requests_mock):
     """Test scenario where refresh_token is no longer valid."""
     job_data = {
         "job_queue": "fake",
@@ -262,13 +262,16 @@ def test_refresh_token_expired(tmp_path, requests_mock, monkeypatch):
     job_file = tmp_path / "test.json"
     job_file.write_text(json.dumps(job_data))
 
-    # Create mock config file with refresh token
+    # Create mock config file with refresh token at the path the CLI expects
+    # (xdg_config_home is mocked to tmp_path by the mock_xdg_config fixture)
+    auth = TestflingerCliAuth(URL)
+    auth_config_path = auth.auth_config
+    auth_config_path.parent.mkdir(parents=True, exist_ok=True)
     config_file = configparser.ConfigParser()
     config_file["AUTH"] = {
         "client_id": "my_client_id",
         "refresh_token": "fake_refresh_token",
     }
-    auth_config_path = tmp_path / "testflinger-cli-auth.conf"
     with auth_config_path.open("w") as file:
         config_file.write(file)
 
@@ -284,11 +287,6 @@ def test_refresh_token_expired(tmp_path, requests_mock, monkeypatch):
     requests_mock.post(
         f"{URL}/oidc/auth-init", status_code=HTTPStatus.NOT_FOUND
     )
-    # Mock agents endpoint for available agents
-    requests_mock.get(
-        f"{URL}/v1/queues/fake/agents",
-        json=[{"name": "fake_agent", "state": "waiting"}],
-    )
 
     with pytest.raises(SystemExit) as exc:
         testflinger_cli.cli()
@@ -298,6 +296,7 @@ def test_refresh_token_expired(tmp_path, requests_mock, monkeypatch):
     history = requests_mock.request_history
     assert len(history) == 2
     assert history[0].path == "/v1/oauth2/refresh"
+    assert history[1].path == "/oidc/auth-init"
 
 
 def test_cli_login_defaults_credentials(auth_fixture, capsys):
@@ -392,10 +391,13 @@ def test_login_oidc_poll_terminal_errors(
     assert expected_message in str(exc.value)
 
 
-@patch("testflinger_cli.auth.time.sleep")
+@patch(
+    "testflinger_cli.auth.TestflingerCliAuth.monitor_for_refresh_token",
+    return_value=None,
+)
 @patch("testflinger_cli.auth.webbrowser.open")
 def test_login_oidc_poll_pending_then_success(
-    mock_open, mock_sleep, oidc_auth_fixture, capsys
+    mock_open, mock_monitor, oidc_auth_fixture, capsys
 ):
     """Test OIDC poll retries on authorization_pending until auth succeeds."""
     oidc_auth_fixture(
@@ -412,15 +414,20 @@ def test_login_oidc_poll_pending_then_success(
     tfcli = testflinger_cli.TestflingerCli()
     tfcli.login()
 
-    # sleep called once before 400, once before 200
-    assert mock_sleep.call_args_list == [call(5), call(5)]
+    # monitor_for_refresh_token called once before 400, once before 200
+    assert mock_monitor.call_count == 2
+    # both calls use the initial interval of 5
+    assert all(c.args[1] == 5 for c in mock_monitor.call_args_list)
     assert tfcli.auth.get_stored_refresh_token() is not None
 
 
-@patch("testflinger_cli.auth.time.sleep")
+@patch(
+    "testflinger_cli.auth.TestflingerCliAuth.monitor_for_refresh_token",
+    return_value=None,
+)
 @patch("testflinger_cli.auth.webbrowser.open")
 def test_login_oidc_poll_slow_down(
-    mock_open, mock_sleep, oidc_auth_fixture, capsys
+    mock_open, mock_monitor, oidc_auth_fixture, capsys
 ):
     """Test OIDC polling increases interval using Retry-After header."""
     oidc_auth_fixture(
@@ -439,7 +446,8 @@ def test_login_oidc_poll_slow_down(
     tfcli.login()
 
     # interval starts at 5, increases by Retry-After (5) after slow_down
-    assert mock_sleep.call_args_list == [call(5), call(10)]
+    intervals = [c.args[1] for c in mock_monitor.call_args_list]
+    assert intervals == [5, 10]
     assert tfcli.auth.get_stored_refresh_token() is not None
 
 
@@ -488,3 +496,47 @@ def test_oidc_poll_timeout_raises_network_error(
     auth = TestflingerCliAuth(URL)
     with pytest.raises(NetworkError):
         auth._authenticate_with_oidc()
+
+
+def test_monitor_for_refresh_token_returns_none_when_no_new_token(
+    requests_mock,
+):
+    """monitor_for_refresh_token returns None when no new token appears."""
+    auth = TestflingerCliAuth(URL)
+    # No token stored on disk, current token is None
+    with patch("testflinger_cli.auth.time.sleep"):
+        result = auth.monitor_for_refresh_token(None, interval=0)
+    assert result is None
+
+
+def test_monitor_for_refresh_token_returns_none_when_token_unchanged(
+    requests_mock,
+):
+    """monitor_for_refresh_token returns None when stored token unchanged."""
+    auth = TestflingerCliAuth(URL)
+    # Store a token on disk
+    auth.client_id = "my_client_id"
+    auth.store_refresh_token("existing_token")
+
+    with patch("testflinger_cli.auth.time.sleep"):
+        result = auth.monitor_for_refresh_token("existing_token", interval=0)
+    assert result is None
+
+
+def test_monitor_for_refresh_token_returns_access_token_on_new_token(
+    requests_mock,
+):
+    """monitor_for_refresh_token returns access token on new token."""
+    fake_access_token = "new_access_token"
+    requests_mock.post(
+        f"{URL}/v1/oauth2/refresh",
+        json={"access_token": fake_access_token},
+    )
+
+    auth = TestflingerCliAuth(URL)
+    auth.client_id = "my_client_id"
+    auth.store_refresh_token("new_refresh_token")
+
+    with patch("testflinger_cli.auth.time.sleep"):
+        result = auth.monitor_for_refresh_token("old_token", interval=1)
+    assert result == fake_access_token


### PR DESCRIPTION
## Description

CLI improvements to store refresh tokens by server rather than 'fighting' to connect and store between two different servers (e.g. while testing)

Additionally when waiting for the OIDC flow, during the downtime between network calls the locally stored refresh token is monitored for changes and if changes are noticed (because another testflinger process on the same machine and same server has already received and stored said refresh token) it will be used instead.

## Resolved issues

Resolves issues with having testflinger communicate with more than one server.

## Documentation

N/A, bugfix

## Web service API changes

No changes to server or API

## Tests

Tested by hand.