### PR TITLE
Feat/agent restart keep state

### DIFF
--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -108,8 +108,8 @@ class TestflingerAgent:
             self.client, heartbeat_frequency=1
         )
         signal.signal(signal.SIGUSR1, self.restart_signal_handler)
-        self.set_agent_state(AgentState.WAITING)
         self._post_initial_agent_data()
+        self._set_startup_state()
         self.metrics_handler = PrometheusHandler(
             self.client.config.get("metrics_endpoint_port"), self.agent_id
         )
@@ -133,6 +133,27 @@ class TestflingerAgent:
             agent_data["identifier"] = identifier
 
         self.client.post_agent_data(agent_data)
+
+    def _set_startup_state(self) -> None:
+        """Set the agent state on startup.
+
+        If the server already has a known state for this agent (e.g. offline or
+        maintenance), preserve that state rather than overriding it with
+        WAITING.  The RESTART state is treated as a signal to come back online,
+        so it is replaced with WAITING as normal.
+        """
+        server_state, comment = self.get_agent_state()
+
+        if server_state in (AgentState.OFFLINE, AgentState.MAINTENANCE):
+            logger.info(
+                "Agent was previously in state '%s' — preserving that state"
+                " on startup.",
+                server_state,
+            )
+            self.set_agent_state(server_state, comment)
+        else:
+            # RESTART, WAITING, UNKNOWN, or no prior state → come up online.
+            self.set_agent_state(AgentState.WAITING)
 
     def set_agent_state(self, state: str, comment: str = "") -> None:
         """Send the agent state to the server.

--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -149,7 +149,6 @@ class TestflingerAgent:
                 " on startup.",
                 server_state,
             )
-            self.set_agent_state(server_state, comment)
         else:
             # RESTART, WAITING, MAINTENANCE, UNKNOWN, or no prior state come
             # up online. Maintenance lifecycle handling belongs to the

--- a/agent/src/testflinger_agent/agent.py
+++ b/agent/src/testflinger_agent/agent.py
@@ -137,14 +137,13 @@ class TestflingerAgent:
     def _set_startup_state(self) -> None:
         """Set the agent state on startup.
 
-        If the server already has a known state for this agent (e.g. offline or
-        maintenance), preserve that state rather than overriding it with
-        WAITING.  The RESTART state is treated as a signal to come back online,
-        so it is replaced with WAITING as normal.
+        If the server has marked this agent offline, preserve that state rather
+        than overriding it with WAITING. The RESTART state is treated as a
+        signal to come back online, so it is replaced with WAITING as normal.
         """
         server_state, comment = self.get_agent_state()
 
-        if server_state in (AgentState.OFFLINE, AgentState.MAINTENANCE):
+        if server_state == AgentState.OFFLINE:
             logger.info(
                 "Agent was previously in state '%s' — preserving that state"
                 " on startup.",
@@ -152,7 +151,9 @@ class TestflingerAgent:
             )
             self.set_agent_state(server_state, comment)
         else:
-            # RESTART, WAITING, UNKNOWN, or no prior state → come up online.
+            # RESTART, WAITING, MAINTENANCE, UNKNOWN, or no prior state come
+            # up online. Maintenance lifecycle handling belongs to the
+            # maintenance-mode feature.
             self.set_agent_state(AgentState.WAITING)
 
     def set_agent_state(self, state: str, comment: str = "") -> None:

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 
 import prometheus_client
 import pytest
+import requests
 import requests_mock as rmock
 from testflinger_common.enums import AgentState, LogType, TestEvent, TestPhase
 
@@ -1072,3 +1073,139 @@ class TestClient:
 
         # Verify None is returned when check_jobs returns None
         assert result is None
+
+
+class TestStartupState:
+    """Tests for _set_startup_state behaviour on agent initialisation.
+
+    The rule is:
+    - OFFLINE or MAINTENANCE → preserve that state (do not come up online)
+    - Everything else (RESTART, WAITING, UNKNOWN, any stale job-phase state,
+      no state key, empty response, HTTP error / unknown agent) → WAITING
+    """
+
+    AGENT_ID = "test01"
+    SERVER = "127.0.0.1:8000"
+    AGENT_DATA_URL = f"http://{SERVER}/v1/agents/data/{AGENT_ID}"
+
+    @pytest.fixture(autouse=True)
+    def clear_registry(self):
+        collectors = tuple(
+            prometheus_client.REGISTRY._collector_to_names.keys()
+        )
+        for collector in collectors:
+            prometheus_client.REGISTRY.unregister(collector)
+        yield
+
+    @pytest.fixture
+    def base_config(self, tmp_path):
+        return validate(
+            {
+                "agent_id": self.AGENT_ID,
+                "polling_interval": 2,
+                "server_address": self.SERVER,
+                "job_queues": ["test"],
+                "execution_basedir": str(tmp_path / "execution"),
+                "logging_basedir": str(tmp_path / "logs"),
+                "results_basedir": str(tmp_path / "results"),
+            }
+        )
+
+    def _startup_state_posted(self, requests_mock) -> str:
+        """Return the state from the final state-bearing POST on startup."""
+        state_posts = [
+            call.json()["state"]
+            for call in requests_mock.request_history
+            if call.method == "POST"
+            and "/v1/agents/data/" in call.path
+            and "state" in (call.json() or {})
+        ]
+        assert state_posts, (
+            "No state POST found — agent never reported a state"
+        )
+        return state_posts[-1]
+
+    @pytest.fixture(autouse=True)
+    def mock_http(self, requests_mock):
+        """Register catch-alls first so specific URL mocks take priority."""
+        requests_mock.get(rmock.ANY)
+        requests_mock.post(rmock.ANY)
+
+    def _make_agent(self, requests_mock, base_config):
+        """Instantiate the agent; mock infrastructure is already registered."""
+        return _TestflingerAgent(_TestflingerClient(base_config))
+
+    # ------------------------------------------------------------------
+    # States that must be PRESERVED (agent stays non-online)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "preserved_state",
+        [AgentState.OFFLINE, AgentState.MAINTENANCE],
+    )
+    def test_startup_preserves_offline_and_maintenance(
+        self, requests_mock, base_config, preserved_state
+    ):
+        """OFFLINE and MAINTENANCE states set by the server must not be
+        overridden with WAITING when the agent restarts.
+        """
+        requests_mock.get(
+            self.AGENT_DATA_URL,
+            json={"state": preserved_state, "comment": "set by admin"},
+        )
+        self._make_agent(requests_mock, base_config)
+        assert self._startup_state_posted(requests_mock) == preserved_state
+
+    # ------------------------------------------------------------------
+    # States that must result in WAITING (agent comes up online)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "server_state",
+        [
+            AgentState.RESTART,  # explicit restart request → come back online
+            AgentState.WAITING,  # already waiting (e.g. clean shutdown)
+            AgentState.UNKNOWN,  # local-only sentinel, treat as no useful info
+            # stale job-phase states left by a crash
+            "setup",
+            "provision",
+            "test",
+            "allocate",
+            "reserve",
+            "cleanup",
+        ],
+    )
+    def test_startup_comes_up_waiting_for_non_preserved_states(
+        self, requests_mock, base_config, server_state
+    ):
+        """Any state that is not OFFLINE or MAINTENANCE must result in the
+        agent coming up as WAITING.
+        """
+        requests_mock.get(
+            self.AGENT_DATA_URL,
+            json={"state": server_state, "comment": ""},
+        )
+        self._make_agent(requests_mock, base_config)
+        assert self._startup_state_posted(requests_mock) == AgentState.WAITING
+
+    @pytest.mark.parametrize(
+        "mock_kwargs, description",
+        [
+            ({"json": {}}, "empty body"),
+            ({"json": {"comment": "no state key"}}, "no state key"),
+            ({"status_code": HTTPStatus.NOT_FOUND}, "404 unknown agent"),
+            (
+                {"exc": requests.exceptions.ConnectionError("unreachable")},
+                "server unreachable",
+            ),
+        ],
+    )
+    def test_startup_comes_up_waiting_when_server_gives_no_state(
+        self, requests_mock, base_config, mock_kwargs, description
+    ):
+        """When the server cannot supply a meaningful state (new agent, error,
+        empty response), the agent must come up as WAITING.
+        """
+        requests_mock.get(self.AGENT_DATA_URL, **mock_kwargs)
+        self._make_agent(requests_mock, base_config)
+        assert self._startup_state_posted(requests_mock) == AgentState.WAITING

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -1182,16 +1182,28 @@ class TestStartupState:
     def test_startup_preserves_offline(self, requests_mock, base_config):
         """An OFFLINE state set by the server must not be overridden with
         WAITING when the agent restarts.
+
+        The agent preserves OFFLINE by leaving the server-side state alone:
+        it must not POST any state on startup in this case (echoing it back
+        would race with any concurrent admin update to state/comment).
         """
         requests_mock.get(
             self.AGENT_DATA_URL,
             json={"state": AgentState.OFFLINE, "comment": "set by admin"},
         )
         self._make_agent(requests_mock, base_config)
-        assert self._startup_state_posted(requests_mock) == {
-            "state": AgentState.OFFLINE,
-            "comment": "set by admin",
-        }
+
+        state_posts = [
+            call.json()
+            for call in requests_mock.request_history
+            if call.method == "POST"
+            and "/v1/agents/data/" in call.path
+            and "state" in (call.json() or {})
+        ]
+        assert state_posts == [], (
+            "Agent must not POST any state on startup when server state is "
+            f"OFFLINE, but posted: {state_posts}"
+        )
 
     # ------------------------------------------------------------------
     # States that must result in WAITING (agent comes up online)

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -1112,10 +1112,10 @@ class TestStartupState:
             }
         )
 
-    def _startup_state_posted(self, requests_mock) -> str:
-        """Return the state from the final state-bearing POST on startup."""
+    def _startup_state_posted(self, requests_mock) -> dict:
+        """Return the final state-bearing POST body on startup."""
         state_posts = [
-            call.json()["state"]
+            call.json()
             for call in requests_mock.request_history
             if call.method == "POST"
             and "/v1/agents/data/" in call.path
@@ -1188,7 +1188,10 @@ class TestStartupState:
             json={"state": AgentState.OFFLINE, "comment": "set by admin"},
         )
         self._make_agent(requests_mock, base_config)
-        assert self._startup_state_posted(requests_mock) == AgentState.OFFLINE
+        assert self._startup_state_posted(requests_mock) == {
+            "state": AgentState.OFFLINE,
+            "comment": "set by admin",
+        }
 
     # ------------------------------------------------------------------
     # States that must result in WAITING (agent comes up online)
@@ -1223,7 +1226,9 @@ class TestStartupState:
             json={"state": server_state, "comment": ""},
         )
         self._make_agent(requests_mock, base_config)
-        assert self._startup_state_posted(requests_mock) == AgentState.WAITING
+        assert self._startup_state_posted(requests_mock)["state"] == (
+            AgentState.WAITING
+        )
 
     @pytest.mark.parametrize(
         "mock_kwargs, description",
@@ -1245,4 +1250,16 @@ class TestStartupState:
         """
         requests_mock.get(self.AGENT_DATA_URL, **mock_kwargs)
         self._make_agent(requests_mock, base_config)
-        assert self._startup_state_posted(requests_mock) == AgentState.WAITING
+        assert self._startup_state_posted(requests_mock)["state"] == (
+            AgentState.WAITING
+        )
+
+    def test_startup_comes_up_waiting_when_server_response_is_invalid_json(
+        self, requests_mock, base_config
+    ):
+        """An invalid success response has no usable prior state."""
+        requests_mock.get(self.AGENT_DATA_URL, text="not JSON")
+        self._make_agent(requests_mock, base_config)
+        assert self._startup_state_posted(requests_mock)["state"] == (
+            AgentState.WAITING
+        )

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -1079,9 +1079,10 @@ class TestStartupState:
     """Tests for _set_startup_state behaviour on agent initialisation.
 
     The rule is:
-    - OFFLINE or MAINTENANCE → preserve that state (do not come up online)
-    - Everything else (RESTART, WAITING, UNKNOWN, any stale job-phase state,
-      no state key, empty response, HTTP error / unknown agent) → WAITING
+    - OFFLINE → preserve that state (do not come up online)
+    - Everything else (MAINTENANCE, RESTART, WAITING, UNKNOWN, any stale
+      job-phase state, no state key, empty response, HTTP error / unknown
+      agent) → WAITING
     """
 
     AGENT_ID = "test01"
@@ -1178,22 +1179,16 @@ class TestStartupState:
     # States that must be PRESERVED (agent stays non-online)
     # ------------------------------------------------------------------
 
-    @pytest.mark.parametrize(
-        "preserved_state",
-        [AgentState.OFFLINE, AgentState.MAINTENANCE],
-    )
-    def test_startup_preserves_offline_and_maintenance(
-        self, requests_mock, base_config, preserved_state
-    ):
-        """OFFLINE and MAINTENANCE states set by the server must not be
-        overridden with WAITING when the agent restarts.
+    def test_startup_preserves_offline(self, requests_mock, base_config):
+        """An OFFLINE state set by the server must not be overridden with
+        WAITING when the agent restarts.
         """
         requests_mock.get(
             self.AGENT_DATA_URL,
-            json={"state": preserved_state, "comment": "set by admin"},
+            json={"state": AgentState.OFFLINE, "comment": "set by admin"},
         )
         self._make_agent(requests_mock, base_config)
-        assert self._startup_state_posted(requests_mock) == preserved_state
+        assert self._startup_state_posted(requests_mock) == AgentState.OFFLINE
 
     # ------------------------------------------------------------------
     # States that must result in WAITING (agent comes up online)
@@ -1202,6 +1197,9 @@ class TestStartupState:
     @pytest.mark.parametrize(
         "server_state",
         [
+            # Maintenance lifecycle handling belongs to the maintenance-mode
+            # feature, which must preserve it through startup and polling.
+            AgentState.MAINTENANCE,
             AgentState.RESTART,  # explicit restart request → come back online
             AgentState.WAITING,  # already waiting (e.g. clean shutdown)
             AgentState.UNKNOWN,  # local-only sentinel, treat as no useful info

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -1131,6 +1131,45 @@ class TestStartupState:
         requests_mock.get(rmock.ANY)
         requests_mock.post(rmock.ANY)
 
+    def test_no_state_posted_before_server_state_is_read(
+        self, requests_mock, base_config
+    ):
+        """State must not be POSTed to the server before the agent has read
+        the server's current state.  Posting state first could clobber an
+        OFFLINE or MAINTENANCE state that was set by an administrator.
+        """
+        requests_mock.get(
+            self.AGENT_DATA_URL,
+            json={"state": AgentState.OFFLINE, "comment": "set by admin"},
+        )
+        self._make_agent(requests_mock, base_config)
+
+        history = requests_mock.request_history
+        # Index of the first GET that reads the agent's current state
+        first_state_get = next(
+            (
+                i
+                for i, call in enumerate(history)
+                if call.method == "GET" and "/v1/agents/data/" in call.path
+            ),
+            None,
+        )
+        assert first_state_get is not None, (
+            "Agent never read its state from the server on startup"
+        )
+        # Any POST before that GET must not contain a 'state' field
+        premature_state_posts = [
+            call
+            for call in history[:first_state_get]
+            if call.method == "POST"
+            and "/v1/agents/data/" in call.path
+            and "state" in (call.json() or {})
+        ]
+        assert not premature_state_posts, (
+            "Agent POSTed a state to the server before reading the current "
+            f"server state: {[c.json() for c in premature_state_posts]}"
+        )
+
     def _make_agent(self, requests_mock, base_config):
         """Instantiate the agent; mock infrastructure is already registered."""
         return _TestflingerAgent(_TestflingerClient(base_config))


### PR DESCRIPTION
# CERTTF-1444: Preserve agent state on restart

## Problem

When an agent process restarted, it unconditionally posted `waiting` as its
new state during `__init__`. This meant that an agent which had been
deliberately taken `offline` or put into `maintenance` by an admin would
silently come back online after any restart (e.g. a system reboot, a
supervisor restart, or an OOM kill), overriding the admin's intent.

## Solution

Replace the unconditional `set_agent_state(WAITING)` call in
`TestflingerAgent.__init__` with a new `_set_startup_state()` method that
first asks the server what state it believes the agent should be in, then
decides accordingly:

| Server state | Action on startup |
|---|---|
| `offline` | Preserve — re-post `offline` with the existing comment |
| `maintenance` | Preserve — re-post `maintenance` with the existing comment |
| `restart` | Come up online (`waiting`) — this is the explicit restart signal |
| `waiting`, `unknown`, any stale job-phase state | Come up online (`waiting`) |
| No state / empty response / 404 / network error | Come up online (`waiting`) — first start or server unavailable |

The `restart` state is intentionally treated as "come back online": it exists
precisely to signal that the agent should restart and resume normal operation.

`_set_startup_state()` delegates to the existing `get_agent_state()` rather
than calling `get_agent_data()` directly, so the heartbeat handler update and
the `UNKNOWN` fallback logic remain in one place.

## Changes

### `agent/src/testflinger_agent/agent.py`

- `__init__`: removed the unconditional `set_agent_state(WAITING)` call;
  `_post_initial_agent_data()` is now called before state selection so
  metadata is always current; replaced with a call to `_set_startup_state()`.
- `_set_startup_state()`: new method implementing the state-preservation logic
  described above.

### `agent/tests/test_agent.py`

Added `TestStartupState` test class with full parametrized coverage of every
meaningful server response the agent can receive at startup:

- **`test_startup_preserves_offline_and_maintenance`** — parametrized over
  `[OFFLINE, MAINTENANCE]`: confirms the state is re-posted unchanged.
- **`test_startup_comes_up_waiting_for_non_preserved_states`** — parametrized
  over `[RESTART, WAITING, UNKNOWN, setup, provision, test, allocate, reserve,
  cleanup]`: confirms all non-preserved states result in `waiting`.
- **`test_startup_comes_up_waiting_when_server_gives_no_state`** — parametrized
  over `[empty body, no state key, 404, ConnectionError]`: confirms that any
  failure to obtain a meaningful state from the server results in `waiting`
  (covering first-ever agent start and transient server unavailability).