### PR TITLE
feat(server): add backend changes to store job events

### DIFF
--- a/common/src/testflinger_common/enums.py
+++ b/common/src/testflinger_common/enums.py
@@ -178,7 +178,6 @@ class JobEvent(TestflingerEvent):
 
     JOB_SUBMITTED = "job_submitted"
     JOB_ASSIGNED = "job_assigned"
-    JOB_STARTED = "job_started"
     JOB_PHASE_STARTED = "job_phase_started"
     JOB_PHASE_COMPLETED = "job_phase_completed"
     JOB_COMPLETED = "job_completed"

--- a/common/src/testflinger_common/enums.py
+++ b/common/src/testflinger_common/enums.py
@@ -167,3 +167,19 @@ class ServerRoles(StrEnum):
     def __ge__(self, other: "ServerRoles") -> bool:
         """Implement of "greater-than-or-equal" between ServerRoles."""
         return not self < other
+
+
+class TestflingerEvent(StrEnum):
+    """Base class for all Testflinger events."""
+
+
+class JobEvent(TestflingerEvent):
+    """Enum of all Job-related events."""
+
+    JOB_SUBMITTED = "job_submitted"
+    JOB_ASSIGNED = "job_assigned"
+    JOB_STARTED = "job_started"
+    JOB_PHASE_STARTED = "job_phase_started"
+    JOB_PHASE_COMPLETED = "job_phase_completed"
+    JOB_COMPLETED = "job_completed"
+    JOB_CANCELLED = "job_cancelled"

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -28,11 +28,11 @@ from flask import current_app, g, jsonify, request, send_file
 from marshmallow import ValidationError
 from prometheus_client import Counter
 from requests.adapters import HTTPAdapter
-from testflinger_common.enums import LogType, ServerRoles, TestPhase
+from testflinger_common.enums import JobEvent, LogType, ServerRoles, TestPhase
 from urllib3.util.retry import Retry
 from werkzeug.routing import BaseConverter
 
-from testflinger import database
+from testflinger import database, events
 from testflinger.api import auth, helpers, schemas
 from testflinger.api.auth import authenticate, require_role
 from testflinger.logs import LogFragment, MongoLogHandler
@@ -140,6 +140,16 @@ def job_post(json_data: dict) -> dict:
     # CAUTION! If you ever move this line, you may need to pass data as a copy
     # because it will get modified by submit_job and other things it calls
     database.add_job(job)
+
+    database.add_job_event(
+        job_id=job["job_id"],
+        event=events.build_event(
+            event_type=JobEvent.JOB_SUBMITTED,
+            timestamp=datetime.now(timezone.utc),
+            client_id=g.client_id,
+            queue_name=job["job_data"]["job_queue"],
+        ),
+    )
     return jsonify(job_id=job.get("job_id"))
 
 
@@ -261,6 +271,15 @@ def job_get():
     job = database.pop_job(queue_list=queue_list, agent_name=agent_name)
     if not job:
         return jsonify({}), HTTPStatus.NO_CONTENT
+
+    database.add_job_event(
+        job_id=job["job_id"],
+        event=events.build_event(
+            event_type=JobEvent.JOB_ASSIGNED,
+            timestamp=datetime.now(timezone.utc),
+            agent_name=agent_name,
+        ),
+    )
     if (secrets := retrieve_secrets(job)) is not None:
         job["test_data"]["secrets"] = secrets
     database.set_agent_job(agent_name, job["job_id"])
@@ -587,7 +606,14 @@ def result_post(job_id: str, json_data: dict) -> str:
     if content_length and content_length >= 16 * 1024 * 1024:
         abort(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, message="Payload too large")
 
+    # We need to get new events before json_data is mutated by add_job_results
+    previous_results = database.get_job_results(job_id) or {}
+    previous_data = previous_results.get("result_data", {})
+    new_events = events.detect_new_result_events(previous_data, json_data)
+
     database.add_job_results(job_id, json_data)
+    for event in new_events:
+        database.add_job_event(job_id=job_id, event=event)
     return "OK"
 
 
@@ -686,6 +712,16 @@ def _cancel_job(job_id):
             "The job is already completed or cancelled",
             HTTPStatus.BAD_REQUEST,
         )
+
+    # Only add an event if the cancellation is actually made
+    database.add_job_event(
+        job_id=job_id,
+        event=events.build_event(
+            event_type=JobEvent.JOB_CANCELLED,
+            timestamp=datetime.now(timezone.utc),
+            client_id=g.client_id,
+        ),
+    )
     return "OK"
 
 

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -145,7 +145,6 @@ def job_post(json_data: dict) -> dict:
         job_id=job["job_id"],
         event=events.build_event(
             event_type=JobEvent.JOB_SUBMITTED,
-            timestamp=datetime.now(timezone.utc),
             client_id=g.client_id,
             queue_name=job["job_data"]["job_queue"],
         ),
@@ -276,7 +275,6 @@ def job_get():
         job_id=job["job_id"],
         event=events.build_event(
             event_type=JobEvent.JOB_ASSIGNED,
-            timestamp=datetime.now(timezone.utc),
             agent_name=agent_name,
         ),
     )
@@ -607,8 +605,9 @@ def result_post(job_id: str, json_data: dict) -> str:
         abort(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, message="Payload too large")
 
     # We need to get new events before json_data is mutated by add_job_results
-    previous_results = database.get_job_results(job_id) or {}
-    previous_data = previous_results.get("result_data", {})
+    previous_data = (database.get_job_results(job_id) or {}).get(
+        "result_data", {}
+    )
     new_events = events.detect_new_result_events(previous_data, json_data)
 
     database.add_job_results(job_id, json_data)
@@ -718,7 +717,6 @@ def _cancel_job(job_id):
         job_id=job_id,
         event=events.build_event(
             event_type=JobEvent.JOB_CANCELLED,
-            timestamp=datetime.now(timezone.utc),
             client_id=g.client_id,
         ),
     )

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -595,7 +595,7 @@ def result_post(job_id: str, json_data: dict) -> str:
     :param job_id: UUID as a string for the job
     :raises HTTPError: If the job_id is not a valid UUID
     """
-    if not check_valid_uuid(job_id):
+    if not check_valid_uuid(job_id) or not database.job_exists(job_id):
         abort(HTTPStatus.BAD_REQUEST, message="Invalid job_id specified")
 
     # fail if input payload is larger than the BSON size limit
@@ -604,13 +604,11 @@ def result_post(job_id: str, json_data: dict) -> str:
     if content_length and content_length >= 16 * 1024 * 1024:
         abort(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, message="Payload too large")
 
-    # We need to get new events before json_data is mutated by add_job_results
-    previous_data = (database.get_job_results(job_id) or {}).get(
-        "result_data", {}
-    )
+    # update_job_results atomically returns the previous result_data, so
+    # event detection is based on the exact state this update transitioned
+    # from
+    previous_data = database.update_job_results(job_id, json_data)
     new_events = events.detect_new_result_events(previous_data, json_data)
-
-    database.add_job_results(job_id, json_data)
     for event in new_events:
         database.add_job_event(job_id=job_id, event=event)
     return "OK"

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -139,7 +139,7 @@ def create_indexes():
     mongo.db.agents.create_index("name", unique=True)
     mongo.db.client_permissions.create_index("client_id", unique=True)
     mongo.db.client_permissions.create_index("sub", sparse=True)
-    mongo.db.jobs.create_index("job_id")
+    mongo.db.jobs.create_index("job_id", unique=True)
     mongo.db.jobs_events.create_index("job_id", unique=True)
     mongo.db.jobs.create_index(["result_data.job_state", "job_data.job_queue"])
     mongo.db.agents.create_index("queues")

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -128,6 +128,11 @@ def create_indexes():
         partialFilterExpression={"sub": {"$exists": True}},
     )
 
+    # Remove stale job events after defined expiration
+    mongo.db.jobs_events.create_index(
+        "updated_at", expireAfterSeconds=DEFAULT_EXPIRATION
+    )
+
     # Faster lookups for common queries
     mongo.db.refresh_tokens.create_index("refresh_token", unique=True)
     mongo.db.refresh_tokens.create_index("client_id")
@@ -135,6 +140,7 @@ def create_indexes():
     mongo.db.client_permissions.create_index("client_id", unique=True)
     mongo.db.client_permissions.create_index("sub", sparse=True)
     mongo.db.jobs.create_index("job_id")
+    mongo.db.jobs_events.create_index("job_id", unique=True)
     mongo.db.jobs.create_index(["result_data.job_state", "job_data.job_queue"])
     mongo.db.agents.create_index("queues")
 
@@ -1032,3 +1038,24 @@ def update_agent_provision_log(agent_name, json_data) -> bool:
         mongo.db.agents.update_one({"name": agent_name}, {"$set": agent})
         found = True
     return found
+
+
+def add_job_event(job_id: str, event: dict) -> None:
+    """Add an event to the job events collection.
+
+    :param job_id: The ID of the job.
+    :param event: The event data to add.
+    """
+    mongo.db.jobs_events.update_one(
+        {"job_id": job_id},
+        {
+            "$push": {
+                "events": {
+                    "$each": [event],
+                    "$sort": {"timestamp": -1},
+                }
+            },
+            "$set": {"updated_at": datetime.now(timezone.utc)},
+        },
+        upsert=True,
+    )

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from flask_pymongo import PyMongo
 from gridfs import GridFS, errors
+from pymongo import ReturnDocument
 from testflinger_common.enums import ServerRoles
 
 # Constants for TTL indexes
@@ -919,19 +920,38 @@ def get_job_results(job_id: str):
     )
 
 
-def add_job_results(job_id: str, json_data: dict):
-    """Add results to specified job id with "result_data" prepended."""
-    # First, we need to prepend "result_data" to each key in the result_data
-    for key in list(json_data):
-        json_data[f"result_data.{key}"] = json_data.pop(key)
+def update_job_results(job_id: str, json_data: dict) -> dict:
+    """Update results for a job and return the previous `result_data`.
 
-    mongo.db.jobs.update_one({"job_id": job_id}, {"$set": json_data})
+    The previous `result_data` is returned to reliable detect any
+    state transitions this document update introduced.
+
+    :param job_id: The job ID to update results for.
+    :param json_data: The result data to store (not modified).
+    :return: The previous `result_data` dict, or an empty dict
+    """
+    # Prepend "result_data" to each key in the result data
+    set_data = {
+        f"result_data.{key}": value for key, value in json_data.items()
+    }
+
+    # find_one_and_update guarantees atomicity as it locks the document
+    # for the duration of the update. Returning the previous document
+    # allows us to properly detect unique events
+    previous_doc = mongo.db.jobs.find_one_and_update(
+        {"job_id": job_id},
+        {"$set": set_data},
+        projection={"result_data": True, "_id": False},
+        return_document=ReturnDocument.BEFORE,
+    )
 
     # Additionally, because the job_data may reflect that the job is now done,
     # we need to disassociate the agent from the job if the job is done:
     terminal_states = {"complete", "completed", "cancelled"}
-    if json_data.get("result_data.job_state") in terminal_states:
+    if json_data.get("job_state") in terminal_states:
         clear_agent_job(job_id)
+
+    return (previous_doc or {}).get("result_data", {})
 
 
 def job_exists(job_id: str) -> bool:

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -1043,18 +1043,15 @@ def update_agent_provision_log(agent_name, json_data) -> bool:
 def add_job_event(job_id: str, event: dict) -> None:
     """Add an event to the job events collection.
 
+    Events are appended in natural insertion order (oldest first).
+
     :param job_id: The ID of the job.
     :param event: The event data to add.
     """
     mongo.db.jobs_events.update_one(
         {"job_id": job_id},
         {
-            "$push": {
-                "events": {
-                    "$each": [event],
-                    "$sort": {"timestamp": -1},
-                }
-            },
+            "$push": {"events": event},
             "$set": {"updated_at": datetime.now(timezone.utc)},
         },
         upsert=True,

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -139,7 +139,7 @@ def create_indexes():
     mongo.db.agents.create_index("name", unique=True)
     mongo.db.client_permissions.create_index("client_id", unique=True)
     mongo.db.client_permissions.create_index("sub", sparse=True)
-    mongo.db.jobs.create_index("job_id", unique=True)
+    mongo.db.jobs.create_index("job_id")
     mongo.db.jobs_events.create_index("job_id", unique=True)
     mongo.db.jobs.create_index(["result_data.job_state", "job_data.job_queue"])
     mongo.db.agents.create_index("queues")

--- a/server/src/testflinger/events.py
+++ b/server/src/testflinger/events.py
@@ -132,7 +132,6 @@ def _build_job_lifecycle_events(
 
     :param previous_data: The previous results data.
     :param new_data: The new results data.
-    :param timestamp: The timestamp of the event.
     :return: new job lifecycle events or empty list if no new events.
     """
     # Early return if there is no job_state reported yet

--- a/server/src/testflinger/events.py
+++ b/server/src/testflinger/events.py
@@ -1,0 +1,182 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""Event handling functions for Testflinger server."""
+
+from datetime import datetime, timezone
+
+from testflinger_common.enums import (
+    JobEvent,
+    JobState,
+    TestflingerEvent,
+    TestPhase,
+)
+
+_MESSAGE_TEMPLATES = {
+    JobEvent.JOB_SUBMITTED: "Job submitted by user {client_id} for queue {queue_name}.",  # noqa: E501
+    JobEvent.JOB_ASSIGNED: "Job assigned to agent {agent_name}.",
+    JobEvent.JOB_STARTED: "Job started",
+    JobEvent.JOB_PHASE_STARTED: "Phase {phase} started.",
+    JobEvent.JOB_PHASE_COMPLETED: "Phase {phase} completed with exit code {status}",  # noqa: E501
+    JobEvent.JOB_COMPLETED: "Job completed.",
+    JobEvent.JOB_CANCELLED: "Job cancellation requested by user {client_id}.",
+}
+
+
+class _DefaultContext(dict):
+    """Render missing placeholders instead of raising KeyError."""
+
+    def __missing__(self, key):
+        return f"<{key}>"
+
+
+def format_event(event_type: TestflingerEvent, **context) -> str:
+    """Interpolate the event message template with the provided context.
+
+    :param event_type: The type of the event.
+    :param context: Additional context for formatting the message.
+    :return: Formatted event message based on template.
+    """
+    template = _MESSAGE_TEMPLATES[event_type]
+    return template.format_map(_DefaultContext(context))
+
+
+def build_event(
+    event_type: TestflingerEvent,
+    timestamp: datetime,
+    detail: str = "",
+    **context,
+) -> dict:
+    """Build an event dictionary with all relevant information.
+
+    The event uses a formatted event message based on the event type and
+    provided context.
+
+    :param event_type: The type of the event.
+    :param timestamp: The timestamp of the event.
+    :param detail: Additional details for the event.
+    :param context: Additional context for formatting the message.
+    :return: Dictionary representing the event.
+    """
+    message = format_event(event_type, **context)
+    return {
+        "event_name": event_type,
+        "timestamp": timestamp,
+        "message": message,
+        "detail": detail,
+    }
+
+
+def detect_new_result_events(
+    previous_data: dict, new_data: dict
+) -> list[dict]:
+    """Detect job events based on the diff between previous and new results.
+
+    Incoming POST requests can send cumulative results, so we need to determine
+    which events haven't been logged yet.
+
+    :param previous_data: The previous results data.
+    :param new_data: The new results data.
+    :return: List of detected new events.
+    """
+    timestamp = datetime.now(timezone.utc)
+    return [
+        *_build_phase_completed_events(previous_data, new_data, timestamp),
+        *_build_job_lifecycle_events(previous_data, new_data, timestamp),
+    ]
+
+
+def _build_phase_completed_events(
+    previous_data: dict, new_data: dict, timestamp: datetime
+) -> list[dict]:
+    """Get a list of phases events that are already completed.
+
+    This compares the previous and new results data to determine
+    which phases have a new `status` key reported so we can later
+    log an event.
+
+    :param previous_data: The previous results data.
+    :param new_data: The new results data.
+    :param timestamp: The timestamp of the event.
+    :return: new phase completed events or empty list if no new events.
+    """
+    return [
+        build_event(
+            event_type=JobEvent.JOB_PHASE_COMPLETED,
+            timestamp=timestamp,
+            phase=phase,
+            status=status,
+        )
+        for phase, status in new_data.get("status", {}).items()
+        if phase not in previous_data.get("status", {})
+    ]
+
+
+def _build_job_lifecycle_events(
+    previous_data: dict, new_data: dict, timestamp: datetime
+) -> list[dict]:
+    """Get a list of job lifecycle events.
+
+    This compares the previous and new results data to determine
+    which job lifecycle events have changed so we can later log an event.
+
+    A job lifecycle is defined as a change in a job's state.
+
+    :param previous_data: The previous results data.
+    :param new_data: The new results data.
+    :param timestamp: The timestamp of the event.
+    :return: new job lifecycle events or empty list if no new events.
+    """
+    # Early return if there is no job_state reported yet
+    new_job_state = new_data.get("job_state")
+    if not new_job_state:
+        return []
+
+    # Terminal job stated log a completion event
+    if new_job_state in {"completed", "complete"}:
+        return [
+            build_event(
+                event_type=JobEvent.JOB_COMPLETED,
+                timestamp=timestamp,
+            )
+        ]
+
+    # Early return if the job state has not changed
+    previous_job_state = previous_data.get("job_state")
+    if (
+        new_job_state not in {phase.value for phase in TestPhase}
+        or new_job_state == previous_job_state
+    ):
+        return []
+
+    new_events = []
+    # Special handler for the first phase of a job
+    if previous_job_state in (None, JobState.WAITING):
+        new_events.append(
+            build_event(
+                event_type=JobEvent.JOB_STARTED,
+                timestamp=timestamp,
+                phase=new_job_state,
+            )
+        )
+    # Any other phase change should log a phase started event
+    new_events.append(
+        build_event(
+            event_type=JobEvent.JOB_PHASE_STARTED,
+            timestamp=timestamp,
+            phase=new_job_state,
+        )
+    )
+    return new_events

--- a/server/src/testflinger/events.py
+++ b/server/src/testflinger/events.py
@@ -19,7 +19,6 @@ from datetime import datetime, timezone
 
 from testflinger_common.enums import (
     JobEvent,
-    JobState,
     TestflingerEvent,
     TestPhase,
 )
@@ -27,7 +26,6 @@ from testflinger_common.enums import (
 _MESSAGE_TEMPLATES = {
     JobEvent.JOB_SUBMITTED: "Job submitted by user {client_id} into queue {queue_name}.",  # noqa: E501
     JobEvent.JOB_ASSIGNED: "Job assigned to agent {agent_name}.",
-    JobEvent.JOB_STARTED: "Job started",
     JobEvent.JOB_PHASE_STARTED: "Phase {phase} started.",
     JobEvent.JOB_PHASE_COMPLETED: "Phase {phase} completed with exit code {status}",  # noqa: E501
     JobEvent.JOB_COMPLETED: "Job completed.",
@@ -157,20 +155,10 @@ def _build_job_lifecycle_events(
     ):
         return []
 
-    new_events = []
-    # Special handler for the first phase of a job
-    if previous_job_state in (None, JobState.WAITING):
-        new_events.append(
-            build_event(
-                event_type=JobEvent.JOB_STARTED,
-                phase=new_job_state,
-            )
-        )
     # All phase changes should log a phase started event
-    new_events.append(
+    return [
         build_event(
             event_type=JobEvent.JOB_PHASE_STARTED,
             phase=new_job_state,
         )
-    )
-    return new_events
+    ]

--- a/server/src/testflinger/events.py
+++ b/server/src/testflinger/events.py
@@ -25,7 +25,7 @@ from testflinger_common.enums import (
 )
 
 _MESSAGE_TEMPLATES = {
-    JobEvent.JOB_SUBMITTED: "Job submitted by user {client_id} for queue {queue_name}.",  # noqa: E501
+    JobEvent.JOB_SUBMITTED: "Job submitted by user {client_id} into queue {queue_name}.",  # noqa: E501
     JobEvent.JOB_ASSIGNED: "Job assigned to agent {agent_name}.",
     JobEvent.JOB_STARTED: "Job started",
     JobEvent.JOB_PHASE_STARTED: "Phase {phase} started.",
@@ -55,17 +55,16 @@ def format_event(event_type: TestflingerEvent, **context) -> str:
 
 def build_event(
     event_type: TestflingerEvent,
-    timestamp: datetime,
     detail: str = "",
     **context,
 ) -> dict:
     """Build an event dictionary with all relevant information.
 
     The event uses a formatted event message based on the event type and
-    provided context.
+    provided context. The event is recorded with the timestamp of when the
+    event was recorded by the caller.
 
     :param event_type: The type of the event.
-    :param timestamp: The timestamp of the event.
     :param detail: Additional details for the event.
     :param context: Additional context for formatting the message.
     :return: Dictionary representing the event.
@@ -73,7 +72,7 @@ def build_event(
     message = format_event(event_type, **context)
     return {
         "event_name": event_type,
-        "timestamp": timestamp,
+        "timestamp": datetime.now(timezone.utc),
         "message": message,
         "detail": detail,
     }
@@ -91,15 +90,14 @@ def detect_new_result_events(
     :param new_data: The new results data.
     :return: List of detected new events.
     """
-    timestamp = datetime.now(timezone.utc)
     return [
-        *_build_phase_completed_events(previous_data, new_data, timestamp),
-        *_build_job_lifecycle_events(previous_data, new_data, timestamp),
+        *_build_phase_completed_events(previous_data, new_data),
+        *_build_job_lifecycle_events(previous_data, new_data),
     ]
 
 
 def _build_phase_completed_events(
-    previous_data: dict, new_data: dict, timestamp: datetime
+    previous_data: dict, new_data: dict
 ) -> list[dict]:
     """Get a list of phases events that are already completed.
 
@@ -109,13 +107,11 @@ def _build_phase_completed_events(
 
     :param previous_data: The previous results data.
     :param new_data: The new results data.
-    :param timestamp: The timestamp of the event.
     :return: new phase completed events or empty list if no new events.
     """
     return [
         build_event(
             event_type=JobEvent.JOB_PHASE_COMPLETED,
-            timestamp=timestamp,
             phase=phase,
             status=status,
         )
@@ -125,7 +121,7 @@ def _build_phase_completed_events(
 
 
 def _build_job_lifecycle_events(
-    previous_data: dict, new_data: dict, timestamp: datetime
+    previous_data: dict, new_data: dict
 ) -> list[dict]:
     """Get a list of job lifecycle events.
 
@@ -152,11 +148,10 @@ def _build_job_lifecycle_events(
         return [
             build_event(
                 event_type=JobEvent.JOB_COMPLETED,
-                timestamp=timestamp,
             )
         ]
 
-    # Early return if the job state has not changed
+    # Early return if the job state has not changed or is not a known TestPhase
     if (
         new_job_state not in {phase.value for phase in TestPhase}
         or new_job_state == previous_job_state
@@ -169,15 +164,13 @@ def _build_job_lifecycle_events(
         new_events.append(
             build_event(
                 event_type=JobEvent.JOB_STARTED,
-                timestamp=timestamp,
                 phase=new_job_state,
             )
         )
-    # Any other phase change should log a phase started event
+    # All phase changes should log a phase started event
     new_events.append(
         build_event(
             event_type=JobEvent.JOB_PHASE_STARTED,
-            timestamp=timestamp,
             phase=new_job_state,
         )
     )

--- a/server/src/testflinger/events.py
+++ b/server/src/testflinger/events.py
@@ -144,8 +144,11 @@ def _build_job_lifecycle_events(
     if not new_job_state:
         return []
 
-    # Terminal job stated log a completion event
+    previous_job_state = previous_data.get("job_state")
+    # Terminal job state: log a completion event once
     if new_job_state in {"completed", "complete"}:
+        if previous_job_state in {"completed", "complete"}:
+            return []
         return [
             build_event(
                 event_type=JobEvent.JOB_COMPLETED,
@@ -154,7 +157,6 @@ def _build_job_lifecycle_events(
         ]
 
     # Early return if the job state has not changed
-    previous_job_state = previous_data.get("job_state")
     if (
         new_job_state not in {phase.value for phase in TestPhase}
         or new_job_state == previous_job_state

--- a/server/tests/test_database.py
+++ b/server/tests/test_database.py
@@ -144,18 +144,17 @@ def test_add_job_event(mock_mongo):
 
 
 @patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
-def test_new_job_events_sorted_by_timestamp(mock_mongo):
-    """Test new jobs are appended to collection, sorted by desc timestamp."""
+def test_new_job_events_preserve_insertion_order(mock_mongo):
+    """Test new events are appended in insertion (oldest-first) order."""
     job_id = str(uuid4())
-    timestamps = [
-        datetime.datetime(2026, 1, 1, 12, 0, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2026, 1, 1, 12, 5, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2026, 1, 1, 12, 10, tzinfo=datetime.timezone.utc),
-    ]
+    timestamp = datetime.datetime(
+        2026, 1, 1, 12, 0, tzinfo=datetime.timezone.utc
+    )
+    # timestamp is fixed for test simplicity and for validating insertion order
     events = [
-        _make_event("job_submitted", "Job submitted", timestamps[0]),
-        _make_event("job_started", "Job started", timestamps[1]),
-        _make_event("job_completed", "Job completed", timestamps[2]),
+        _make_event("job_submitted", "Job submitted", timestamp),
+        _make_event("job_started", "Job started", timestamp),
+        _make_event("job_completed", "Job completed", timestamp),
     ]
 
     for event in events:
@@ -164,13 +163,9 @@ def test_new_job_events_sorted_by_timestamp(mock_mongo):
     doc = mock_mongo.db.jobs_events.find_one({"job_id": job_id})
     stored_events = doc["events"]
     assert len(stored_events) == 3
-    # We need to sort the expected events by timestamp to match the db ordering
-    expected_events = sorted(
-        events, key=lambda evt: evt["timestamp"], reverse=True
-    )
     # strip tz info before comparison as mongomock stores datetime in naive UTC
     normalized_expected = [
         {**evt, "timestamp": evt["timestamp"].replace(tzinfo=None)}
-        for evt in expected_events
+        for evt in events
     ]
     assert stored_events == normalized_expected

--- a/server/tests/test_database.py
+++ b/server/tests/test_database.py
@@ -112,7 +112,9 @@ def test_create_indexes_gridfs_collections(mock_mongo):
     assert files_ttl.get("expireAfterSeconds") == DEFAULT_EXPIRATION
 
 
-def _make_event(event: str, message: str, timestamp: datetime) -> dict:
+def _make_event(
+    event: str, message: str, timestamp: datetime.datetime
+) -> dict:
     """Build a minimal event dict as produced by events.build_event.
     This is using a string for the event_name instead of the enum for
     test simplicity.

--- a/server/tests/test_database.py
+++ b/server/tests/test_database.py
@@ -15,7 +15,9 @@
 #
 """Unit tests for testflinger database functions."""
 
+import datetime
 from unittest.mock import patch
+from uuid import uuid4
 
 import mongomock
 import pytest
@@ -23,6 +25,7 @@ from mongomock.gridfs import enable_gridfs_integration
 
 from testflinger.database import (
     DEFAULT_EXPIRATION,
+    add_job_event,
     create_indexes,
     retrieve_file,
     save_file,
@@ -107,3 +110,67 @@ def test_create_indexes_gridfs_collections(mock_mongo):
     assert chunks_ttl.get("expireAfterSeconds") == DEFAULT_EXPIRATION
     assert files_ttl is not None
     assert files_ttl.get("expireAfterSeconds") == DEFAULT_EXPIRATION
+
+
+def _make_event(event: str, message: str, timestamp: datetime) -> dict:
+    """Build a minimal event dict as produced by events.build_event.
+    This is using a string for the event_name instead of the enum for
+    test simplicity.
+    """
+    return {
+        "event_name": event,
+        "timestamp": timestamp,
+        "message": message,
+        "detail": "",
+    }
+
+
+@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
+def test_add_job_event(mock_mongo):
+    """Test add_job_event stores the event in the jobs_events collection."""
+    timestamp = datetime.datetime.now(datetime.timezone.utc)
+    event = _make_event("job_submitted", "Job submitted", timestamp)
+    job_id = str(uuid4())
+    add_job_event(job_id=job_id, event=event)
+
+    doc = mock_mongo.db.jobs_events.find_one({"job_id": job_id})
+    assert doc is not None
+    assert len(doc["events"]) == 1
+    stored_data = doc["events"][0]
+    assert stored_data["event_name"] == "job_submitted"
+    assert stored_data["message"] == "Job submitted"
+    # updated_at must be set for the TTL index
+    assert "updated_at" in doc
+
+
+@patch("testflinger.database.mongo", new_callable=mongomock.MongoClient)
+def test_new_job_events_sorted_by_timestamp(mock_mongo):
+    """Test new jobs are appended to collection, sorted by desc timestamp."""
+    job_id = str(uuid4())
+    timestamps = [
+        datetime.datetime(2026, 1, 1, 12, 0, tzinfo=datetime.timezone.utc),
+        datetime.datetime(2026, 1, 1, 12, 5, tzinfo=datetime.timezone.utc),
+        datetime.datetime(2026, 1, 1, 12, 10, tzinfo=datetime.timezone.utc),
+    ]
+    events = [
+        _make_event("job_submitted", "Job submitted", timestamps[0]),
+        _make_event("job_started", "Job started", timestamps[1]),
+        _make_event("job_completed", "Job completed", timestamps[2]),
+    ]
+
+    for event in events:
+        add_job_event(job_id=job_id, event=event)
+
+    doc = mock_mongo.db.jobs_events.find_one({"job_id": job_id})
+    stored_events = doc["events"]
+    assert len(stored_events) == 3
+    # We need to sort the expected events by timestamp to match the db ordering
+    expected_events = sorted(
+        events, key=lambda evt: evt["timestamp"], reverse=True
+    )
+    # strip tz info before comparison as mongomock stores datetime in naive UTC
+    normalized_expected = [
+        {**evt, "timestamp": evt["timestamp"].replace(tzinfo=None)}
+        for evt in expected_events
+    ]
+    assert stored_events == normalized_expected

--- a/server/tests/test_events.py
+++ b/server/tests/test_events.py
@@ -1,0 +1,132 @@
+# Copyright (C) 2026 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""Unit tests for testflinger events functions."""
+
+import pytest
+from testflinger_common.enums import JobEvent, JobState
+
+from testflinger.events import detect_new_result_events
+
+
+def _event_names(events: list[dict]) -> list[str]:
+    """Extract event_name values from a list of event dicts."""
+    return [event["event_name"] for event in events]
+
+
+def test_first_phase_transition_emits_job_started():
+    """Test transitioning from explicit "waiting" state emits JOB_STARTED."""
+    previous_data = {"job_state": JobState.WAITING}
+    new_data = {"job_state": JobState.SETUP}
+
+    events = detect_new_result_events(previous_data, new_data)
+
+    assert set(_event_names(events)) == {
+        JobEvent.JOB_STARTED,
+        JobEvent.JOB_PHASE_STARTED,
+    }
+
+
+def test_subsequent_phase_transition_emits_only_phase_started():
+    """Test a phase-to-phase transition only emits JOB_PHASE_STARTED."""
+    previous_data = {"job_state": JobState.SETUP}
+    new_data = {"job_state": JobState.PROVISION}
+
+    events = detect_new_result_events(previous_data, new_data)
+
+    assert _event_names(events) == [JobEvent.JOB_PHASE_STARTED]
+
+
+def test_same_job_state_emits_no_events():
+    """Test re-posting the same job_state does not emit duplicate events."""
+    previous_data = {"job_state": JobState.PROVISION}
+    new_data = {"job_state": JobState.PROVISION}
+
+    events = detect_new_result_events(previous_data, new_data)
+
+    assert events == []
+
+
+def test_new_status_key_emits_phase_completed():
+    """Test a newly-reported phase status emits JOB_PHASE_COMPLETED."""
+    previous_data = {}
+    new_data = {"status": {JobState.SETUP: 0}}
+
+    events = detect_new_result_events(previous_data, new_data)
+
+    assert len(events) == 1
+    assert events[0]["event_name"] == JobEvent.JOB_PHASE_COMPLETED
+    assert JobState.SETUP.value in events[0]["message"]
+
+
+def test_repeated_status_key_emits_no_duplicate_event():
+    """Test re-posting the same phase status emits no duplicate event."""
+    previous_data = {"status": {JobState.SETUP: 0}}
+    new_data = {"status": {JobState.SETUP: 0}}
+
+    events = detect_new_result_events(previous_data, new_data)
+
+    assert events == []
+
+
+def test_multiple_new_status_keys_emit_multiple_events():
+    """Test multiple new phase statuses in one payload each emit an event."""
+    previous_data = {"status": {}}
+    new_data = {"status": {JobState.SETUP: 0, JobState.PROVISION: 1}}
+
+    events = detect_new_result_events(previous_data, new_data)
+
+    assert len(events) == 2
+    assert all(
+        event["event_name"] == JobEvent.JOB_PHASE_COMPLETED for event in events
+    )
+    messages = [event["message"] for event in events]
+    assert any(JobState.SETUP.value in message for message in messages)
+    assert any(JobState.PROVISION.value in message for message in messages)
+
+
+@pytest.mark.parametrize("terminal_state", (JobState.COMPLETED, "completed"))
+def test_terminal_job_state_completed_emits_job_completed(terminal_state):
+    """Test a terminal job_state emits JOB_COMPLETED."""
+    previous_data = {"job_state": JobState.CLEANUP}
+    new_data = {"job_state": terminal_state}
+
+    events = detect_new_result_events(previous_data, new_data)
+
+    assert _event_names(events) == [JobEvent.JOB_COMPLETED]
+
+
+def test_cancelled_job_state_emits_no_events():
+    """Test job_state "cancelled" emits no events from this function.
+
+    Cancellation events are recorded separately via the job action
+    endpoint, not through result posts.
+    """
+    previous_data = {"job_state": JobState.TEST}
+    new_data = {"job_state": JobState.CANCELLED}
+
+    events = detect_new_result_events(previous_data, new_data)
+
+    assert events == []
+
+
+def test_empty_payload_emits_no_events():
+    """Test a payload with neither job_state nor status emits nothing."""
+    previous_data = {"job_state": JobState.TEST, "status": {JobState.TEST: 0}}
+    new_data = {"device_info": {"foo": "bar"}}
+
+    events = detect_new_result_events(previous_data, new_data)
+
+    assert events == []

--- a/server/tests/test_events.py
+++ b/server/tests/test_events.py
@@ -18,25 +18,12 @@
 import pytest
 from testflinger_common.enums import JobEvent, JobState
 
-from testflinger.events import detect_new_result_events
+from testflinger.events import _MESSAGE_TEMPLATES, detect_new_result_events
 
 
 def _event_names(events: list[dict]) -> list[str]:
     """Extract event_name values from a list of event dicts."""
     return [event["event_name"] for event in events]
-
-
-def test_first_phase_transition_emits_job_started():
-    """Test transitioning from explicit "waiting" state emits JOB_STARTED."""
-    previous_data = {"job_state": JobState.WAITING}
-    new_data = {"job_state": JobState.SETUP}
-
-    events = detect_new_result_events(previous_data, new_data)
-
-    assert set(_event_names(events)) == {
-        JobEvent.JOB_STARTED,
-        JobEvent.JOB_PHASE_STARTED,
-    }
 
 
 def test_subsequent_phase_transition_emits_only_phase_started():
@@ -130,3 +117,9 @@ def test_empty_payload_emits_no_events():
     events = detect_new_result_events(previous_data, new_data)
 
     assert events == []
+
+
+def test_all_job_events_have_template():
+    """Test that all JobEvent values have a corresponding message template."""
+    for event in JobEvent:
+        assert event in _MESSAGE_TEMPLATES, f"Missing template for {event}"

--- a/server/tests/test_events.py
+++ b/server/tests/test_events.py
@@ -26,8 +26,10 @@ def _event_names(events: list[dict]) -> list[str]:
     return [event["event_name"] for event in events]
 
 
-def test_subsequent_phase_transition_emits_only_phase_started():
-    """Test a phase-to-phase transition only emits JOB_PHASE_STARTED."""
+def test_phase_transitions_emits_only_phase_started():
+    """Test a phase transition without results emits only JOB_PHASE_STARTED."""
+    # Only using job_state changes to simulate a phase-to-phase transitions.
+    # Data without any results does not emit JOB_PHASE_COMPLETED events
     previous_data = {"job_state": JobState.SETUP}
     new_data = {"job_state": JobState.PROVISION}
 
@@ -84,11 +86,11 @@ def test_multiple_new_status_keys_emit_multiple_events():
     assert any(JobState.PROVISION.value in message for message in messages)
 
 
-@pytest.mark.parametrize("terminal_state", (JobState.COMPLETED, "completed"))
-def test_terminal_job_state_completed_emits_job_completed(terminal_state):
-    """Test a terminal job_state emits JOB_COMPLETED."""
+@pytest.mark.parametrize("completed_state", (JobState.COMPLETED, "completed"))
+def test_job_state_completed_emits_job_completed(completed_state):
+    """Test a completed job_state emits JOB_COMPLETED event."""
     previous_data = {"job_state": JobState.CLEANUP}
-    new_data = {"job_state": terminal_state}
+    new_data = {"job_state": completed_state}
 
     events = detect_new_result_events(previous_data, new_data)
 

--- a/server/tests/test_results.py
+++ b/server/tests/test_results.py
@@ -287,7 +287,7 @@ def test_result_log_nonexistent_job_returns_empty(mongo_app, log_type):
 @pytest.mark.parametrize("phase", list(TestPhase))
 def test_result_status_single_phase(mongo_app, agent_auth_header, phase):
     """Status endpoint returns the correct exit code for each TestPhase."""
-    app, _ = mongo_app
+    app, mongo = mongo_app
     newjob = app.post("/v1/job", json={"job_queue": "test"})
     job_id = newjob.json.get("job_id")
 
@@ -302,11 +302,16 @@ def test_result_status_single_phase(mongo_app, agent_auth_header, phase):
     assert response.status_code == HTTPStatus.OK
     assert response.json.get(f"{phase}_status") == 0
 
+    # A new status key should emit exactly one JOB_PHASE_COMPLETED event.
+    doc = mongo.jobs_events.find_one({"job_id": job_id})
+    event_names = [event["event_name"] for event in doc["events"]]
+    assert event_names.count("job_phase_completed") == 1
+
 
 @pytest.mark.parametrize("exit_code", [0, 1, 2, 127, 255])
 def test_result_status_exit_codes(mongo_app, agent_auth_header, exit_code):
     """Status endpoint correctly surfaces various phase exit code values."""
-    app, _ = mongo_app
+    app, mongo = mongo_app
     newjob = app.post("/v1/job", json={"job_queue": "test"})
     job_id = newjob.json.get("job_id")
 
@@ -321,13 +326,22 @@ def test_result_status_exit_codes(mongo_app, agent_auth_header, exit_code):
     assert response.status_code == HTTPStatus.OK
     assert response.json.get("test_status") == exit_code
 
+    # The JOB_PHASE_COMPLETED event message should surface the exit code.
+    doc = mongo.jobs_events.find_one({"job_id": job_id})
+    phase_completed = next(
+        event
+        for event in doc["events"]
+        if event["event_name"] == "job_phase_completed"
+    )
+    assert str(exit_code) in phase_completed["message"]
+
 
 @pytest.mark.parametrize("job_state", list(JobState))
 def test_result_status_job_state_values(
     mongo_app, agent_auth_header, job_state
 ):
     """Status endpoint returns the correct job_state for each JobState."""
-    app, _ = mongo_app
+    app, mongo = mongo_app
     newjob = app.post("/v1/job", json={"job_queue": "test"})
     job_id = newjob.json.get("job_id")
 
@@ -342,10 +356,22 @@ def test_result_status_job_state_values(
     assert response.status_code == HTTPStatus.OK
     assert response.json.get("job_state") == job_state
 
+    # Also validate the corresponding lifecycle event(s) were recorded.
+    doc = mongo.jobs_events.find_one({"job_id": job_id})
+    event_names = {event["event_name"] for event in doc["events"]}
+    if job_state in {"complete", "completed"}:
+        assert "job_completed" in event_names
+    elif job_state in {phase.value for phase in TestPhase}:
+        assert {"job_started", "job_phase_started"} <= event_names
+    else:
+        # any other job_state values should not emit any lifecycle events
+        # besides the initial JOB_SUBMITTED event that is always present.
+        assert event_names == {"job_submitted"}
+
 
 def test_result_status_all_phases(mongo_app, agent_auth_header):
     """Status endpoint returns exit codes for all phases when all posted."""
-    app, _ = mongo_app
+    app, mongo = mongo_app
     newjob = app.post("/v1/job", json={"job_queue": "test"})
     job_id = newjob.json.get("job_id")
 
@@ -361,6 +387,12 @@ def test_result_status_all_phases(mongo_app, agent_auth_header):
     assert response.status_code == HTTPStatus.OK
     for idx, phase in enumerate(TestPhase):
         assert response.json.get(f"{phase}_status") == idx
+
+    # Posting all phases in one payload should emit one JOB_PHASE_COMPLETED
+    # event per phase.
+    doc = mongo.jobs_events.find_one({"job_id": job_id})
+    event_names = [event["event_name"] for event in doc["events"]]
+    assert event_names.count("job_phase_completed") == len(TestPhase)
 
 
 # ---------------------------------------------------------------------------
@@ -445,3 +477,77 @@ def test_result_log_contains_no_status_fields(mongo_app, agent_auth_header):
         f"Log endpoint returned unexpected status fields: "
         f"{returned_keys & _STATUS_FIELDS}"
     )
+
+
+def test_result_post_emits_only_start_events_once_per_phase(
+    mongo_app, agent_auth_header
+):
+    """Test the phase started event is emitted only once per phase."""
+    app, mongo = mongo_app
+    newjob = app.post("/v1/job", json={"job_queue": "test"})
+    job_id = newjob.json.get("job_id")
+    result_url = f"/v1/result/{job_id}"
+
+    app.post(
+        result_url,
+        json={"job_state": JobState.PROVISION},
+        headers=agent_auth_header,
+    )
+    app.post(
+        result_url,
+        json={"job_state": JobState.TEST},
+        headers=agent_auth_header,
+    )
+
+    doc = mongo.jobs_events.find_one({"job_id": job_id})
+    event_names = [event["event_name"] for event in doc["events"]]
+    assert event_names.count("job_submitted") == 1
+    assert event_names.count("job_started") == 1
+    assert event_names.count("job_phase_started") == 2
+
+
+def test_result_post_does_not_duplicate_phase_completed_on_retry(
+    mongo_app, agent_auth_header
+):
+    """Test re-posting the same phase status does not duplicate the event."""
+    app, mongo = mongo_app
+    newjob = app.post("/v1/job", json={"job_queue": "test"})
+    job_id = newjob.json.get("job_id")
+    result_url = f"/v1/result/{job_id}"
+
+    app.post(
+        result_url,
+        json={"status": {JobState.PROVISION: 0}},
+        headers=agent_auth_header,
+    )
+    app.post(
+        result_url,
+        json={"status": {JobState.PROVISION: 0}},
+        headers=agent_auth_header,
+    )
+
+    doc = mongo.jobs_events.find_one({"job_id": job_id})
+    event_names = [event["event_name"] for event in doc["events"]]
+    assert event_names.count("job_phase_completed") == 1
+
+
+def test_result_post_no_events_for_device_info_only_payload(
+    mongo_app, agent_auth_header
+):
+    """Test posting device_info without job_state/status emits no events."""
+    app, mongo = mongo_app
+    newjob = app.post("/v1/job", json={"job_queue": "test"})
+    job_id = newjob.json.get("job_id")
+    result_url = f"/v1/result/{job_id}"
+
+    response = app.post(
+        result_url,
+        json={"device_info": {"foo": "bar"}},
+        headers=agent_auth_header,
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    doc = mongo.jobs_events.find_one({"job_id": job_id})
+    # Only the job_submitted event from job creation should be present
+    assert len(doc["events"]) == 1
+    assert doc["events"][0]["event_name"] == "job_submitted"

--- a/server/tests/test_results.py
+++ b/server/tests/test_results.py
@@ -20,7 +20,7 @@ from http import HTTPStatus
 from io import BytesIO
 
 import pytest
-from testflinger_common.enums import JobState, LogType, TestPhase
+from testflinger_common.enums import JobEvent, JobState, LogType, TestPhase
 
 
 def test_result_get_result_not_exists(mongo_app):
@@ -331,7 +331,7 @@ def test_result_status_exit_codes(mongo_app, agent_auth_header, exit_code):
     phase_completed = next(
         event
         for event in doc["events"]
-        if event["event_name"] == "job_phase_completed"
+        if event["event_name"] == JobEvent.JOB_PHASE_COMPLETED
     )
     assert str(exit_code) in phase_completed["message"]
 
@@ -360,13 +360,13 @@ def test_result_status_job_state_values(
     doc = mongo.jobs_events.find_one({"job_id": job_id})
     event_names = {event["event_name"] for event in doc["events"]}
     if job_state in {"complete", "completed"}:
-        assert "job_completed" in event_names
+        assert JobEvent.JOB_COMPLETED in event_names
     elif job_state in {phase.value for phase in TestPhase}:
-        assert {"job_started", "job_phase_started"} <= event_names
+        assert JobEvent.JOB_PHASE_STARTED in event_names
     else:
         # any other job_state values should not emit any lifecycle events
         # besides the initial JOB_SUBMITTED event that is always present.
-        assert event_names == {"job_submitted"}
+        assert event_names == {JobEvent.JOB_SUBMITTED}
 
 
 def test_result_status_all_phases(mongo_app, agent_auth_header):
@@ -392,7 +392,7 @@ def test_result_status_all_phases(mongo_app, agent_auth_header):
     # event per phase.
     doc = mongo.jobs_events.find_one({"job_id": job_id})
     event_names = [event["event_name"] for event in doc["events"]]
-    assert event_names.count("job_phase_completed") == len(TestPhase)
+    assert event_names.count(JobEvent.JOB_PHASE_COMPLETED) == len(TestPhase)
 
 
 # ---------------------------------------------------------------------------
@@ -501,9 +501,8 @@ def test_result_post_emits_only_start_events_once_per_phase(
 
     doc = mongo.jobs_events.find_one({"job_id": job_id})
     event_names = [event["event_name"] for event in doc["events"]]
-    assert event_names.count("job_submitted") == 1
-    assert event_names.count("job_started") == 1
-    assert event_names.count("job_phase_started") == 2
+    assert event_names.count(JobEvent.JOB_SUBMITTED) == 1
+    assert event_names.count(JobEvent.JOB_PHASE_STARTED) == 2
 
 
 def test_result_post_does_not_duplicate_phase_completed_on_retry(
@@ -528,7 +527,7 @@ def test_result_post_does_not_duplicate_phase_completed_on_retry(
 
     doc = mongo.jobs_events.find_one({"job_id": job_id})
     event_names = [event["event_name"] for event in doc["events"]]
-    assert event_names.count("job_phase_completed") == 1
+    assert event_names.count(JobEvent.JOB_PHASE_COMPLETED) == 1
 
 
 def test_result_post_no_events_for_device_info_only_payload(
@@ -550,4 +549,4 @@ def test_result_post_no_events_for_device_info_only_payload(
     doc = mongo.jobs_events.find_one({"job_id": job_id})
     # Only the job_submitted event from job creation should be present
     assert len(doc["events"]) == 1
-    assert doc["events"][0]["event_name"] == "job_submitted"
+    assert doc["events"][0]["event_name"] == JobEvent.JOB_SUBMITTED

--- a/server/tests/test_results.py
+++ b/server/tests/test_results.py
@@ -309,7 +309,10 @@ def test_result_status_single_phase(mongo_app, agent_auth_header, phase):
 
 
 @pytest.mark.parametrize("exit_code", [0, 1, 2, 127, 255])
-def test_result_status_exit_codes(mongo_app, agent_auth_header, exit_code):
+@pytest.mark.parametrize("phase", TestPhase)
+def test_result_status_exit_codes(
+    mongo_app, agent_auth_header, exit_code, phase
+):
     """Status endpoint correctly surfaces various phase exit code values."""
     app, mongo = mongo_app
     newjob = app.post("/v1/job", json={"job_queue": "test"})
@@ -318,13 +321,13 @@ def test_result_status_exit_codes(mongo_app, agent_auth_header, exit_code):
     result_url = f"/v1/result/{job_id}"
     app.post(
         result_url,
-        json={"status": {TestPhase.TEST: exit_code}},
+        json={"status": {phase: exit_code}},
         headers=agent_auth_header,
     )
 
     response = app.get(f"{result_url}/status")
     assert response.status_code == HTTPStatus.OK
-    assert response.json.get("test_status") == exit_code
+    assert response.json.get(f"{phase}_status") == exit_code
 
     # The JOB_PHASE_COMPLETED event message should surface the exit code.
     doc = mongo.jobs_events.find_one({"job_id": job_id})


### PR DESCRIPTION
## Description
This is the foundation PR for adding job events to be retrievable by the API and visible in the UI. 

This adds an `events` module where we can:
1. format an event enum to a user friendly message containing additional context 
2. build an event with an generic return structure (that can also be leveraged by follow-up `AgentEvent`)
3. Detects an incomming POST request to determine which event should be logged

The changes are server side only as it determines the job/phase state based on the POST request received from an agent.
Each event was added in the relevant endpoint where we need to log the job event.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Merging the full stack resolves [CERTTF-1448](https://warthogs.atlassian.net/browse/CERTTF-1448)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
No new endpoint in this PR
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests for the code added in this PR. Follow-up end to end testing is made on subsequent PRs
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[CERTTF-1448]: https://warthogs.atlassian.net/browse/CERTTF-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ