### PR TITLE
fix(server): addresss access_token validation issues

### DIFF
--- a/server/charm/charmcraft.yaml
+++ b/server/charm/charmcraft.yaml
@@ -99,6 +99,13 @@ config:
       type: string
       default: ""
       description: The secret key used for signing authorization tokens
+    jwt_leeway:
+      type: int
+      default: 5
+      description: |
+        The allowed drift in seconds for validating JWT tokens.
+        Useful in k8s deployments where the clock may not be perfectly
+        synchronized between the k8s nodes.
     testflinger_secrets_master_key:
       type: string
       default: ""

--- a/server/charm/src/charm.py
+++ b/server/charm/src/charm.py
@@ -442,6 +442,7 @@ class TestflingerCharm(ops.CharmBase):
             "MONGODB_DATABASE": db_data.get("db_database"),
             "MONGODB_MAX_POOL_SIZE": str(self.typed_config.max_pool_size),
             "JWT_SIGNING_KEY": self.typed_config.jwt_signing_key,
+            "JWT_LEEWAY": str(self.typed_config.jwt_leeway),
             "TESTFLINGER_SECRETS_MASTER_KEY": self.typed_config.testflinger_secrets_master_key,  # noqa: E501
             "TESTFLINGER_KEY_VAULT_URI": self._fetch_keyvault_uri() or "",
             "HTTP_PROXY": self.typed_config.http_proxy,

--- a/server/charm/src/config.py
+++ b/server/charm/src/config.py
@@ -18,6 +18,7 @@ class TestflingerServerConfig(pydantic.BaseModel):
     keepalive: int = 10
     max_pool_size: int = 100
     jwt_signing_key: str = ""
+    jwt_leeway: int = 5
     testflinger_secrets_master_key: str = ""
     http_proxy: str = ""
     https_proxy: str = ""

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -125,6 +125,7 @@ def decode_jwt_token(auth_token: str | None, secret_key: str) -> dict | None:
         decoded_jwt = jwt.decode(
             auth_token,
             secret_key,
+            leeway=10,
             algorithms="HS256",
             options={"require": ["exp", "iat", "sub"]},
         )

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -34,6 +34,9 @@ from testflinger.owasp import OWASPLogger
 DEFAULT_REFRESH_TOKEN_EXPIRATION = 6 * 24 * 60 * 60  # 6 days in seconds
 DEFAULT_ACCESS_TOKEN_EXPIRATION = 60 * 10  # 10 minutes
 HASH_ROUNDS = 8
+# The number of seconds to allow for clock drift when validating JWT tokens.
+# Increasing this value will affect `iat` and `exp` claims in the JWT token.
+JWT_LEEWAY = int(os.environ.get("JWT_LEEWAY", "5"))
 
 # Fields from client_permissions to include in the Testflinger JWT
 PERMISSIONS_FIELDS = frozenset(
@@ -125,7 +128,7 @@ def decode_jwt_token(auth_token: str | None, secret_key: str) -> dict | None:
         decoded_jwt = jwt.decode(
             auth_token,
             secret_key,
-            leeway=10,
+            leeway=JWT_LEEWAY,
             algorithms="HS256",
             options={"require": ["exp", "iat", "sub"]},
         )

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -130,6 +130,16 @@ def decode_jwt_token(auth_token: str | None, secret_key: str) -> dict | None:
         )
     except jwt.exceptions.ExpiredSignatureError:
         abort(HTTPStatus.UNAUTHORIZED, "Token has expired")
+    except jwt.exceptions.ImmatureSignatureError:
+        abort(HTTPStatus.UNAUTHORIZED, "Token not yet valid")
+    except jwt.exceptions.InvalidSignatureError:
+        abort(HTTPStatus.FORBIDDEN, "Invalid Token signature")
+    except jwt.exceptions.MissingRequiredClaimError as e:
+        abort(HTTPStatus.FORBIDDEN, f"Token missing required claim: {e.claim}")
+    except jwt.exceptions.InvalidIssuedAtError:
+        abort(HTTPStatus.FORBIDDEN, "Token has invalid issued-at claim")
+    except jwt.exceptions.DecodeError:
+        abort(HTTPStatus.FORBIDDEN, "Unable to decode token")
     except jwt.exceptions.InvalidTokenError:
         abort(HTTPStatus.FORBIDDEN, "Invalid Token")
 

--- a/server/src/testflinger/api/auth.py
+++ b/server/src/testflinger/api/auth.py
@@ -140,8 +140,6 @@ def decode_jwt_token(auth_token: str | None, secret_key: str) -> dict | None:
         abort(HTTPStatus.FORBIDDEN, "Invalid Token signature")
     except jwt.exceptions.MissingRequiredClaimError as e:
         abort(HTTPStatus.FORBIDDEN, f"Token missing required claim: {e.claim}")
-    except jwt.exceptions.InvalidIssuedAtError:
-        abort(HTTPStatus.FORBIDDEN, "Token has invalid issued-at claim")
     except jwt.exceptions.DecodeError:
         abort(HTTPStatus.FORBIDDEN, "Unable to decode token")
     except jwt.exceptions.InvalidTokenError:

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -1139,7 +1139,7 @@ def refresh_access_token(json_data: dict):
     return {
         "access_token": access_token,
         "token_type": "Bearer",
-        "expires_in": 30,
+        "expires_in": auth.DEFAULT_ACCESS_TOKEN_EXPIRATION,
     }
 
 

--- a/server/tests/test_v1_authorization.py
+++ b/server/tests/test_v1_authorization.py
@@ -22,6 +22,7 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
+from unittest.mock import patch
 
 import bcrypt
 import jwt
@@ -166,8 +167,8 @@ def test_priority_expired_token(mongo_app_with_permissions):
     app, _, _, _, _ = mongo_app_with_permissions
     secret_key = os.environ.get("JWT_SIGNING_KEY")
     expired_token_payload = {
-        "exp": datetime.now(timezone.utc) - timedelta(seconds=2),
-        "iat": datetime.now(timezone.utc) - timedelta(seconds=4),
+        "exp": datetime.now(timezone.utc) - timedelta(seconds=10),
+        "iat": datetime.now(timezone.utc) - timedelta(seconds=12),
         "sub": "access_token",
         "permissions": {
             "max_priority": {},
@@ -197,7 +198,7 @@ def test_missing_fields_in_token(mongo_app_with_permissions):
         "/v1/job", json=job, headers={"Authorization": f"Bearer {token}"}
     )
     assert 403 == job_response.status_code
-    assert "Invalid Token" in job_response.text
+    assert "Token missing required claim" in job_response.text
 
 
 def test_missing_role_defaults_to_contributor(mongo_app_with_permissions):
@@ -1595,3 +1596,135 @@ def test_revoke_rejects_operator_injection(
 
     # Request aborted by schema validation, returns 422 Unprocessable Entity
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "exception, expected_status, expected_message",
+    [
+        (
+            jwt.exceptions.ExpiredSignatureError(),
+            HTTPStatus.UNAUTHORIZED,
+            "Token has expired",
+        ),
+        (
+            jwt.exceptions.ImmatureSignatureError(),
+            HTTPStatus.UNAUTHORIZED,
+            "Token not yet valid",
+        ),
+        (
+            jwt.exceptions.InvalidSignatureError(),
+            HTTPStatus.FORBIDDEN,
+            "Invalid Token signature",
+        ),
+        (
+            jwt.exceptions.MissingRequiredClaimError("exp"),
+            HTTPStatus.FORBIDDEN,
+            "Token missing required claim",
+        ),
+        (
+            jwt.exceptions.DecodeError(),
+            HTTPStatus.FORBIDDEN,
+            "Unable to decode token",
+        ),
+        (
+            jwt.exceptions.InvalidTokenError(),
+            HTTPStatus.FORBIDDEN,
+            "Invalid Token",
+        ),
+    ],
+)
+@patch("testflinger.api.auth.jwt.decode")
+def test_jwt_exception_handling(
+    mock_decode,
+    mongo_app_with_permissions,
+    exception,
+    expected_status,
+    expected_message,
+):
+    """Test that jwt decode exceptions return expected HTTP status codes."""
+    app, _, _, _, _ = mongo_app_with_permissions
+    mock_decode.side_effect = exception
+
+    job = {"job_queue": "myqueue", "job_priority": 100}
+    response = app.post(
+        "/v1/job",
+        json=job,
+        headers={"Authorization": "Bearer fake.token.value"},
+    )
+
+    assert response.status_code == expected_status
+    assert expected_message in response.text
+
+
+def test_access_token_valid_if_expired_within_leeway(
+    mongo_app_with_permissions,
+):
+    """Test access token is valid if already expired within leeway period."""
+    app, _, client_id, _, _ = mongo_app_with_permissions
+    secret_key = os.environ.get("JWT_SIGNING_KEY")
+    # Token expired 2 seconds ago, within the default 5-second leeway
+    token_payload = {
+        "exp": datetime.now(timezone.utc) - timedelta(seconds=2),
+        "iat": datetime.now(timezone.utc),
+        "sub": "access_token",
+        "permissions": {
+            "client_id": client_id,
+            "max_priority": {"*": 1, "myqueue": 100},
+            "role": ServerRoles.CONTRIBUTOR,
+        },
+    }
+    token = jwt.encode(token_payload, secret_key, algorithm="HS256")
+    job = {"job_queue": "myqueue"}
+    response = app.post(
+        "/v1/job", json=job, headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == HTTPStatus.OK
+
+
+def test_access_token_valid_if_iat_within_leeway(mongo_app_with_permissions):
+    """Test access token is valid if issued-at is within leeway period."""
+    app, _, client_id, _, _ = mongo_app_with_permissions
+    secret_key = os.environ.get("JWT_SIGNING_KEY")
+    # Token issued 2 seconds in the future, within the default 5s leeway
+    token_payload = {
+        "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+        "iat": datetime.now(timezone.utc) + timedelta(seconds=2),
+        "sub": "access_token",
+        "permissions": {
+            "client_id": client_id,
+            "max_priority": {"*": 1, "myqueue": 100},
+            "role": ServerRoles.CONTRIBUTOR,
+        },
+    }
+    token = jwt.encode(token_payload, secret_key, algorithm="HS256")
+    job = {"job_queue": "myqueue"}
+    response = app.post(
+        "/v1/job", json=job, headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == HTTPStatus.OK
+
+
+def test_access_token_invalid_if_iat_not_within_leeway(
+    mongo_app_with_permissions,
+):
+    """Test access token is invalid if issued-at isn't within leeway period."""
+    app, _, client_id, _, _ = mongo_app_with_permissions
+    secret_key = os.environ.get("JWT_SIGNING_KEY")
+    # Token issued 10 seconds in the future, outside the default 5s leeway
+    token_payload = {
+        "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+        "iat": datetime.now(timezone.utc) + timedelta(seconds=10),
+        "sub": "access_token",
+        "permissions": {
+            "client_id": client_id,
+            "max_priority": {"*": 1, "myqueue": 100},
+            "role": ServerRoles.CONTRIBUTOR,
+        },
+    }
+    token = jwt.encode(token_payload, secret_key, algorithm="HS256")
+    job = {"job_queue": "myqueue"}
+    response = app.post(
+        "/v1/job", json=job, headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert "Token not yet valid" in response.text


### PR DESCRIPTION
## Description
This adds some fixes for the access_token/jwt token

1. Use the `DEFAULT_ACCESS_TOKEN_EXPIRATION` instead of hardcoded seconds
2. Add more exception handling to JWT token validation so errors are more clear to consumer e.g. CLI
3. Add configurable JWT_LEEWAY, useful in k8s deployments where nodes clock may have some drift making the JWT token validation failed
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
QOL
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
NA
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
NA
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests for the new portion of code. It was also verified from JWT library that both `iat` and `exp` are using the leeway:
```
        if "iat" in payload and options["verify_iat"]:
            self._validate_iat(payload, now, leeway)
        ...
        if "exp" in payload and options["verify_exp"]:
            self._validate_exp(payload, now, leeway)
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
