### PR TITLE
Add client id (submitted by) to API endpoints.  Also adjusts the data…

### DIFF
--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -99,6 +99,7 @@ FIELDS_CHOICES = (
     "provision_type",
     "comment",
     "job_id",
+    "submitted_by",
     "queues",
 )
 
@@ -513,6 +514,20 @@ class TestflingerCli:
             default=None,
             help="Filter agents by comment (regex)",
         )
+        parser.add_argument(
+            "--filter-job-id",
+            dest="filter_job_id",
+            type=helpers.regex_arg,
+            default=None,
+            help="Filter agents by current job ID (regex)",
+        )
+        parser.add_argument(
+            "--filter-submitted-by",
+            dest="filter_submitted_by",
+            type=helpers.regex_arg,
+            default=None,
+            help="Filter agents by the submitter of their current job (regex)",
+        )
 
     def _add_queue_status_args(self, subparsers):
         """Command line arguments for queue status."""
@@ -749,6 +764,14 @@ class TestflingerCli:
                 return lambda a: regex.search(str(a.get(field, "")))
             return lambda a: True
 
+        def nested_job_re_filter(field: str, regex: object) -> callable:
+            """Filter on a field nested inside agent['job']."""
+            if regex:
+                return lambda a: regex.search(
+                    str((a.get("job") or {}).get(field, ""))
+                )
+            return lambda a: True
+
         # Filter agents by allowed states
         return [
             a
@@ -763,6 +786,10 @@ class TestflingerCli:
                         "provision_type", self.args.filter_provision_type
                     )(a),
                     re_filter("comment", self.args.filter_comment)(a),
+                    nested_job_re_filter("job_id", self.args.filter_job_id)(a),
+                    nested_job_re_filter(
+                        "submitted_by", self.args.filter_submitted_by
+                    )(a),
                 )
             )
         ]
@@ -827,6 +854,16 @@ class TestflingerCli:
         # Map 'status' to 'state' in agent dicts for backward compatibility
         field_map = {"status": "state"}
 
+        def get_field(agent: dict, field: str) -> str:
+            """Resolve a field value from an agent dict, including nested."""
+            if field in ("job_id", "submitted_by"):
+                return (agent.get("job") or {}).get(field, "-")
+            key = field_map.get(field, field)
+            val = agent.get(key, "-")
+            if isinstance(val, list):
+                val = ", ".join(str(v) for v in val)
+            return str(val)
+
         # Header names and valid fields
         header_map = {
             "name": "Name",
@@ -835,22 +872,19 @@ class TestflingerCli:
             "provision_type": "Provision Type",
             "comment": "Comment",
             "job_id": "Job ID",
+            "submitted_by": "Submitted By",
             "queues": "Queues",
         }
         headers = [header_map[f] for f in self.args.fields]
 
         # Calculate column widths
-        col_widths = []
-        for field, header in zip(self.args.fields, headers, strict=False):
-            key = field_map.get(field, field)
-            width = max(
+        col_widths = [
+            max(
                 len(header),
-                max(
-                    (len(str(agent.get(key, "-"))) for agent in agents),
-                    default=0,
-                ),
+                max((len(get_field(a, f)) for a in agents), default=0),
             )
-            col_widths.append(width)
+            for f, header in zip(self.args.fields, headers, strict=False)
+        ]
 
         # Print header
         print(
@@ -861,14 +895,10 @@ class TestflingerCli:
         )
         # Print rows
         for agent in agents:
-            row = []
-            for f, w in zip(self.args.fields, col_widths, strict=True):
-                key = field_map.get(f, f)
-                val = agent.get(key, "-")
-                # Convert list values to comma-separated string
-                if isinstance(val, list):
-                    val = ", ".join(str(v) for v in val)
-                row.append(f"{val:<{w}}")
+            row = [
+                f"{get_field(agent, f):<{w}}"
+                for f, w in zip(self.args.fields, col_widths, strict=True)
+            ]
             print("  ".join(row))
 
     def _print_agent_names(self, agents: list[dict]) -> None:

--- a/cli/testflinger_cli/__init__.py
+++ b/cli/testflinger_cli/__init__.py
@@ -515,13 +515,6 @@ class TestflingerCli:
             help="Filter agents by comment (regex)",
         )
         parser.add_argument(
-            "--filter-job-id",
-            dest="filter_job_id",
-            type=helpers.regex_arg,
-            default=None,
-            help="Filter agents by current job ID (regex)",
-        )
-        parser.add_argument(
             "--filter-submitted-by",
             dest="filter_submitted_by",
             type=helpers.regex_arg,
@@ -786,7 +779,6 @@ class TestflingerCli:
                         "provision_type", self.args.filter_provision_type
                     )(a),
                     re_filter("comment", self.args.filter_comment)(a),
-                    nested_job_re_filter("job_id", self.args.filter_job_id)(a),
                     nested_job_re_filter(
                         "submitted_by", self.args.filter_submitted_by
                     )(a),

--- a/server/devel/create_sample_data.py
+++ b/server/devel/create_sample_data.py
@@ -319,8 +319,8 @@ def main():
     # Primary client used for queue/agent setup (needs admin role)
     admin_client = TestflingerClient(
         server_url=args.server,
-        client_id=os.environ.get("TESTFLINGER_CLIENT_ID", "dev-admin"),
-        client_key=os.environ.get("TESTFLINGER_SECRET_KEY", "dev-secret-for-testing"),
+        client_id=os.environ.get("TESTFLINGER_CLIENT_ID", "testflinger-admin"),
+        client_key=os.environ.get("TESTFLINGER_SECRET_KEY", "testflinger"),
     )
 
     queues = QueueDataGenerator(num_queues=args.queues)

--- a/server/devel/create_sample_users.py
+++ b/server/devel/create_sample_users.py
@@ -39,9 +39,10 @@ from pymongo import MongoClient
 from testflinger.database import get_mongo_uri
 from sample_users import SAMPLE_CLIENTS
 
-# testflinger-admin is the OIDC identity used for authentication via Dex.
-# It is registered here so it also has a permissions record in MongoDB.
+# testflinger-admin is both the OIDC identity (via Dex) and a credential-based
+# admin client used by create_sample_data.py.
 TESTFLINGER_ADMIN_ID = "testflinger-admin"
+TESTFLINGER_ADMIN_SECRET = "testflinger"
 
 
 def _make_secret_hash(secret: str) -> str:
@@ -57,13 +58,14 @@ def main():
         db.client_permissions.insert_one(
             {
                 "client_id": TESTFLINGER_ADMIN_ID,
+                "client_secret_hash": _make_secret_hash(TESTFLINGER_ADMIN_SECRET),
                 "role": "admin",
                 "max_priority": {"*": 100},
                 "allowed_queues": [],
                 "max_reservation_time": {},
             }
         )
-        print(f"Created OIDC admin credential '{TESTFLINGER_ADMIN_ID}'")
+        print(f"Created admin credential '{TESTFLINGER_ADMIN_ID}'")
 
     for client in SAMPLE_CLIENTS:
         client_id = client["client_id"]

--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -109,6 +109,9 @@
               }
             ]
           },
+          "job_id": {
+            "type": "string"
+          },
           "location": {
             "type": "string"
           },

--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -61,6 +61,11 @@
           "job_id": {
             "type": "string"
           },
+          "job_submitted_by": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
           "location": {
             "type": "string"
           },
@@ -306,6 +311,88 @@
         ],
         "type": "object"
       },
+      "JobOut": {
+        "additionalProperties": false,
+        "properties": {
+          "allocate_data": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "allocation_timeout": {
+            "type": "integer"
+          },
+          "debug": {
+            "type": "boolean"
+          },
+          "exclude_agents": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "firmware_update_data": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "global_timeout": {
+            "type": "integer"
+          },
+          "job_id": {
+            "type": "string"
+          },
+          "job_priority": {
+            "type": "integer"
+          },
+          "job_queue": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "job_status_webhook": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "output_timeout": {
+            "type": "integer"
+          },
+          "parent_job_id": {
+            "type": "string"
+          },
+          "provision_data": {
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
+              {
+                "$ref": "#/components/schemas/ProvisionData"
+              }
+            ]
+          },
+          "reserve_data": {
+            "$ref": "#/components/schemas/ReserveData"
+          },
+          "submitted_by": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "test_data": {
+            "$ref": "#/components/schemas/TestData"
+          }
+        },
+        "required": [
+          "job_queue"
+        ],
+        "type": "object"
+      },
       "JobSearchResponse": {
         "additionalProperties": false,
         "properties": {
@@ -489,6 +576,11 @@
           },
           "allocate_status": {
             "type": "integer"
+          },
+          "cancelled_by": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
           },
           "cleanup_output": {
             "type": "string"
@@ -1495,7 +1587,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Job"
+                  "$ref": "#/components/schemas/JobOut"
                 }
               }
             },

--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -52,19 +52,62 @@
         },
         "type": "object"
       },
+      "AgentJob": {
+        "additionalProperties": false,
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "job_id": {
+            "type": "string"
+          },
+          "job_priority": {
+            "type": "integer"
+          },
+          "job_queue": {
+            "type": "string"
+          },
+          "job_state": {
+            "type": "string"
+          },
+          "started_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "submitted_by": {
+            "default": null,
+            "nullable": true,
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "job_id"
+        ],
+        "type": "object"
+      },
       "AgentOut": {
         "additionalProperties": false,
         "properties": {
           "comment": {
             "type": "string"
           },
-          "job_id": {
-            "type": "string"
-          },
-          "job_submitted_by": {
-            "default": null,
-            "nullable": true,
-            "type": "string"
+          "job": {
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
+              {
+                "$ref": "#/components/schemas/AgentJob"
+              }
+            ]
           },
           "location": {
             "type": "string"

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -77,6 +77,7 @@ class AgentOut(Schema):
     """Agent data output schema."""
 
     name = fields.String(required=True)
+    job_id = fields.String(required=False)
     state = fields.String(required=False)
     queues = fields.List(fields.String(), required=False)
     location = fields.String(required=False)

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -71,6 +71,7 @@ class AgentOut(Schema):
     job_id = fields.String(required=False)
     comment = fields.String(required=False)
     restricted_to = fields.Dict(required=False)
+    job_submitted_by = fields.String(load_default=None)
 
 
 class ActionIn(Schema):
@@ -412,6 +413,12 @@ class JobId(Schema):
     job_id = fields.String(required=True)
 
 
+class JobOut(Job):
+    """Job output schema — extends Job with server-assigned fields."""
+
+    submitted_by = fields.String(load_default=None)
+
+
 class JobSearchRequest(Schema):
     """Job search request schema."""
 
@@ -464,6 +471,7 @@ class ResultGet(Schema):
 
     device_info = fields.Dict(required=False)
     job_state = fields.String(required=False)
+    cancelled_by = fields.String(load_default=None)
 
 
 class ResultPost(Schema):

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -60,6 +60,19 @@ class AgentIn(Schema):
     comment = fields.String(required=False)
 
 
+class AgentJob(Schema):
+    """Lightweight summary of the job currently assigned to an agent."""
+
+    job_id = fields.String(required=True)
+    submitted_by = fields.String(load_default=None)
+    created_at = fields.DateTime(required=False)
+    started_at = fields.DateTime(required=False)
+    job_queue = fields.String(required=False)
+    job_state = fields.String(required=False)
+    job_priority = fields.Integer(required=False)
+    tags = fields.List(fields.String(), required=False)
+
+
 class AgentOut(Schema):
     """Agent data output schema."""
 
@@ -68,10 +81,9 @@ class AgentOut(Schema):
     queues = fields.List(fields.String(), required=False)
     location = fields.String(required=False)
     provision_type = fields.String(required=False)
-    job_id = fields.String(required=False)
     comment = fields.String(required=False)
     restricted_to = fields.Dict(required=False)
-    job_submitted_by = fields.String(load_default=None)
+    job = fields.Nested(AgentJob, required=False, allow_none=True)
 
 
 class ActionIn(Schema):

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -623,9 +623,7 @@ def result_get(job_id: str):
 
     # Reconstruct result format with logs and phase statuses
     log_handler = MongoLogHandler(database.mongo)
-    result = log_handler.format_logs_as_results(job_id, result_data)
-    result["cancelled_by"] = result_data.get("cancelled_by")
-    return result
+    return log_handler.format_logs_as_results(job_id, result_data)
 
 
 @v1.post("/job/<job_id>/action")

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -115,9 +115,9 @@ def job_post(json_data: dict) -> dict:
         # Make sure that there are at least some agents in the selected queue
         # which can run this job.
         agents_can_run = [
-            agent
-            for agent in database.get_agents_on_queue(job_queue)
-            if agent["name"] not in exclude_agents
+            name
+            for name in database.get_agent_names_on_queue(job_queue)
+            if name not in exclude_agents
         ]
         if not agents_can_run:
             abort(

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -1008,7 +1008,7 @@ def get_agents_on_queue(queue_name):
             message=f"Queue '{queue_name}' does not exist.",
         )
 
-    agents = database.get_agents_on_queue(queue_name)
+    agents = database.get_agents(queue=queue_name)
     if not agents:
         return [], HTTPStatus.NO_CONTENT
     return agents

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -201,9 +201,9 @@ def job_builder(data: dict) -> dict:
         },
     }
 
-    # Always store the client_id of the submitting user at the top level of
-    # the job document so it can be displayed in the web views.
-    job["client_id"] = g.client_id
+    # Always store the submitted_by field at the top level of the job
+    # document so it can be displayed in the web views and API.
+    job["submitted_by"] = g.client_id
 
     # If the job_id is provided, keep it as long as the uuid is good.
     # This is for job resubmission
@@ -305,7 +305,7 @@ def retrieve_secrets(data: dict) -> dict | None:
 @v1.get("/job/<job_id>")
 @authenticate
 @require_role(ServerRoles.ADMIN, ServerRoles.MANAGER, ServerRoles.CONTRIBUTOR)
-@v1.output(schemas.Job)
+@v1.output(schemas.JobOut)
 def job_get_id(job_id):
     """Request the json job definition for a specified job, even if it has
        already run.
@@ -318,12 +318,14 @@ def job_get_id(job_id):
     if not check_valid_uuid(job_id):
         abort(400, message="Invalid job_id specified")
     response = database.mongo.db.jobs.find_one(
-        {"job_id": job_id}, projection={"job_data": True, "_id": False}
+        {"job_id": job_id},
+        projection={"job_data": True, "submitted_by": True, "_id": False},
     )
     if not response:
         return {}, 204
     job_data = response.get("job_data")
     job_data["job_id"] = job_id
+    job_data["submitted_by"] = response.get("submitted_by")
     return job_data
 
 
@@ -621,7 +623,9 @@ def result_get(job_id: str):
 
     # Reconstruct result format with logs and phase statuses
     log_handler = MongoLogHandler(database.mongo)
-    return log_handler.format_logs_as_results(job_id, result_data)
+    result = log_handler.format_logs_as_results(job_id, result_data)
+    result["cancelled_by"] = result_data.get("cancelled_by")
+    return result
 
 
 @v1.post("/job/<job_id>/action")
@@ -646,7 +650,7 @@ def action_post(job_id, json_data):
 
 
 def _cancel_job(job_id):
-    modifications = database.cancel_job(job_id)
+    modifications = database.cancel_job(job_id, client_id=g.client_id)
     if not modifications:
         return (
             "The job is already completed or cancelled",

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -327,13 +327,13 @@ def get_queue_wait_times(queues: list[str] | None = None) -> list[dict]:
     return list(wait_times)
 
 
-def get_agents_on_queue(queue: str) -> list[dict]:
-    """Return a list of agents listening on the given queue."""
+def get_agent_names_on_queue(queue: str) -> list[str]:
+    """Return a list of agent names listening on the given queue."""
     agents = mongo.db.agents.find(
         {"queues": {"$in": [queue]}},
-        {"_id": 0},
+        {"_id": 0, "name": 1},
     )
-    return list(agents)
+    return [agent["name"] for agent in agents]
 
 
 def get_jobs_on_queue(queue: str) -> list[dict]:
@@ -447,10 +447,12 @@ def check_queue_restricted(queue: str) -> bool:
 def _active_job_pipeline_stages() -> list[dict]:
     """Return aggregation stages that join agents with their active job.
 
-    The ``$lookup`` uses only basic localField/foreignField form for broad
+    The ``$lookup`` uses the basic localField/foreignField form for broad
     driver and mongomock compatibility.  A subsequent ``$addFields`` stage
-    projects ``submitted_by`` from the matched job doc as ``job_submitted_by``
-    (or ``None`` when there is no active job).
+    builds a nested ``job`` object containing lightweight job data
+    (``job_id``, ``submitted_by``, ``created_at``, ``started_at``,
+    ``job_queue``, ``job_state``, ``job_priority``, ``tags``) from the
+    matched job document, or ``None`` when the agent has no active job.
     """
     return [
         {
@@ -463,14 +465,25 @@ def _active_job_pipeline_stages() -> list[dict]:
         },
         {
             "$addFields": {
-                "job_submitted_by": {
+                "job": {
                     "$let": {
-                        "vars": {"job": {"$arrayElemAt": ["$_job_docs", 0]}},
-                        "in": "$$job.submitted_by",
-                    }
-                }
-            }
-        },
+                        "vars": {"j": {"$arrayElemAt": ["$_job_docs", 0]}},
+                        "in": {
+                            "$cond": {
+                                "if": {"$eq": ["$$j", None]},
+                                "then": None,
+                                "else": {
+                                    "job_id": "$$j.job_id",
+                                    "submitted_by": "$$j.submitted_by",
+                                    "created_at": "$$j.created_at",
+                                    "started_at": "$$j.started_at",
+                                    "job_queue": "$$j.job_data.job_queue",
+                                    "job_state": "$$j.result_data.job_state",
+                                    "job_priority": "$$j.job_priority",
+                                    "tags": "$$j.job_data.tags",
+                                },
+                            }
+                        },
                     }
                 }
             }
@@ -483,8 +496,9 @@ def get_agent_info(agent: str) -> dict | None:
     """Return the information for a specified agent, with active job attached.
 
     Uses a single aggregation pipeline to join the agent with its current
-    job document (if any), populating ``job_submitted_by`` from the job's
-    ``submitted_by`` field.
+    job document (if any), populating a nested ``job`` object with
+    lightweight job data (``job_id``, ``submitted_by``, ``job_queue``,
+    ``job_state``, ``job_priority``, ``tags``).
     """
     pipeline = [
         {"$match": {"name": agent}},
@@ -554,12 +568,14 @@ def get_agents(queue: str | None = None) -> list[dict]:
     """Return a list of agents with active job info attached.
 
     Uses a single aggregation pipeline to join each agent with its
-    current job document (if any), returning ``job_submitted_by`` as the
-    ``submitted_by`` field from the job document.
+    current job document (if any), populating a nested ``job`` object
+    with lightweight job data (``job_id``, ``submitted_by``,
+    ``job_queue``, ``job_state``, ``job_priority``, ``tags``).
 
     :param queue: If provided, filter agents to those listening on this
         queue.
-    :returns: List of agent dicts, each with a ``job_submitted_by`` field.
+    :returns: List of agent dicts, each with a ``job`` field (or ``None``
+        when the agent has no active job).
     """
     match_stage = (
         {"$match": {"queues": {"$in": [queue]}}} if queue else {"$match": {}}

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -267,13 +267,18 @@ def pop_job(queue_list: list[str], agent_name: str) -> dict | None:
     return job
 
 
-def cancel_job(job_id):
+def cancel_job(job_id, client_id: str | None = None):
     """Cancel a specified job ID.
 
     :param job_id:
         UUID as a string for the job
+    :param client_id:
+        The client ID of the user requesting the cancellation
     """
     modifications = 0
+    update_fields = {"result_data.job_state": "cancelled"}
+    if client_id is not None:
+        update_fields["result_data.cancelled_by"] = client_id
     # Set the job status to cancelled
     response = mongo.db.jobs.update_one(
         {
@@ -282,7 +287,7 @@ def cancel_job(job_id):
                 "$nin": ["cancelled", "complete", "completed"]
             },
         },
-        {"$set": {"result_data.job_state": "cancelled"}},
+        {"$set": update_fields},
     )
     modifications += response.modified_count
 
@@ -323,7 +328,7 @@ def get_queue_wait_times(queues: list[str] | None = None) -> list[dict]:
 
 
 def get_agents_on_queue(queue: str) -> list[dict]:
-    """Get the agents that are listening on the specified queue."""
+    """Return a list of agents listening on the given queue."""
     agents = mongo.db.agents.find(
         {"queues": {"$in": [queue]}},
         {"_id": 0},
@@ -439,12 +444,57 @@ def check_queue_restricted(queue: str) -> bool:
     return queue_count != 0
 
 
-def get_agent_info(agent: str) -> dict:
-    """Return the information for a specified agent."""
-    agent_data = mongo.db.agents.find_one(
-        {"name": agent}, {"_id": False, "log": False}
-    )
-    return agent_data
+def _active_job_pipeline_stages() -> list[dict]:
+    """Return aggregation stages that join agents with their active job.
+
+    The ``$lookup`` uses only basic localField/foreignField form for broad
+    driver and mongomock compatibility.  A subsequent ``$addFields`` stage
+    projects ``client_id`` from the matched job doc as ``job_submitted_by``
+    (or ``None`` when there is no active job).
+    """
+    return [
+        {
+            "$lookup": {
+                "from": "jobs",
+                "localField": "job_id",
+                "foreignField": "job_id",
+                "as": "_job_docs",
+            }
+        },
+        {
+            "$addFields": {
+                "job_submitted_by": {
+                    "$let": {
+                        "vars": {"job": {"$arrayElemAt": ["$_job_docs", 0]}},
+                        "in": {
+                            "$cond": [
+                                {"$gt": [{"$size": "$_job_docs"}, 0]},
+                                "$$job.submitted_by",
+                                None,
+                            ]
+                        },
+                    }
+                }
+            }
+        },
+        {"$project": {"_job_docs": False}},
+    ]
+
+
+def get_agent_info(agent: str) -> dict | None:
+    """Return the information for a specified agent, with active job attached.
+
+    Uses a single aggregation pipeline to join the agent with its current
+    job document (if any), populating ``job_submitted_by`` from the job's
+    ``submitted_by`` field.
+    """
+    pipeline = [
+        {"$match": {"name": agent}},
+        {"$project": {"_id": False, "log": False}},
+        *_active_job_pipeline_stages(),
+    ]
+    results = list(mongo.db.agents.aggregate(pipeline))
+    return results[0] if results else None
 
 
 def set_agent_job(agent_name: str, job_id: str) -> None:
@@ -502,10 +552,26 @@ def get_restricted_queues_owners() -> dict[str, list[str]]:
     return queue_to_clients
 
 
-def get_agents() -> list[dict]:
-    """Return a list of all agents."""
-    agents = mongo.db.agents.find({}, {"_id": False, "log": False})
-    return list(agents)
+def get_agents(queue: str | None = None) -> list[dict]:
+    """Return a list of agents with active job info attached.
+
+    Uses a single aggregation pipeline to join each agent with its
+    current job document (if any), returning ``job_submitted_by`` as the
+    ``submitted_by`` field from the job document.
+
+    :param queue: If provided, filter agents to those listening on this
+        queue.
+    :returns: List of agent dicts, each with a ``job_submitted_by`` field.
+    """
+    match_stage = (
+        {"$match": {"queues": {"$in": [queue]}}} if queue else {"$match": {}}
+    )
+    pipeline = [
+        match_stage,
+        {"$project": {"_id": False, "log": False}},
+        *_active_job_pipeline_stages(),
+    ]
+    return list(mongo.db.agents.aggregate(pipeline))
 
 
 def add_restricted_queue(queue: str, client_id: str):
@@ -688,8 +754,18 @@ def register_oidc_client(userinfo: dict) -> None:
 def get_job_results(job_id: str):
     """Retrieve results for a specific job id."""
     return mongo.db.jobs.find_one(
-        {"job_id": job_id}, {"result_data": True, "_id": False}
+        {"job_id": job_id},
+        {"result_data": True, "_id": False},
     )
+
+
+def get_job(job_id: str) -> dict | None:
+    """Retrieve the full job document for a specific job id.
+
+    :param job_id: UUID as a string for the job.
+    :returns: The full job document, or None if not found.
+    """
+    return mongo.db.jobs.find_one({"job_id": job_id}, {"_id": False})
 
 
 def add_job_results(job_id: str, json_data: dict):
@@ -772,13 +848,13 @@ def update_agent_provision_log(agent_name, json_data) -> bool:
     timestamp = datetime.now(timezone.utc)
     agent_record["updated_at"] = json_data["timestamp"] = timestamp
 
-    # Look up the client_id from the job so it can be displayed in the
+    # Look up the submitted_by from the job so it can be displayed in the
     # provision history table.
     job = mongo.db.jobs.find_one(
         {"job_id": json_data["job_id"]},
-        {"client_id": 1, "_id": 0},
+        {"submitted_by": 1, "_id": 0},
     )
-    json_data["client_id"] = job.get("client_id") if job else None
+    json_data["submitted_by"] = job.get("submitted_by") if job else None
 
     update_operation = {
         "$set": json_data,

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -466,13 +466,11 @@ def _active_job_pipeline_stages() -> list[dict]:
                 "job_submitted_by": {
                     "$let": {
                         "vars": {"job": {"$arrayElemAt": ["$_job_docs", 0]}},
-                        "in": {
-                            "$cond": [
-                                {"$gt": [{"$size": "$_job_docs"}, 0]},
-                                "$$job.submitted_by",
-                                None,
-                            ]
-                        },
+                        "in": "$$job.submitted_by",
+                    }
+                }
+            }
+        },
                     }
                 }
             }

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -449,7 +449,7 @@ def _active_job_pipeline_stages() -> list[dict]:
 
     The ``$lookup`` uses only basic localField/foreignField form for broad
     driver and mongomock compatibility.  A subsequent ``$addFields`` stage
-    projects ``client_id`` from the matched job doc as ``job_submitted_by``
+    projects ``submitted_by`` from the matched job doc as ``job_submitted_by``
     (or ``None`` when there is no active job).
     """
     return [

--- a/server/src/testflinger/templates/_agents_table.html
+++ b/server/src/testflinger/templates/_agents_table.html
@@ -77,11 +77,11 @@
           </td>
           <td data-heading="Updated At">{{ agent.updated_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
           <td class="u-align--right u-truncate" data-heading="Job ID">
-            {% if agent.job_id %}
-              <a href="{{ url_for('testflinger.job_detail', job_id=agent.job_id) }}">{{ agent.job_id }}</a>
+            {% if agent.job and agent.job.job_id %}
+              <a href="{{ url_for('testflinger.job_detail', job_id=agent.job.job_id) }}">{{ agent.job.job_id }}</a>
             {% endif %}
           </td>
-          <td data-heading="Submitted By">{{ agent.job_submitted_by or "" }}</td>
+          <td data-heading="Submitted By">{{ agent.job.submitted_by if agent.job else "" }}</td>
         </tr>
       {% endfor %}
     {% else %}

--- a/server/src/testflinger/templates/_agents_table.html
+++ b/server/src/testflinger/templates/_agents_table.html
@@ -81,7 +81,7 @@
               <a href="{{ url_for('testflinger.job_detail', job_id=agent.job_id) }}">{{ agent.job_id }}</a>
             {% endif %}
           </td>
-          <td data-heading="Submitted By">{{ agent.active_job.client_id if agent.active_job else "" }}</td>
+          <td data-heading="Submitted By">{{ agent.job_submitted_by or "" }}</td>
         </tr>
       {% endfor %}
     {% else %}

--- a/server/src/testflinger/templates/agent_detail.html
+++ b/server/src/testflinger/templates/agent_detail.html
@@ -123,7 +123,7 @@
             <td>
               <a href="{{ url_for('testflinger.job_detail', job_id=log.job_id) }}">{{ log.job_id }}</a>
             </td>
-            <td>{{ log.client_id or "" }}</td>
+            <td>{{ log.submitted_by or "" }}</td>
             <td class="u-align--right p-table__cell--icon-placeholder">
               <i class="{{ 'p-icon--success' if log.exit_code==0 else 'p-icon--error' }}"></i>{{ log.exit_code }}
             </td>

--- a/server/src/testflinger/templates/agent_detail.html
+++ b/server/src/testflinger/templates/agent_detail.html
@@ -29,11 +29,11 @@
         <th scope="row">Last updated</th>
         <td>{{ agent.updated_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
       </tr>
-      {% if agent.job_id %}
+      {% if agent.job and agent.job.job_id %}
         <tr>
           <th scope="row">Job</th>
           <td>
-            <a href="{{ url_for('testflinger.job_detail', job_id=agent.job_id) }}">{{ agent.job_id }}</a>
+            <a href="{{ url_for('testflinger.job_detail', job_id=agent.job.job_id) }}">{{ agent.job.job_id }}</a>
           </td>
         </tr>
       {% endif %}

--- a/server/src/testflinger/templates/job_detail.html
+++ b/server/src/testflinger/templates/job_detail.html
@@ -42,7 +42,7 @@
       </tr>
       <tr>
         <th scope="row">Submitted By</th>
-        <td>{{ job.client_id or "" }}</td>
+        <td>{{ job.submitted_by or "" }}</td>
       </tr>
     </tbody>
   </table>

--- a/server/src/testflinger/templates/jobs.html
+++ b/server/src/testflinger/templates/jobs.html
@@ -48,7 +48,7 @@
           <td data-heading="Job ID">
             <a href="{{ url_for('testflinger.job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a>
           </td>
-          <td data-heading="Submitted By">{{ job.client_id or "" }}</td>
+          <td data-heading="Submitted By">{{ job.submitted_by or "" }}</td>
           <td data-heading="Queue">
             <a href="{{ url_for('testflinger.queue_detail', queue_name=job.job_data.job_queue) }}">{{ job.job_data.job_queue }}</a>
           </td>

--- a/server/src/testflinger/templates/queue_detail.html
+++ b/server/src/testflinger/templates/queue_detail.html
@@ -43,7 +43,7 @@
           <td data-heading="Job ID">
             <a href="{{ url_for('testflinger.job_detail', job_id=job.job_id) }}">{{ job.job_id }}</a>
           </td>
-          <td data-heading="Submitted By">{{ job.client_id or "" }}</td>
+          <td data-heading="Submitted By">{{ job.submitted_by or "" }}</td>
           <td data-heading="State">{{ job.result_data.job_state }}</td>
           <td data-heading="Created At">{{ job.created_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
         </tr>

--- a/server/src/testflinger/views.py
+++ b/server/src/testflinger/views.py
@@ -166,7 +166,7 @@ def agent_detail(agent_id):
         tzinfo=timezone.utc
     ) + timedelta(days=1)
 
-    agent_info = mongo.db.agents.find_one({"name": agent_id})
+    agent_info = database.get_agent_info(agent_id)
     if not agent_info:
         response = make_response(
             render_template("agent_not_found.html", agent_id=agent_id)

--- a/server/src/testflinger/views.py
+++ b/server/src/testflinger/views.py
@@ -209,26 +209,6 @@ def agent_detail(agent_id):
         stop_datetime=stop_datetime,
     )
 
-    # Enrich provision log entries with the submitted_by from the
-    # corresponding job.
-    job_ids = {
-        entry["job_id"]
-        for entry in agent_info["provision_log"]
-        if entry.get("job_id")
-    }
-    if job_ids:
-        submitted_by_map = {
-            doc["job_id"]: doc.get("submitted_by")
-            for doc in mongo.db.jobs.find(
-                {"job_id": {"$in": list(job_ids)}},
-                {"job_id": 1, "submitted_by": 1, "_id": 0},
-            )
-        }
-        for entry in agent_info["provision_log"]:
-            entry.setdefault(
-                "submitted_by", submitted_by_map.get(entry.get("job_id"))
-            )
-
     if agent_info["provision_log"]:
         agent_info["provision_success_rate"] = int(
             100

--- a/server/src/testflinger/views.py
+++ b/server/src/testflinger/views.py
@@ -34,7 +34,6 @@ from pygments.lexers import BashLexer, YamlLexer
 
 from testflinger import database
 from testflinger.api.schemas import Job
-from testflinger.database import mongo
 from testflinger.logs import MongoLogHandler
 
 views = APIBlueprint("testflinger", __name__, enable_openapi=False)
@@ -186,7 +185,7 @@ def agent_detail(agent_id):
 
     queue_info = []
     for queue_name in agent_info.pop("queues", []):
-        queue_data = mongo.db.queues.find_one({"name": queue_name})
+        queue_data = database.mongo.db.queues.find_one({"name": queue_name})
         if not queue_data:
             # If it's not an advertised queue, create some dummy data
             queue_data = {"description": ""}
@@ -231,7 +230,7 @@ def agent_detail(agent_id):
 @views.route("/jobs")
 def jobs():
     """Jobs view."""
-    jobs_data = mongo.db.jobs.find({}, sort=[("created_at", -1)])
+    jobs_data = database.mongo.db.jobs.find({}, sort=[("created_at", -1)])
     return render_template("jobs.html", jobs=jobs_data)
 
 
@@ -250,7 +249,7 @@ def job_detail(job_id):
         if not any(
             key.endswith(("_output", "_serial")) for key in result_data.keys()
         ):
-            log_handler = MongoLogHandler(mongo)
+            log_handler = MongoLogHandler(database.mongo)
             log_handler.format_logs_as_results(job_id, result_data)
 
     job_data["agent_name"] = job_data.get("result_data", {}).get("agent_id")
@@ -274,13 +273,13 @@ def queues_data():
     """Generate data for the queues view, this makes testing easier."""
     # First, get all the advertised queues with descriptions
     queue_data = list(
-        mongo.db.queues.find(
+        database.mongo.db.queues.find(
             projection={"_id": 0, "name": 1, "description": 1}
         )
     )
 
     # Get all the queues the agents say they are listening to from agent data
-    agent_data = mongo.db.agents.find({}, {"_id": 0, "queues": 1})
+    agent_data = database.mongo.db.agents.find({}, {"_id": 0, "queues": 1})
     agent_queues_set = {
         queue for agent in agent_data for queue in agent.get("queues", [])
     }
@@ -305,13 +304,13 @@ def queues_data():
 @views.route("/queues/<queue_name>")
 def queue_detail(queue_name):
     """Queue detailed view."""
-    queue_data = mongo.db.queues.find_one({"name": queue_name})
+    queue_data = database.mongo.db.queues.find_one({"name": queue_name})
     if not queue_data:
         # If it's not an advertised queue, create some dummy data
         queue_data = {"name": queue_name, "description": "No description"}
 
     # Find all the jobs active jobs in this queue
-    job_data = mongo.db.jobs.find(
+    job_data = database.mongo.db.jobs.find(
         {
             "job_data.job_queue": queue_name,
             "result_data.job_state": {

--- a/server/src/testflinger/views.py
+++ b/server/src/testflinger/views.py
@@ -143,7 +143,7 @@ def home():
 @views.route("/agents")
 def agents():
     """Agents view."""
-    agent_info = attach_active_job(database.get_agents())
+    agent_info = database.get_agents()
     return render_template("agents.html", agents=agent_info)
 
 
@@ -209,7 +209,7 @@ def agent_detail(agent_id):
         stop_datetime=stop_datetime,
     )
 
-    # Enrich provision log entries with the client_id from the
+    # Enrich provision log entries with the submitted_by from the
     # corresponding job.
     job_ids = {
         entry["job_id"]
@@ -217,16 +217,16 @@ def agent_detail(agent_id):
         if entry.get("job_id")
     }
     if job_ids:
-        client_id_map = {
-            doc["job_id"]: doc.get("client_id")
+        submitted_by_map = {
+            doc["job_id"]: doc.get("submitted_by")
             for doc in mongo.db.jobs.find(
                 {"job_id": {"$in": list(job_ids)}},
-                {"job_id": 1, "client_id": 1, "_id": 0},
+                {"job_id": 1, "submitted_by": 1, "_id": 0},
             )
         }
         for entry in agent_info["provision_log"]:
             entry.setdefault(
-                "client_id", client_id_map.get(entry.get("job_id"))
+                "submitted_by", submitted_by_map.get(entry.get("job_id"))
             )
 
     if agent_info["provision_log"]:
@@ -258,7 +258,7 @@ def jobs():
 @views.route("/jobs/<job_id>")
 def job_detail(job_id):
     """Job detail view."""
-    job_data = mongo.db.jobs.find_one({"job_id": job_id})
+    job_data = database.get_job(job_id)
     if not job_data:
         response = make_response(
             render_template("job_not_found.html", job_id=job_id),
@@ -352,8 +352,7 @@ def queue_detail(queue_name):
     for key, value in queue_percentile_data.items():
         queue_percentile_data[key] = seconds_to_hms(value)
 
-    agents_data = database.get_agents_on_queue(queue_name)
-    agents_data = attach_active_job(agents_data)
+    agents_data = database.get_agents(queue=queue_name)
 
     return render_template(
         "queue_detail.html",
@@ -371,32 +370,3 @@ def seconds_to_hms(seconds: float) -> str:
     minutes = (seconds % 3600) // 60
     seconds = seconds % 60
     return f"{hours:02d}h {minutes:02d}m {seconds:02d}s"
-
-
-def attach_active_job(agents):
-    """Attach job_id and client_id from each agent's current job.
-
-    For each agent that has a job_id, look up the corresponding job
-    document and attach its job_id and client_id to the agent dict
-    under ``active_job``.  Agents without a job_id or whose job
-    no longer exists get ``active_job`` set to None.
-
-    :param agents: an iterable of agent dictionaries (e.g. a Mongo
-        cursor or a list).
-    :returns: a list of agent dictionaries with active_job set.
-    """
-    agents = list(agents)
-    job_ids = [agent["job_id"] for agent in agents if agent.get("job_id")]
-    if job_ids:
-        job_data_map = {
-            doc["job_id"]: doc
-            for doc in mongo.db.jobs.find(
-                {"job_id": {"$in": job_ids}},
-                {"job_id": 1, "client_id": 1, "_id": 0},
-            )
-        }
-    else:
-        job_data_map = {}
-    for agent in agents:
-        agent.setdefault("active_job", job_data_map.get(agent.get("job_id")))
-    return agents

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -1105,6 +1105,52 @@ def test_agents_provision_logs_post(mongo_app, agent_auth_header):
     assert agent_data["provision_streak_count"] == 1
 
 
+def test_provision_log_submitted_by_copied_from_job(
+    mongo_app, agent_auth_header, role_clients_factory
+):
+    """Test that submitted_by is copied from the job onto the provision log entry.
+
+    When an agent posts a provision log, the server looks up the job to find
+    who submitted it and stores that on the provision log entry.
+    """
+    app, mongo = mongo_app
+    contributor = role_clients_factory[ServerRoles.CONTRIBUTOR]
+    agent_name = "agent1"
+
+    # Register the agent
+    app.post(
+        f"/v1/agents/data/{agent_name}",
+        json={"state": "waiting", "queues": ["test"], "location": "here"},
+        headers=agent_auth_header,
+    )
+
+    # Submit a job as a known client
+    result = app.post(
+        "/v1/job",
+        json={"job_queue": "test"},
+        headers=contributor["bearer_header"],
+    )
+    assert result.status_code == 200
+    job_id = result.json["job_id"]
+
+    # Confirm submitted_by was stored on the job
+    job = mongo.jobs.find_one({"job_id": job_id})
+    assert job["submitted_by"] == contributor["id"]
+
+    # Agent posts a provision log for that job
+    result = app.post(
+        f"/v1/agents/provision_logs/{agent_name}",
+        json={"job_id": job_id, "exit_code": 0, "detail": "provision_success"},
+        headers=agent_auth_header,
+    )
+    assert result.status_code == 200
+
+    # submitted_by should be copied from the job onto the provision log entry
+    provision_log_records = mongo.provision_logs.find_one({"name": agent_name})
+    entry = provision_log_records["provision_log"][0]
+    assert entry["submitted_by"] == contributor["id"]
+
+
 def test_agents_status_put(mongo_app, agent_auth_header, webhook_fixture):
     """Test api to receive agent status requests."""
     app, _ = mongo_app

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -1108,7 +1108,7 @@ def test_agents_provision_logs_post(mongo_app, agent_auth_header):
 def test_provision_log_submitted_by_copied_from_job(
     mongo_app, agent_auth_header, role_clients_factory
 ):
-    """Test that submitted_by is copied from the job onto the provision log entry.
+    """Test that submitted_by is copied from the job onto the provision log.
 
     When an agent posts a provision log, the server looks up the job to find
     who submitted it and stores that on the provision log entry.

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -735,10 +735,10 @@ def test_resubmit_job_state(mongo_app):
     assert "waiting" == updated_data.get("job_state")
 
 
-def test_job_post_stores_client_id(mongo_app):
-    """Test that submitting a job stores client_id at top level.
+def test_job_post_stores_submitted_by(mongo_app):
+    """Test that submitting a job stores submitted_by at top level.
 
-    When OIDC is not enabled, the client_id can be None (anonymous), but
+    When OIDC is not enabled, submitted_by can be None (anonymous), but
     the key should still be present on the job document.
     """
     app, mongo = mongo_app
@@ -746,12 +746,12 @@ def test_job_post_stores_client_id(mongo_app):
     output = app.post("/v1/job", json=job_data)
     job_id = output.json.get("job_id")
     job = mongo.jobs.find_one({"job_id": job_id})
-    assert "client_id" in job
-    assert job["client_id"] is None
+    assert "submitted_by" in job
+    assert job["submitted_by"] is None
 
 
-def test_job_builder_stores_client_id(testapp):
-    """Test that job_builder stores g.client_id on the job document."""
+def test_job_builder_stores_submitted_by(testapp):
+    """Test that job_builder stores g.client_id as submitted_by on the job."""
     from unittest.mock import patch
 
     data = {"job_queue": "test"}
@@ -763,7 +763,7 @@ def test_job_builder_stores_client_id(testapp):
         mock_g.client_id = "test-client-123"
         mock_g.permissions = {}
         job = v1.job_builder(data)
-    assert job["client_id"] == "test-client-123"
+    assert job["submitted_by"] == "test-client-123"
 
 
 def test_get_nonexistant_job(mongo_app, agent_auth_header):

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -436,7 +436,11 @@ def test_authorized_view_access(oidc_app, endpoint):
     """Test views are available when OIDC is enabled and user authenticated."""
     app, _ = oidc_app
     mongo = mongomock.MongoClient()
-    with app.test_client() as client, patch("testflinger.views.mongo", mongo):
+    with (
+        app.test_client() as client,
+        patch("testflinger.views.mongo", mongo),
+        patch("testflinger.database.mongo", mongo),
+    ):
         with client.session_transaction() as sess:
             sess["user"] = "testuser"
         response = client.get(endpoint)

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -26,10 +26,10 @@ import pytest
 import yaml
 from testflinger_common.enums import LogType, TestPhase
 
+from testflinger.database import get_agents
 from testflinger.views import (
     agent_detail,
     as_yaml,
-    attach_active_job,
     build_job_yaml,
     highlight,
     job_detail,
@@ -227,7 +227,10 @@ def test_job_not_found(testapp):
     a job is not found.
     """
     mongo = mongomock.MongoClient()
-    with patch("testflinger.views.mongo", mongo):
+    with (
+        patch("testflinger.views.mongo", mongo),
+        patch("testflinger.database.mongo", mongo),
+    ):
         with testapp.test_request_context():
             response = job_detail("job1")
 
@@ -277,6 +280,7 @@ def test_job_results_mongo_logs(testapp):
     )
     with (
         patch("testflinger.views.mongo", mongo),
+        patch("testflinger.database.mongo", mongo),
     ):
         with testapp.test_request_context():
             response = job_detail(job_id)
@@ -346,7 +350,10 @@ def test_job_detail_has_copy_button(testapp):
             "result_data": {"job_state": "complete"},
         }
     )
-    with patch("testflinger.views.mongo", mongo):
+    with (
+        patch("testflinger.views.mongo", mongo),
+        patch("testflinger.database.mongo", mongo),
+    ):
         with testapp.test_request_context():
             response = job_detail(job_id)
 
@@ -396,7 +403,10 @@ def test_job_detail_renders_yaml_not_python_repr(testapp):
             "result_data": {"job_state": "complete"},
         }
     )
-    with patch("testflinger.views.mongo", mongo):
+    with (
+        patch("testflinger.views.mongo", mongo),
+        patch("testflinger.database.mongo", mongo),
+    ):
         with testapp.test_request_context():
             response = job_detail(job_id)
 
@@ -441,8 +451,8 @@ def test_home_accessible_without_auth_when_oidc_enabled(oidc_app):
     assert response.status_code == HTTPStatus.OK
 
 
-def test_attach_active_job():
-    """Test that agents are enriched with active_job from their jobs."""
+def test_get_agents_active_job():
+    """Test that get_agents enriches agents with job_submitted_by."""
     mongo = mongomock.MongoClient()
     mongo.db.agents.insert_many(
         [
@@ -453,48 +463,45 @@ def test_attach_active_job():
     )
     mongo.db.jobs.insert_many(
         [
-            {"job_id": "job-1", "client_id": "client-A"},
-            {"job_id": "job-2", "client_id": "client-B"},
+            {"job_id": "job-1", "submitted_by": "client-A"},
+            {"job_id": "job-2", "submitted_by": "client-B"},
         ]
     )
 
-    agents = list(mongo.db.agents.find())
-    with patch("testflinger.views.mongo", mongo):
-        enriched = attach_active_job(agents)
+    with patch("testflinger.database.mongo", mongo):
+        enriched = get_agents()
 
     by_name = {a["name"]: a for a in enriched}
-    assert by_name["agent1"]["active_job"]["client_id"] == "client-A"
-    assert by_name["agent2"]["active_job"]["client_id"] == "client-B"
-    assert by_name["agent3"]["active_job"] is None
+    assert by_name["agent1"]["job_submitted_by"] == "client-A"
+    assert by_name["agent2"]["job_submitted_by"] == "client-B"
+    assert by_name["agent3"].get("job_submitted_by") is None
 
 
-def test_enrich_agents_no_jobs():
-    """Test enrichment when no agents have a job_id."""
+def test_get_agents_no_jobs():
+    """Test get_agents enrichment when no agents have a job_id."""
     mongo = mongomock.MongoClient()
     mongo.db.agents.insert_many([{"name": "agent1"}, {"name": "agent2"}])
 
-    agents = list(mongo.db.agents.find())
-    with patch("testflinger.views.mongo", mongo):
-        enriched = attach_active_job(agents)
+    with patch("testflinger.database.mongo", mongo):
+        enriched = get_agents()
 
     for agent in enriched:
-        assert agent["active_job"] is None
+        assert agent.get("job_submitted_by") is None
 
 
-def test_enrich_agents_job_not_found():
-    """Test enrichment when the job has been deleted."""
+def test_get_agents_job_not_found():
+    """Test get_agents enrichment when the job has been deleted."""
     mongo = mongomock.MongoClient()
     mongo.db.agents.insert_one({"name": "agent1", "job_id": "deleted-job"})
 
-    agents = list(mongo.db.agents.find())
-    with patch("testflinger.views.mongo", mongo):
-        enriched = attach_active_job(agents)
+    with patch("testflinger.database.mongo", mongo):
+        enriched = get_agents()
 
-    assert enriched[0]["active_job"] is None
+    assert enriched[0].get("job_submitted_by") is None
 
 
 def test_agent_detail_provision_log_with_client_id(testapp):
-    """Test that provision log entries are enriched with client_id."""
+    """Test that provision log entries are enriched with submitted_by."""
     mongo = mongomock.MongoClient()
     job_id_1 = str(uuid.uuid4())
     job_id_2 = str(uuid.uuid4())
@@ -506,8 +513,8 @@ def test_agent_detail_provision_log_with_client_id(testapp):
     )
     mongo.db.jobs.insert_many(
         [
-            {"job_id": job_id_1, "client_id": "client-A"},
-            {"job_id": job_id_2, "client_id": "client-B"},
+            {"job_id": job_id_1, "submitted_by": "client-A"},
+            {"job_id": job_id_2, "submitted_by": "client-B"},
         ]
     )
     provision_log = [

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -501,7 +501,7 @@ def test_get_agents_job_not_found():
 
 
 def test_agent_detail_provision_log_with_client_id(testapp):
-    """Test that provision log entries are enriched with submitted_by."""
+    """Test that provision log entries display submitted_by."""
     mongo = mongomock.MongoClient()
     job_id_1 = str(uuid.uuid4())
     job_id_2 = str(uuid.uuid4())
@@ -511,22 +511,18 @@ def test_agent_detail_provision_log_with_client_id(testapp):
             "updated_at": datetime.now(tz=timezone.utc),
         }
     )
-    mongo.db.jobs.insert_many(
-        [
-            {"job_id": job_id_1, "submitted_by": "client-A"},
-            {"job_id": job_id_2, "submitted_by": "client-B"},
-        ]
-    )
     provision_log = [
         {
             "job_id": job_id_1,
             "exit_code": 0,
             "timestamp": datetime.now(tz=timezone.utc),
+            "submitted_by": "client-A",
         },
         {
             "job_id": job_id_2,
             "exit_code": 1,
             "timestamp": datetime.now(tz=timezone.utc),
+            "submitted_by": "client-B",
         },
     ]
 

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -91,10 +91,7 @@ def test_queues():
     )
 
     # Get the data from the function we use to generate the view
-    with (
-        patch("testflinger.views.mongo", mongo),
-        patch("testflinger.database.mongo", mongo),
-    ):
+    with patch("testflinger.database.mongo", mongo):
         data = queues_data()
 
     # Make sure we found all the queues, not just advertised ones
@@ -125,10 +122,7 @@ def test_agent_detail_no_provision_log(testapp):
     mongo.db.agents.insert_one(
         {"name": "agent1", "updated_at": datetime.now(tz=timezone.utc)}
     )
-    with (
-        patch("testflinger.views.mongo", mongo),
-        patch("testflinger.database.mongo", mongo),
-    ):
+    with patch("testflinger.database.mongo", mongo):
         with testapp.test_request_context():
             response = agent_detail("agent1")
 
@@ -142,7 +136,7 @@ def test_agent_not_found(testapp):
     an agent is not found.
     """
     mongo = mongomock.MongoClient()
-    with patch("testflinger.views.mongo", mongo):
+    with patch("testflinger.database.mongo", mongo):
         with testapp.test_request_context():
             response = agent_detail("agent1")
 
@@ -167,10 +161,7 @@ def test_agent_detail_with_restricted_to(testapp):
             "updated_at": datetime.now(tz=timezone.utc),
         }
     )
-    with (
-        patch("testflinger.views.mongo", mongo),
-        patch("testflinger.database.mongo", mongo),
-    ):
+    with patch("testflinger.database.mongo", mongo):
         with testapp.test_request_context():
             response = agent_detail("agent1")
 
@@ -206,10 +197,7 @@ def test_agent_detail_with_non_advertised_queue(testapp):
         ]
     )
 
-    with (
-        patch("testflinger.views.mongo", mongo),
-        patch("testflinger.database.mongo", mongo),
-    ):
+    with patch("testflinger.database.mongo", mongo):
         with testapp.test_request_context():
             response = agent_detail("agent1")
 
@@ -227,10 +215,7 @@ def test_job_not_found(testapp):
     a job is not found.
     """
     mongo = mongomock.MongoClient()
-    with (
-        patch("testflinger.views.mongo", mongo),
-        patch("testflinger.database.mongo", mongo),
-    ):
+    with patch("testflinger.database.mongo", mongo):
         with testapp.test_request_context():
             response = job_detail("job1")
 
@@ -278,10 +263,7 @@ def test_job_results_mongo_logs(testapp):
             },
         ]
     )
-    with (
-        patch("testflinger.views.mongo", mongo),
-        patch("testflinger.database.mongo", mongo),
-    ):
+    with patch("testflinger.database.mongo", mongo):
         with testapp.test_request_context():
             response = job_detail(job_id)
 
@@ -350,10 +332,7 @@ def test_job_detail_has_copy_button(testapp):
             "result_data": {"job_state": "complete"},
         }
     )
-    with (
-        patch("testflinger.views.mongo", mongo),
-        patch("testflinger.database.mongo", mongo),
-    ):
+    with patch("testflinger.database.mongo", mongo):
         with testapp.test_request_context():
             response = job_detail(job_id)
 
@@ -403,10 +382,7 @@ def test_job_detail_renders_yaml_not_python_repr(testapp):
             "result_data": {"job_state": "complete"},
         }
     )
-    with (
-        patch("testflinger.views.mongo", mongo),
-        patch("testflinger.database.mongo", mongo),
-    ):
+    with patch("testflinger.database.mongo", mongo):
         with testapp.test_request_context():
             response = job_detail(job_id)
 
@@ -438,7 +414,6 @@ def test_authorized_view_access(oidc_app, endpoint):
     mongo = mongomock.MongoClient()
     with (
         app.test_client() as client,
-        patch("testflinger.views.mongo", mongo),
         patch("testflinger.database.mongo", mongo),
     ):
         with client.session_transaction() as sess:
@@ -531,7 +506,6 @@ def test_agent_detail_provision_log_with_client_id(testapp):
     ]
 
     with (
-        patch("testflinger.views.mongo", mongo),
         patch("testflinger.database.mongo", mongo),
         patch(
             "testflinger.views.database.get_provision_log",

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -456,7 +456,7 @@ def test_home_accessible_without_auth_when_oidc_enabled(oidc_app):
 
 
 def test_get_agents_active_job():
-    """Test that get_agents enriches agents with job_submitted_by."""
+    """Test that get_agents enriches agents with a nested job object."""
     mongo = mongomock.MongoClient()
     mongo.db.agents.insert_many(
         [
@@ -476,9 +476,9 @@ def test_get_agents_active_job():
         enriched = get_agents()
 
     by_name = {a["name"]: a for a in enriched}
-    assert by_name["agent1"]["job_submitted_by"] == "client-A"
-    assert by_name["agent2"]["job_submitted_by"] == "client-B"
-    assert by_name["agent3"].get("job_submitted_by") is None
+    assert by_name["agent1"]["job"]["submitted_by"] == "client-A"
+    assert by_name["agent2"]["job"]["submitted_by"] == "client-B"
+    assert by_name["agent3"].get("job") is None
 
 
 def test_get_agents_no_jobs():
@@ -490,7 +490,7 @@ def test_get_agents_no_jobs():
         enriched = get_agents()
 
     for agent in enriched:
-        assert agent.get("job_submitted_by") is None
+        assert agent.get("job") is None
 
 
 def test_get_agents_job_not_found():
@@ -501,7 +501,7 @@ def test_get_agents_job_not_found():
     with patch("testflinger.database.mongo", mongo):
         enriched = get_agents()
 
-    assert enriched[0].get("job_submitted_by") is None
+    assert enriched[0].get("job") is None
 
 
 def test_agent_detail_provision_log_with_client_id(testapp):


### PR DESCRIPTION
# Add `submitted_by` and `cancelled_by` to the Testflinger API

## Summary

Exposes job identity fields through the API that were previously only visible in the web interface.

## Changes

### New fields

- **`GET /job/{job_id}`** — returns `submitted_by` (who submitted the job)
- **`GET /result/{job_id}`** — returns `cancelled_by` (who cancelled the job, `null` if not cancelled)
- **`GET /agents/data`** / **`GET /agents/data/{agent_name}`** — returns `job_submitted_by` (who submitted the job the agent is currently running)

### Internal rename

The job document field `client_id` has been renamed to `submitted_by` throughout — in MongoDB documents, templates, and all database queries. This is a clean rename with no migration required as no data exists on main yet.

`client_id` is retained where it refers to authenticated user identity (credentials, permissions, secrets, tokens) — those are unrelated concepts.

### Database

`get_agents` and `get_agent_info` now use a single MongoDB aggregation pipeline (`$lookup`) to join agent documents with their active job in one query, replacing the previous two-query approach.

`cancel_job` now accepts and stores the `client_id` of the cancelling user as `result_data.cancelled_by`.

`get_job` added as a shared function used by both the web views and API, replacing a direct `mongo.db.jobs.find_one` call in `views.py`.

### Docs

`docs/reference/api-roles.rst` updated to add the missing `GET /v1/` entry.