### PR TITLE
feat(server): add an endpoint to retrieve job events

### DIFF
--- a/docs/reference/api-roles-table.txt
+++ b/docs/reference/api-roles-table.txt
@@ -78,6 +78,12 @@
      - :octicon:`check-circle-fill;1em;sd-text-success` :vh:`allowed`
      - :octicon:`check-circle-fill;1em;sd-text-success` :vh:`allowed`
    * - ``GET``
+     - ``/v1/events/job/{job_id}``
+     - :octicon:`check-circle-fill;1em;sd-text-success` :vh:`allowed`
+     - :octicon:`check-circle-fill;1em;sd-text-success` :vh:`allowed`
+     - :octicon:`check-circle-fill;1em;sd-text-success` :vh:`allowed`
+     - :octicon:`check-circle-fill;1em;sd-text-success` :vh:`allowed`
+   * - ``GET``
      - ``/v1/result/{job_id}``
      - :octicon:`check-circle-fill;1em;sd-text-success` :vh:`allowed`
      - :octicon:`check-circle-fill;1em;sd-text-success` :vh:`allowed`

--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -246,6 +246,7 @@
             "type": "string"
           },
           "timestamp": {
+            "format": "date-time",
             "type": "string"
           }
         },

--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -233,6 +233,28 @@
         ],
         "type": "object"
       },
+      "Event": {
+        "additionalProperties": false,
+        "properties": {
+          "detail": {
+            "type": "string"
+          },
+          "event_name": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_name",
+          "timestamp"
+        ],
+        "type": "object"
+      },
       "HTTPError": {
         "properties": {
           "detail": {
@@ -342,6 +364,25 @@
         "required": [
           "event_name",
           "timestamp"
+        ],
+        "type": "object"
+      },
+      "JobEventsOut": {
+        "additionalProperties": false,
+        "properties": {
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            },
+            "type": "array"
+          },
+          "job_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "events",
+          "job_id"
         ],
         "type": "object"
       },
@@ -1471,6 +1512,53 @@
         "x-permission-roles": [
           "admin",
           "manager"
+        ]
+      }
+    },
+    "/v1/events/job/{job_id}": {
+      "get": {
+        "description": ":param job_id: UUID as a string for the job",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobEventsOut"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPError"
+                }
+              }
+            },
+            "description": "Not found"
+          }
+        },
+        "summary": "Get all available events associated with a specific job_id.",
+        "tags": [
+          "V1"
+        ],
+        "x-permission-roles": [
+          "admin",
+          "manager",
+          "contributor",
+          "agent"
         ]
       }
     },

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -780,7 +780,7 @@ class Event(Schema):
     """Event schema."""
 
     event_name = fields.String(required=True)
-    timestamp = fields.String(required=True)
+    timestamp = fields.DateTime(required=True)
     message = fields.String(required=False)
     detail = fields.String(required=False)
 

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -774,3 +774,19 @@ class ImagesIn(Schema):
                         f"Provision data for image '{image_name}' in queue"
                         f" '{queue}' must be a string"
                     )
+
+
+class Event(Schema):
+    """Event schema."""
+
+    event_name = fields.String(required=True)
+    timestamp = fields.String(required=True)
+    message = fields.String(required=False)
+    detail = fields.String(required=False)
+
+
+class JobEventsOut(Schema):
+    """Job Events output schema."""
+
+    job_id = fields.String(required=True)
+    events = fields.List(fields.Nested(Event), required=True)

--- a/server/src/testflinger/api/v1.py
+++ b/server/src/testflinger/api/v1.py
@@ -1605,3 +1605,19 @@ def secrets_delete(client_id, path):
         abort(HTTPStatus.INTERNAL_SERVER_ERROR, message=str(error))
 
     return "OK"
+
+
+@v1.get("/events/job/<job_id>")
+@authenticate
+@require_role(*ServerRoles)
+@v1.output(schemas.JobEventsOut)
+def get_job_events(job_id):
+    """Get all available events associated with a specific job_id.
+
+    :param job_id: UUID as a string for the job
+    """
+    if not check_valid_uuid(job_id) or not database.job_exists(job_id):
+        abort(HTTPStatus.NOT_FOUND, message="Job not found")
+
+    job_events = database.get_job_events(job_id)
+    return jsonify({"job_id": job_id, "events": job_events})

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -1087,4 +1087,4 @@ def get_job_events(job_id: str) -> list[dict]:
     result = mongo.db.jobs_events.find_one(
         {"job_id": job_id}, {"_id": False, "events": True}
     )
-    return result["events"] if result else []
+    return result.get("events", []) if result else []

--- a/server/src/testflinger/database.py
+++ b/server/src/testflinger/database.py
@@ -1076,3 +1076,15 @@ def add_job_event(job_id: str, event: dict) -> None:
         },
         upsert=True,
     )
+
+
+def get_job_events(job_id: str) -> list[dict]:
+    """Retrieve events for a specific job id.
+
+    :param job_id: The ID of the job.
+    :return: List of events for the job, or an empty list if none exist.
+    """
+    result = mongo.db.jobs_events.find_one(
+        {"job_id": job_id}, {"_id": False, "events": True}
+    )
+    return result["events"] if result else []

--- a/server/tests/permissions.json
+++ b/server/tests/permissions.json
@@ -88,5 +88,8 @@
   "/v1/secrets/<client_id>/<path>": {
     "DELETE": ["CONTRIBUTOR", "MANAGER", "ADMIN"],
     "PUT": ["CONTRIBUTOR", "MANAGER", "ADMIN"]
+  },
+  "/v1/events/job/<job_id>": {
+    "GET": ["AGENT", "CONTRIBUTOR", "MANAGER", "ADMIN"]
   }
 }

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -2083,6 +2083,5 @@ def test_get_job_events(mongo_app, agent_auth_header):
     event_names = {event["event_name"] for event in output.json["events"]}
     assert event_names == {
         "job_submitted",
-        "job_started",
         "job_phase_started",
     }

--- a/server/tests/test_v1.py
+++ b/server/tests/test_v1.py
@@ -2055,3 +2055,34 @@ def test_agent_job_id_not_cleared_for_nonterminal_state(
 
     agent_record = mongo.agents.find_one({"name": agent_name})
     assert agent_record.get("job_id") == job_id
+
+
+def test_get_job_events(mongo_app, agent_auth_header):
+    """Test that job events can be retrieved for a given job."""
+    app, _ = mongo_app
+    job_data = {"job_queue": "test"}
+
+    # Submitting a job automatically fires a job_submitted event
+    output = app.post("/v1/job", json=job_data)
+    assert output.status_code == HTTPStatus.OK
+    job_id = output.json.get("job_id")
+
+    # Post a result transitioning the job into its first phase, which fires
+    # job_started and job_phase_started events
+    output = app.post(
+        f"/v1/result/{job_id}",
+        json={"job_state": "setup"},
+        headers=agent_auth_header,
+    )
+    assert output.status_code == HTTPStatus.OK
+
+    output = app.get(f"/v1/events/job/{job_id}")
+    assert output.status_code == HTTPStatus.OK
+    assert output.json["job_id"] == job_id
+
+    event_names = {event["event_name"] for event in output.json["events"]}
+    assert event_names == {
+        "job_submitted",
+        "job_started",
+        "job_phase_started",
+    }


### PR DESCRIPTION
## Description
This PR adds a GET endpoint to retrieve the events for a specified job

Given `/job/<job_id>/events` is already taken by the webhook endpoint and to prevent breaking changes, the proposed endpoint is: `/events/job/<job_id>` which can be understood as `/events/<resource>/<id>` (to be scalable to agent events for example)

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Merging the full stack resolves [CERTTF-1448](https://warthogs.atlassian.net/browse/CERTTF-1448)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
Added new endpoint for GET `/v1/events/job/<job_id>`

Output is handled by a `JobEventOut` schema that returns the `job_id` and the events that are also defined by schema `Event` (to be reused by follow-up `AgentEventOut`)


<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit test for code in this PR.

### Manual test
1. Create an agent role so we can post results
```
testflinger-cli --server http://localhost:5000 admin set client-permissions --testflinger-client-id 'agent' --testflinger-client-secret 'supersecretagentpasswd' --role 'agent'
```

2. Submit job to a test queue:
```
testflinger-cli --server http://localhost:5000 submit ~/Desktop/Testflinger/localhost_tf.yaml 
Job submitted successfully!
job_id: 761b5e30-adef-489f-9ded-be4265679de1
```

3. Define variables:
```
JOB_ID=761b5e30-adef-489f-9ded-be4265679de1
TOKEN=$(curl -s -u "agent:supersecretagentpasswd" -X POST http://localhost:5000/v1/oauth2/token | jq -r '.access_token')
BASE=http://localhost:5000/v1/result/$JOB_ID
```

4. Start the job:
```
curl -X POST $BASE -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"job_state": "setup"}'
```

3. Complete setup with phase:
```
curl -X POST $BASE -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"status": {"setup": 0}}'
```

4. Add more transitions including a test failure:
```
curl -X POST $BASE -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"job_state": "provision"}'

curl -X POST $BASE -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"status": {"setup": 0, "provision": 0}}'

curl -X POST $BASE -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"job_state": "test"}'

curl -X POST $BASE -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"status": {"setup": 0, "provision": 0, "test": 1}}'
```

5. Mark the job as completed:
```
curl -X POST $BASE -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"job_state": "completed"}'
```

6. Finally, get all events:
```
{
  "job_id": "761b5e30-adef-489f-9ded-be4265679de1",
  "events": [
    {
      "event_name": "job_submitted",
      "timestamp": {
        "$date": "2026-09-01T20:40:41.033Z"
      },
      "message": "Job submitted by user testflinger-admin for queue test_queue5.",
      "detail": ""
    },
    {
      "event_name": "job_started",
      "timestamp": {
        "$date": "2026-09-01T20:41:22.794Z"
      },
      "message": "Job started",
      "detail": ""
    },
    {
      "event_name": "job_phase_started",
      "timestamp": {
        "$date": "2026-09-01T20:41:22.794Z"
      },
      "message": "Phase setup started.",
      "detail": ""
    },
    {
      "event_name": "job_phase_completed",
      "timestamp": {
        "$date": "2026-09-01T20:41:51.905Z"
      },
      "message": "Phase setup completed with exit code 0",
      "detail": "",
      "status": 0
    },
    {
      "event_name": "job_phase_started",
      "timestamp": {
        "$date": "2026-09-01T20:41:58.421Z"
      },
      "message": "Phase provision started.",
      "detail": ""
    },
    {
      "event_name": "job_phase_completed",
      "timestamp": {
        "$date": "2026-09-01T20:42:08.284Z"
      },
      "message": "Phase provision completed with exit code 0",
      "detail": "",
      "status": 0
    },
    {
      "event_name": "job_phase_started",
      "timestamp": {
        "$date": "2026-09-01T20:42:12.215Z"
      },
      "message": "Phase test started.",
      "detail": ""
    },
    {
      "event_name": "job_phase_completed",
      "timestamp": {
        "$date": "2026-09-01T20:42:20.822Z"
      },
      "message": "Phase test completed with exit code 1",
      "detail": "",
      "status": 1
    },
    {
      "event_name": "job_completed",
      "timestamp": {
        "$date": "2026-09-01T20:42:28.632Z"
      },
      "message": "Job completed.",
      "detail": ""
    }
  ]
}
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[CERTTF-1448]: https://warthogs.atlassian.net/browse/CERTTF-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ