### PR TITLE
Control host SSE logs improvements

### DIFF
--- a/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
@@ -242,8 +242,8 @@ class ControlHostConnector(ABC, DefaultDevice):
                 )
             break
 
-    @staticmethod
     def _stream_sse_logs(
+        self,
         response: requests.Response,
     ) -> Tuple[int, bool, Optional[str]]:
         """Parse and log Server-Sent Events from a streaming response.
@@ -267,30 +267,11 @@ class ControlHostConnector(ABC, DefaultDevice):
 
         for line in response.iter_lines(decode_unicode=True):
             if line == "":
-                if data_lines:
-                    payload = "\n".join(data_lines)
-                    try:
-                        entry = json.loads(payload)
-                    except json.JSONDecodeError:
-                        logger.warning("Malformed SSE data: %s", payload)
-                    else:
-                        level_name = entry.get("level", "").upper()
-                        log_level = getattr(logging, level_name, None)
-                        if log_level is None:
-                            logger.warning(
-                                "Unknown log level '%s', defaulting to INFO",
-                                entry.get("level", ""),
-                            )
-                            log_level = logging.INFO
-                        logger.log(
-                            log_level,
-                            "[control-host] %s",
-                            entry.get("message", payload),
-                        )
-                        emitted += 1
-                        if event_has_id:
-                            last_id = event_id
-                            cursor_updated = True
+                if data_lines and self._log_sse_payload("\n".join(data_lines)):
+                    emitted += 1
+                    if event_has_id:
+                        last_id = event_id
+                        cursor_updated = True
 
                 event_id = None
                 event_has_id = False
@@ -313,6 +294,28 @@ class ControlHostConnector(ABC, DefaultDevice):
                 data_lines.append(value)
 
         return emitted, cursor_updated, last_id
+
+    @staticmethod
+    def _log_sse_payload(payload: str) -> bool:
+        """Log one JSON SSE payload and report whether it was handled."""
+        try:
+            entry = json.loads(payload)
+        except json.JSONDecodeError:
+            logger.warning("Malformed SSE data: %s", payload)
+            return False
+
+        level_name = entry.get("level", "").upper()
+        log_level = getattr(logging, level_name, None)
+        if log_level is None:
+            logger.warning(
+                "Unknown log level '%s', defaulting to INFO",
+                entry.get("level", ""),
+            )
+            log_level = logging.INFO
+        logger.log(
+            log_level, "[control-host] %s", entry.get("message", payload)
+        )
+        return True
 
     def _copy_ssh_id(self):
         """Copy the ssh id to the device."""

--- a/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
@@ -196,13 +196,7 @@ class ControlHostConnector(ABC, DefaultDevice):
         job_id = job["job_id"]
 
         timeout = (self.CONNECTION_TIMEOUT, self.READ_TIMEOUT)
-        # Backoff state for SSE reconnects. Reset to the base delay after a
-        # stream that made progress (emitted >= 1 log entry); double (up
-        # to the cap) on consecutive reconnects that produced no new lines.
         reconnect_delay = self.SSE_RECONNECT_DELAY
-        # Resume cursor: the last SSE event id seen, sent back as the
-        # Last-Event-ID header on reconnect so a resume-aware server can
-        # skip entries the client has already received.
         last_id: Optional[str] = None
         while True:
             headers = (
@@ -217,7 +211,6 @@ class ControlHostConnector(ABC, DefaultDevice):
             with sse:
                 emitted, last_id = self._stream_sse_logs(sse)
 
-            # Check job status after the SSE stream ends
             status = self._api_get(f"/api/v1/provision/{job_id}").json()
             if status["status"] == "running":
                 logger.warning(
@@ -228,11 +221,8 @@ class ControlHostConnector(ABC, DefaultDevice):
                 )
                 time.sleep(reconnect_delay)
                 if emitted:
-                    # The previous stream made progress; reconnect promptly.
                     reconnect_delay = self.SSE_RECONNECT_DELAY
                 else:
-                    # Nothing came through; back off to avoid hammering the
-                    # control host if its stream keeps dropping.
                     reconnect_delay = min(
                         reconnect_delay * 2, self.SSE_RECONNECT_MAX_DELAY
                     )
@@ -260,12 +250,10 @@ class ControlHostConnector(ABC, DefaultDevice):
         (e.g. "event:", "retry:") are non-standard for this endpoint and
         logged as warnings.
 
-        :returns: A ``(emitted, last_id)`` tuple where *emitted* is the
-            number of log entries successfully emitted and *last_id* is the
-            most recently seen ``id:`` value (or None when the stream
-            carried no ids). The caller sends *last_id* back as the
-            Last-Event-ID header on reconnect so a resume-aware server can
-            skip entries the client has already received.
+        :returns: ``(emitted, last_id)`` — count of log entries emitted
+            and the most recently seen ``id:`` value (None if the stream
+            carried none). *last_id* is sent back as the Last-Event-ID
+            header on reconnect.
         """
         sse_data_prefix = "data: "
         sse_id_prefix = "id: "

--- a/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
@@ -200,14 +200,22 @@ class ControlHostConnector(ABC, DefaultDevice):
         # stream that made progress (emitted >= 1 log entry); double (up
         # to the cap) on consecutive reconnects that produced no new lines.
         reconnect_delay = self.SSE_RECONNECT_DELAY
+        # Resume cursor: the last SSE event id seen, sent back as the
+        # Last-Event-ID header on reconnect so a resume-aware server can
+        # skip entries the client has already received.
+        last_id: Optional[str] = None
         while True:
+            headers = (
+                {"Last-Event-ID": last_id} if last_id is not None else None
+            )
             sse = self._api_get(
                 f"/api/v1/provision/{job_id}/logs",
                 stream=True,
                 timeout=timeout,
+                headers=headers,
             )
             with sse:
-                emitted = self._stream_sse_logs(sse)
+                emitted, last_id = self._stream_sse_logs(sse)
 
             # Check job status after the SSE stream ends
             status = self._api_get(f"/api/v1/provision/{job_id}").json()
@@ -239,23 +247,35 @@ class ControlHostConnector(ABC, DefaultDevice):
             break
 
     @staticmethod
-    def _stream_sse_logs(response: requests.Response) -> int:
+    def _stream_sse_logs(
+        response: requests.Response,
+    ) -> Tuple[int, Optional[str]]:
         """Parse and log Server-Sent Events from a streaming response.
 
-        The SSE protocol sends newline-delimited lines in the format:
-            data: {"level": "INFO", "message": "..."}
-        Empty lines act as event separators and are skipped.
-        Lines not starting with "data: " (e.g. "event:", "retry:")
-        are non-standard for this endpoint and logged as warnings.
+        Recognised SSE fields:
+            data: {"level": "INFO", "message": "..."}  -- log entry payload
+            id: <event-id>                              -- resume cursor
 
-        :returns: Number of log entries successfully emitted. The caller
-            uses this to track whether the stream made progress and to
-            drive reconnect backoff.
+        Empty lines act as event separators and are skipped. Other fields
+        (e.g. "event:", "retry:") are non-standard for this endpoint and
+        logged as warnings.
+
+        :returns: A ``(emitted, last_id)`` tuple where *emitted* is the
+            number of log entries successfully emitted and *last_id* is the
+            most recently seen ``id:`` value (or None when the stream
+            carried no ids). The caller sends *last_id* back as the
+            Last-Event-ID header on reconnect so a resume-aware server can
+            skip entries the client has already received.
         """
         sse_data_prefix = "data: "
+        sse_id_prefix = "id: "
         emitted = 0
+        last_id: Optional[str] = None
         for line in response.iter_lines(decode_unicode=True):
             if not line:
+                continue
+            if line.startswith(sse_id_prefix):
+                last_id = line[len(sse_id_prefix) :].strip()
                 continue
             if not line.startswith(sse_data_prefix):
                 logger.warning("Unexpected SSE line: %s", line)
@@ -277,7 +297,7 @@ class ControlHostConnector(ABC, DefaultDevice):
                 log_level, "[control-host] %s", entry.get("message", line)
             )
             emitted += 1
-        return emitted
+        return emitted, last_id
 
     def _copy_ssh_id(self):
         """Copy the ssh id to the device."""

--- a/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
@@ -22,6 +22,7 @@ the configuration and preparing the API arguments.
 
 import json
 import logging
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
@@ -48,6 +49,13 @@ class ControlHostConnector(ABC, DefaultDevice):
     CONNECTION_TIMEOUT = 30
     READ_TIMEOUT = 60 * 90
     REST_PORT = 8000
+    # Backoff between SSE stream reconnects. The base delay is used when the
+    # previous stream made progress (emitted >= 1 log entry); the delay
+    # doubles (up to the cap) on consecutive reconnects that produced no new
+    # log lines, to avoid hammering the control host when its stream keeps
+    # dropping.
+    SSE_RECONNECT_DELAY = 2
+    SSE_RECONNECT_MAX_DELAY = 30
 
     def _api_post(self, endpoint: str, **kwargs) -> requests.Response:
         """Send a POST request to the control host REST API.
@@ -188,6 +196,10 @@ class ControlHostConnector(ABC, DefaultDevice):
         job_id = job["job_id"]
 
         timeout = (self.CONNECTION_TIMEOUT, self.READ_TIMEOUT)
+        # Backoff state for SSE reconnects. Reset to the base delay after a
+        # stream that made progress (emitted >= 1 log entry); double (up
+        # to the cap) on consecutive reconnects that produced no new lines.
+        reconnect_delay = self.SSE_RECONNECT_DELAY
         while True:
             sse = self._api_get(
                 f"/api/v1/provision/{job_id}/logs",
@@ -195,16 +207,27 @@ class ControlHostConnector(ABC, DefaultDevice):
                 timeout=timeout,
             )
             with sse:
-                self._stream_sse_logs(sse)
+                emitted = self._stream_sse_logs(sse)
 
             # Check job status after the SSE stream ends
             status = self._api_get(f"/api/v1/provision/{job_id}").json()
             if status["status"] == "running":
                 logger.warning(
                     "SSE stream disconnected but job %s is still running,"
-                    " reconnecting...",
+                    " reconnecting in %ds...",
                     job_id,
+                    reconnect_delay,
                 )
+                time.sleep(reconnect_delay)
+                if emitted:
+                    # The previous stream made progress; reconnect promptly.
+                    reconnect_delay = self.SSE_RECONNECT_DELAY
+                else:
+                    # Nothing came through; back off to avoid hammering the
+                    # control host if its stream keeps dropping.
+                    reconnect_delay = min(
+                        reconnect_delay * 2, self.SSE_RECONNECT_MAX_DELAY
+                    )
                 continue
             if status["status"] != "completed":
                 raise ProvisioningError(
@@ -216,7 +239,7 @@ class ControlHostConnector(ABC, DefaultDevice):
             break
 
     @staticmethod
-    def _stream_sse_logs(response: requests.Response) -> None:
+    def _stream_sse_logs(response: requests.Response) -> int:
         """Parse and log Server-Sent Events from a streaming response.
 
         The SSE protocol sends newline-delimited lines in the format:
@@ -224,8 +247,13 @@ class ControlHostConnector(ABC, DefaultDevice):
         Empty lines act as event separators and are skipped.
         Lines not starting with "data: " (e.g. "event:", "retry:")
         are non-standard for this endpoint and logged as warnings.
+
+        :returns: Number of log entries successfully emitted. The caller
+            uses this to track whether the stream made progress and to
+            drive reconnect backoff.
         """
         sse_data_prefix = "data: "
+        emitted = 0
         for line in response.iter_lines(decode_unicode=True):
             if not line:
                 continue
@@ -248,6 +276,8 @@ class ControlHostConnector(ABC, DefaultDevice):
             logger.log(
                 log_level, "[control-host] %s", entry.get("message", line)
             )
+            emitted += 1
+        return emitted
 
     def _copy_ssh_id(self):
         """Copy the ssh id to the device."""

--- a/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/control_host/__init__.py
@@ -209,7 +209,13 @@ class ControlHostConnector(ABC, DefaultDevice):
                 headers=headers,
             )
             with sse:
-                emitted, last_id = self._stream_sse_logs(sse)
+                (
+                    emitted,
+                    cursor_updated,
+                    stream_last_id,
+                ) = self._stream_sse_logs(sse)
+            if cursor_updated:
+                last_id = stream_last_id
 
             status = self._api_get(f"/api/v1/provision/{job_id}").json()
             if status["status"] == "running":
@@ -239,53 +245,74 @@ class ControlHostConnector(ABC, DefaultDevice):
     @staticmethod
     def _stream_sse_logs(
         response: requests.Response,
-    ) -> Tuple[int, Optional[str]]:
+    ) -> Tuple[int, bool, Optional[str]]:
         """Parse and log Server-Sent Events from a streaming response.
 
-        Recognised SSE fields:
-            data: {"level": "INFO", "message": "..."}  -- log entry payload
-            id: <event-id>                              -- resume cursor
+        An SSE event ends with a blank line and may contain an ``id`` field
+        and multiple ``data`` fields. The resume cursor advances only after
+        its event's log payload has been handled successfully, so malformed
+        data cannot cause a log entry to be skipped after reconnecting.
 
-        Empty lines act as event separators and are skipped. Other fields
-        (e.g. "event:", "retry:") are non-standard for this endpoint and
-        logged as warnings.
-
-        :returns: ``(emitted, last_id)`` — count of log entries emitted
-            and the most recently seen ``id:`` value (None if the stream
-            carried none). *last_id* is sent back as the Last-Event-ID
-            header on reconnect.
+        :returns: ``(emitted, cursor_updated, last_id)`` — the number of log
+            entries emitted, whether an event updated the resume cursor, and
+            that cursor. A ``None`` cursor clears Last-Event-ID; an unchanged
+            cursor means a reconnect must retain its previous value.
         """
-        sse_data_prefix = "data: "
-        sse_id_prefix = "id: "
         emitted = 0
+        cursor_updated = False
         last_id: Optional[str] = None
+        event_id: Optional[str] = None
+        event_has_id = False
+        data_lines: list[str] = []
+
         for line in response.iter_lines(decode_unicode=True):
-            if not line:
+            if line == "":
+                if data_lines:
+                    payload = "\n".join(data_lines)
+                    try:
+                        entry = json.loads(payload)
+                    except json.JSONDecodeError:
+                        logger.warning("Malformed SSE data: %s", payload)
+                    else:
+                        level_name = entry.get("level", "").upper()
+                        log_level = getattr(logging, level_name, None)
+                        if log_level is None:
+                            logger.warning(
+                                "Unknown log level '%s', defaulting to INFO",
+                                entry.get("level", ""),
+                            )
+                            log_level = logging.INFO
+                        logger.log(
+                            log_level,
+                            "[control-host] %s",
+                            entry.get("message", payload),
+                        )
+                        emitted += 1
+                        if event_has_id:
+                            last_id = event_id
+                            cursor_updated = True
+
+                event_id = None
+                event_has_id = False
+                data_lines.clear()
                 continue
-            if line.startswith(sse_id_prefix):
-                last_id = line[len(sse_id_prefix) :].strip()
+
+            if line.startswith(":"):
                 continue
-            if not line.startswith(sse_data_prefix):
-                logger.warning("Unexpected SSE line: %s", line)
+
+            field, separator, value = line.partition(":")
+            if not separator:
                 continue
-            try:
-                entry = json.loads(line[len(sse_data_prefix) :])
-            except json.JSONDecodeError:
-                logger.warning("Malformed SSE data: %s", line)
-                continue
-            level_name = entry.get("level", "").upper()
-            log_level = getattr(logging, level_name, None)
-            if log_level is None:
-                logger.warning(
-                    "Unknown log level '%s', defaulting to INFO",
-                    entry.get("level", ""),
-                )
-                log_level = logging.INFO
-            logger.log(
-                log_level, "[control-host] %s", entry.get("message", line)
-            )
-            emitted += 1
-        return emitted, last_id
+            if value.startswith(" "):
+                value = value[1:]
+
+            if field == "id":
+                event_id = value or None
+                event_has_id = True
+            elif field == "data":
+                data_lines.append(value)
+
+        return emitted, cursor_updated, last_id
 
     def _copy_ssh_id(self):
         """Copy the ssh id to the device."""

--- a/device-connectors/src/testflinger_device_connectors/devices/control_host/tests/test_control_host.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/control_host/tests/test_control_host.py
@@ -499,6 +499,9 @@ class TestControlHostConnectorRun:
         """Test that _run reconnects to SSE stream if the job is still
         running after a disconnection.
         """
+        sleep = mocker.patch(
+            "testflinger_device_connectors.devices.control_host.time.sleep"
+        )
         mock_get = mocker.patch("requests.get")
 
         # First SSE stream disconnects with partial logs
@@ -532,6 +535,153 @@ class TestControlHostConnectorRun:
         assert "step 1" in caplog.text
         assert "still running" in caplog.text
         assert "step 2" in caplog.text
+        # Both streams emitted a log line, so progress was made and the
+        # reconnect delay stays at the base value.
+        sleep.assert_called_once_with(connector.SSE_RECONNECT_DELAY)
+
+    def test_run_exponential_backoff_on_no_progress(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that reconnect delay doubles (up to the cap) when the SSE
+        stream produces no new log lines on each reconnect.
+        """
+        sleep = mocker.patch(
+            "testflinger_device_connectors.devices.control_host.time.sleep"
+        )
+        mock_get = mocker.patch("requests.get")
+
+        # Three empty reconnects, then a final one with a log line.
+        empty_sse = self._make_sse([])
+        status_running = Mock()
+        status_running.raise_for_status = Mock()
+        status_running.json.return_value = {"status": "running"}
+
+        sse_final = self._make_sse(
+            ['data: {"level": "INFO", "message": "done"}']
+        )
+        status_done = Mock()
+        status_done.raise_for_status = Mock()
+        status_done.json.return_value = {"status": "completed"}
+
+        mock_get.side_effect = [
+            empty_sse,
+            status_running,
+            empty_sse,
+            status_running,
+            empty_sse,
+            status_running,
+            sse_final,
+            status_done,
+        ]
+
+        connector._run()
+
+        # Three backoffs: 2 (initial), 4 (doubled), 8 (doubled again)
+        assert sleep.call_count == 3
+        sleep.assert_has_calls(
+            [
+                mocker.call(connector.SSE_RECONNECT_DELAY),
+                mocker.call(connector.SSE_RECONNECT_DELAY * 2),
+                mocker.call(connector.SSE_RECONNECT_DELAY * 4),
+            ]
+        )
+
+    def test_run_resets_backoff_after_progress(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that reconnect delay resets to the base value after a
+        stream that made progress (emitted at least one log line).
+        """
+        sleep = mocker.patch(
+            "testflinger_device_connectors.devices.control_host.time.sleep"
+        )
+        mock_get = mocker.patch("requests.get")
+
+        # Reconnect 1: empty -> delay doubles
+        empty_sse_1 = self._make_sse([])
+        # Reconnect 2: emits a line -> delay resets
+        progress_sse = self._make_sse(
+            ['data: {"level": "INFO", "message": "progress"}']
+        )
+        # Reconnect 3: empty again -> delay doubles from base
+        empty_sse_2 = self._make_sse([])
+        # Reconnect 4: completes
+        sse_final = self._make_sse(
+            ['data: {"level": "INFO", "message": "done"}']
+        )
+
+        status_running = Mock()
+        status_running.raise_for_status = Mock()
+        status_running.json.return_value = {"status": "running"}
+        status_done = Mock()
+        status_done.raise_for_status = Mock()
+        status_done.json.return_value = {"status": "completed"}
+
+        mock_get.side_effect = [
+            empty_sse_1,
+            status_running,
+            progress_sse,
+            status_running,
+            empty_sse_2,
+            status_running,
+            sse_final,
+            status_done,
+        ]
+
+        connector._run()
+
+        # Sleeps: 2 (initial), 4 (doubled), 2 (reset after progress)
+        assert sleep.call_count == 3
+        sleep.assert_has_calls(
+            [
+                mocker.call(connector.SSE_RECONNECT_DELAY),
+                mocker.call(connector.SSE_RECONNECT_DELAY * 2),
+                mocker.call(connector.SSE_RECONNECT_DELAY),
+            ]
+        )
+
+    def test_run_reconnect_backoff_is_capped(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that reconnect delay does not exceed the max."""
+        sleep = mocker.patch(
+            "testflinger_device_connectors.devices.control_host.time.sleep"
+        )
+        mock_get = mocker.patch("requests.get")
+
+        # Many empty reconnects so the backoff grows beyond the cap.
+        empty_sse = self._make_sse([])
+        status_running = Mock()
+        status_running.raise_for_status = Mock()
+        status_running.json.return_value = {"status": "running"}
+        status_done = Mock()
+        status_done.raise_for_status = Mock()
+        status_done.json.return_value = {"status": "completed"}
+        sse_final = self._make_sse(
+            ['data: {"level": "INFO", "message": "done"}']
+        )
+
+        # base=2 -> 4 -> 8 -> 16 -> 30 (capped) -> 30 (capped)
+        side_effects = []
+        for _ in range(5):
+            side_effects.extend([empty_sse, status_running])
+        side_effects.extend([sse_final, status_done])
+        mock_get.side_effect = side_effects
+
+        connector._run()
+
+        expected_delays = [
+            connector.SSE_RECONNECT_DELAY,
+            connector.SSE_RECONNECT_DELAY * 2,
+            connector.SSE_RECONNECT_DELAY * 4,
+            connector.SSE_RECONNECT_DELAY * 8,
+            connector.SSE_RECONNECT_MAX_DELAY,
+        ]
+        assert sleep.call_count == len(expected_delays)
+        for actual, expected in zip(
+            sleep.call_args_list, expected_delays, strict=True
+        ):
+            assert actual == mocker.call(expected)
 
     def test_run_raises_on_failed_status(self, mocker, connector, mock_post):
         """Test that _run raises ProvisioningError on non-completed status."""

--- a/device-connectors/src/testflinger_device_connectors/devices/control_host/tests/test_control_host.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/control_host/tests/test_control_host.py
@@ -683,6 +683,67 @@ class TestControlHostConnectorRun:
         ):
             assert actual == mocker.call(expected)
 
+    def test_run_resumes_from_last_event_id_on_reconnect(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Test that on reconnect the client sends the last seen SSE event
+        id via the Last-Event-ID header, so a resume-aware server can skip
+        already-delivered entries.
+        """
+        mocker.patch(
+            "testflinger_device_connectors.devices.control_host.time.sleep"
+        )
+        mock_get = mocker.patch("requests.get")
+
+        # First stream: event id 1 carries "step 1".
+        sse_1 = self._make_sse(
+            [
+                "id: 1",
+                'data: {"level": "INFO", "message": "step 1"}',
+            ]
+        )
+        status_running = Mock()
+        status_running.raise_for_status = Mock()
+        status_running.json.return_value = {"status": "running"}
+
+        # Second stream: a resume-aware server skips id 1 and sends id 2.
+        sse_2 = self._make_sse(
+            [
+                "id: 2",
+                'data: {"level": "INFO", "message": "step 2"}',
+            ]
+        )
+        status_completed = Mock()
+        status_completed.raise_for_status = Mock()
+        status_completed.json.return_value = {"status": "completed"}
+
+        mock_get.side_effect = [
+            sse_1,
+            status_running,
+            sse_2,
+            status_completed,
+        ]
+
+        with caplog.at_level(logging.DEBUG):
+            connector._run()
+
+        # The id: field is a normal SSE field, not an unexpected line.
+        assert "Unexpected SSE line" not in caplog.text
+
+        # First connect: no resume cursor yet. Reconnect: carries the id.
+        sse_calls = [
+            c for c in mock_get.call_args_list if c[0][0].endswith("/logs")
+        ]
+        assert len(sse_calls) == 2
+        assert sse_calls[0][1].get("headers") is None
+        assert sse_calls[1][1]["headers"]["Last-Event-ID"] == "1"
+
+        # "step 1" is logged exactly once: the resume-aware server did not
+        # replay it on reconnect, so it is not re-logged.
+        assert "step 1" in caplog.text
+        assert caplog.text.count("step 1") == 1
+        assert "step 2" in caplog.text
+
     def test_run_raises_on_failed_status(self, mocker, connector, mock_post):
         """Test that _run raises ProvisioningError on non-completed status."""
         mock_get = mocker.patch("requests.get")

--- a/device-connectors/src/testflinger_device_connectors/devices/control_host/tests/test_control_host.py
+++ b/device-connectors/src/testflinger_device_connectors/devices/control_host/tests/test_control_host.py
@@ -269,7 +269,13 @@ class TestControlHostConnectorRun:
         return mock
 
     def _make_sse(self, lines):
-        """Create a mock SSE response context manager."""
+        """Create a mock SSE response context manager.
+
+        Complete a non-empty final event, as a real SSE response does with
+        its terminating blank line.
+        """
+        if lines and lines[-1] != "":
+            lines = [*lines, ""]
         mock_sse = Mock()
         mock_sse.iter_lines.return_value = lines
         mock_sse.__enter__ = Mock(return_value=mock_sse)
@@ -324,6 +330,7 @@ class TestControlHostConnectorRun:
 
         lines = [
             'data: {"level": "INFO", "message": "Starting provisioning"}',
+            "",
             'data: {"level": "WARNING", "message": "Disk space low"}',
         ]
         mock_sse = self._make_sse(lines)
@@ -347,10 +354,10 @@ class TestControlHostConnectorRun:
         assert info_record.levelno == logging.INFO
         assert warn_record.levelno == logging.WARNING
 
-    def test_run_logs_unexpected_non_data_lines(
+    def test_run_ignores_standard_non_data_fields(
         self, mocker, connector, mock_post, caplog
     ):
-        """Test that non-'data:' SSE lines are logged as warnings."""
+        """Test that standard SSE fields other than data are ignored."""
         mock_get = mocker.patch("requests.get")
 
         lines = [
@@ -364,11 +371,11 @@ class TestControlHostConnectorRun:
         mock_status.json.return_value = {"status": "completed"}
         mock_get.side_effect = [mock_sse, mock_status]
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INFO):
             connector._run()
 
-        assert "Unexpected SSE line: event: error" in caplog.text
-        assert "Unexpected SSE line: retry: 3000" in caplog.text
+        assert "Unexpected SSE line" not in caplog.text
+        assert "[control-host] ok" in caplog.text
 
     def test_run_skips_empty_lines(self, mocker, connector, mock_post, caplog):
         """Test that empty SSE lines are silently skipped."""
@@ -398,6 +405,7 @@ class TestControlHostConnectorRun:
 
         lines = [
             "data: {not valid json",
+            "",
             'data: {"level": "INFO", "message": "ok"}',
         ]
         mock_sse = self._make_sse(lines)
@@ -440,8 +448,8 @@ class TestControlHostConnectorRun:
         """Test that a missing 'message' key falls back to raw line."""
         mock_get = mocker.patch("requests.get")
 
-        raw_line = 'data: {"level": "INFO"}'
-        lines = [raw_line]
+        payload = '{"level": "INFO"}'
+        lines = [f"data: {payload}"]
         mock_sse = self._make_sse(lines)
         mock_status = Mock()
         mock_status.raise_for_status = Mock()
@@ -451,7 +459,7 @@ class TestControlHostConnectorRun:
         with caplog.at_level(logging.INFO):
             connector._run()
 
-        assert f"[control-host] {raw_line}" in caplog.text
+        assert f"[control-host] {payload}" in caplog.text
 
     def test_run_handles_invalid_log_level(
         self, mocker, connector, mock_post, caplog
@@ -698,7 +706,7 @@ class TestControlHostConnectorRun:
         # First stream: event id 1 carries "step 1".
         sse_1 = self._make_sse(
             [
-                "id: 1",
+                "id:1",
                 'data: {"level": "INFO", "message": "step 1"}',
             ]
         )
@@ -709,7 +717,7 @@ class TestControlHostConnectorRun:
         # Second stream: a resume-aware server skips id 1 and sends id 2.
         sse_2 = self._make_sse(
             [
-                "id: 2",
+                "id:2",
                 'data: {"level": "INFO", "message": "step 2"}',
             ]
         )
@@ -743,6 +751,161 @@ class TestControlHostConnectorRun:
         assert "step 1" in caplog.text
         assert caplog.text.count("step 1") == 1
         assert "step 2" in caplog.text
+
+    def test_run_retains_cursor_when_stream_has_no_id(
+        self, mocker, connector, mock_post
+    ):
+        """A disconnected stream without an ID must not lose the cursor."""
+        mocker.patch(
+            "testflinger_device_connectors.devices.control_host.time.sleep"
+        )
+        mock_get = mocker.patch("requests.get")
+
+        sse_with_id = self._make_sse(
+            [
+                "id: 1",
+                'data: {"level": "INFO", "message": "first"}',
+            ]
+        )
+        empty_sse = self._make_sse([])
+        sse_final = self._make_sse(
+            ['data: {"level": "INFO", "message": "final"}']
+        )
+        status_running = Mock()
+        status_running.raise_for_status = Mock()
+        status_running.json.return_value = {"status": "running"}
+        status_completed = Mock()
+        status_completed.raise_for_status = Mock()
+        status_completed.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [
+            sse_with_id,
+            status_running,
+            empty_sse,
+            status_running,
+            sse_final,
+            status_completed,
+        ]
+
+        connector._run()
+
+        sse_calls = [
+            call
+            for call in mock_get.call_args_list
+            if call[0][0].endswith("/logs")
+        ]
+        assert [call[1].get("headers") for call in sse_calls] == [
+            None,
+            {"Last-Event-ID": "1"},
+            {"Last-Event-ID": "1"},
+        ]
+
+    def test_run_clears_cursor_after_empty_event_id(
+        self, mocker, connector, mock_post
+    ):
+        """An empty event ID clears the Last-Event-ID reconnect header."""
+        mocker.patch(
+            "testflinger_device_connectors.devices.control_host.time.sleep"
+        )
+        mock_get = mocker.patch("requests.get")
+
+        sse_with_id = self._make_sse(
+            [
+                "id: 1",
+                'data: {"level": "INFO", "message": "first"}',
+            ]
+        )
+        sse_clear_id = self._make_sse(
+            [
+                "id:",
+                'data: {"level": "INFO", "message": "reset"}',
+            ]
+        )
+        sse_final = self._make_sse(
+            ['data: {"level": "INFO", "message": "final"}']
+        )
+        status_running = Mock()
+        status_running.raise_for_status = Mock()
+        status_running.json.return_value = {"status": "running"}
+        status_completed = Mock()
+        status_completed.raise_for_status = Mock()
+        status_completed.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [
+            sse_with_id,
+            status_running,
+            sse_clear_id,
+            status_running,
+            sse_final,
+            status_completed,
+        ]
+
+        connector._run()
+
+        sse_calls = [
+            call
+            for call in mock_get.call_args_list
+            if call[0][0].endswith("/logs")
+        ]
+        assert [call[1].get("headers") for call in sse_calls] == [
+            None,
+            {"Last-Event-ID": "1"},
+            None,
+        ]
+
+    def test_run_does_not_checkpoint_malformed_event(
+        self, mocker, connector, mock_post
+    ):
+        """Malformed payloads must not advance the resume cursor."""
+        mocker.patch(
+            "testflinger_device_connectors.devices.control_host.time.sleep"
+        )
+        mock_get = mocker.patch("requests.get")
+
+        malformed_sse = self._make_sse(["id: 1", "data: {not valid json"])
+        sse_final = self._make_sse(
+            ['data: {"level": "INFO", "message": "final"}']
+        )
+        status_running = Mock()
+        status_running.raise_for_status = Mock()
+        status_running.json.return_value = {"status": "running"}
+        status_completed = Mock()
+        status_completed.raise_for_status = Mock()
+        status_completed.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [
+            malformed_sse,
+            status_running,
+            sse_final,
+            status_completed,
+        ]
+
+        connector._run()
+
+        sse_calls = [
+            call
+            for call in mock_get.call_args_list
+            if call[0][0].endswith("/logs")
+        ]
+        assert [call[1].get("headers") for call in sse_calls] == [None, None]
+
+    def test_run_handles_multiline_sse_data(
+        self, mocker, connector, mock_post, caplog
+    ):
+        """Multiple data fields are joined before parsing one SSE event."""
+        mock_get = mocker.patch("requests.get")
+        sse = self._make_sse(
+            [
+                'data: {"level": "INFO",',
+                'data: "message": "split event"}',
+            ]
+        )
+        status_completed = Mock()
+        status_completed.raise_for_status = Mock()
+        status_completed.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [sse, status_completed]
+
+        with caplog.at_level(logging.INFO):
+            connector._run()
+
+        assert "[control-host] split event" in caplog.text
 
     def test_run_raises_on_failed_status(self, mocker, connector, mock_post):
         """Test that _run raises ProvisioningError on non-completed status."""


### PR DESCRIPTION
## Description

From user reports, the SSE endpoint has a couple of problems:
1. it can close before the reported status is reported as FAILED
2. it reconnects w/o delays, re-reading the whole thing

An exponential back off is added to avoid hasty reconnections (there's no need, SSE will return what we missed anyway).

Reconnects include the last successfully processed SSE event ID in the standard Last-Event-ID request header. This requires the control-host log endpoint to emit SSE id: fields and honor that header when resuming a stream. When the endpoint does not support resumable SSE, the connector remains compatible but may replay buffered logs after reconnecting. 

## Resolved issues

Part of https://warthogs.atlassian.net/browse/ZAP-1528

## Documentation

Docstrings/inline comments. No need to update the product docs.

## Web service API changes

No

## Tests

Still working fine (tested with both server sending `id:` and not)
```
DISABLE_CONTROL_HOST_POWERCYCLE=1 uv run testflinger-device-connector control_host_iot provision -c ./local.yaml ./local.json
2026-07-22 10:50:53,718 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Running pre-provision hook
2026-07-22 10:50:53,719 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Skipping control host power cycle (DISABLE_CONTROL_HOST_POWERCYCLE is set).
2026-07-22 10:50:53,719 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Setting up provisioning on control host 192.168.68.59
2026-07-22 10:50:53,722 hp-pro-sff-400-g9-desktop-pc-c30464 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server. Retrying in the background...
2026-07-22 10:50:56,813 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: BEGIN provision
2026-07-22 10:50:56,813 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Provisioning device
2026-07-22 10:50:56,817 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: POST http://192.168.68.59:8000/api/v1/provision
2026-07-22 10:50:56,844 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: GET http://192.168.68.59:8000/api/v1/provision/2cc715fc-db75-4379-8499-b9dbaa45b95c/logs
2026-07-22 10:50:56,901 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Running the RPiClassic preset...
2026-07-22 10:50:57,129 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] ser2net configured: /dev/ttyACM3 at 115200 baud on TCP port 3000
2026-07-22 10:50:57,158 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] ser2net started (pid 206104)
2026-07-22 10:51:03,870 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Detected device is /dev/sda
2026-07-22 10:51:03,874 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Compressed image, skipping SHA verification
2026-07-22 10:51:03,875 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Downloading https://cdimage.ubuntu.com/ubuntu-server/noble/daily-preinstalled/current/noble-preinstalled-server-arm64+raspi.img.xz
2026-07-22 10:51:03,875 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Attempt 1/3
2026-07-22 10:51:03,883 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Decompressing on the fly with xz
2026-07-22 10:51:04,556 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Progress: 0%
2026-07-22 10:51:19,627 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Progress: 10%
2026-07-22 10:51:23,736 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: Successfully connected to serial logging server
2026-07-22 10:51:39,522 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Progress: 20%
2026-07-22 10:51:47,590 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Progress: 30%
2026-07-22 10:51:55,595 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Progress: 40%
2026-07-22 10:52:01,551 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Progress: 50%
2026-07-22 10:52:08,599 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Progress: 60%
2026-07-22 10:52:17,594 hp-pro-sff-400-g9-desktop-pc-c30464 INFO: DEVICE CONNECTOR: [control-host] Progress: 70%
```