### PR TITLE
feat(server): add tabular visualization for job events in the UI

### DIFF
--- a/server/schemas/openapi.json
+++ b/server/schemas/openapi.json
@@ -245,6 +245,10 @@
           "message": {
             "type": "string"
           },
+          "status": {
+            "nullable": true,
+            "type": "integer"
+          },
           "timestamp": {
             "format": "date-time",
             "type": "string"

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -783,6 +783,7 @@ class Event(Schema):
     timestamp = fields.DateTime(required=True)
     message = fields.String(required=False)
     detail = fields.String(required=False)
+    status = fields.Integer(required=False, allow_none=True)
 
 
 class JobEventsOut(Schema):

--- a/server/src/testflinger/events.py
+++ b/server/src/testflinger/events.py
@@ -74,7 +74,7 @@ def build_event(
         "message": message,
         "detail": detail,
     }
-    # Preserve the status key in the event if its present in the context
+    # Preserve the status key in the event if it's present in the context
     if "status" in context:
         event["status"] = context["status"]
     return event

--- a/server/src/testflinger/events.py
+++ b/server/src/testflinger/events.py
@@ -68,12 +68,16 @@ def build_event(
     :return: Dictionary representing the event.
     """
     message = format_event(event_type, **context)
-    return {
+    event = {
         "event_name": event_type,
         "timestamp": datetime.now(timezone.utc),
         "message": message,
         "detail": detail,
     }
+    # Preserve the status key in the event if its present in the context
+    if "status" in context:
+        event["status"] = context["status"]
+    return event
 
 
 def detect_new_result_events(

--- a/server/src/testflinger/templates/_job_activity.html
+++ b/server/src/testflinger/templates/_job_activity.html
@@ -1,0 +1,48 @@
+<h2 class="p-muted-heading">Activity</h2>
+<div class="p-tabs">
+  <div class="p-tabs__list" role="tablist" aria-label="Job activity tabs">
+    <div class="p-tabs__item">
+      <button class="p-tabs__link"
+              role="tab"
+              aria-selected="true"
+              aria-controls="events-panel"
+              id="events-tab">Events</button>
+    </div>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="events-panel"
+       aria-labelledby="events-tab">
+    {% if job.events %}
+      <table aria-label="Events table" class="p-table--mobile-card">
+        <thead>
+          <tr>
+            <th style="width: 150pt">Time</th>
+            <th>Event</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for event in job.events %}
+            <tr>
+              <td data-heading="Time">{{ event.timestamp.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+              <td data-heading="Event">
+                {% if event.status is defined and event.status is not none %}
+                  {% if event.status == 0 %}
+                    <i class="p-icon--success" aria-label="Success"></i>
+                  {% else %}
+                    <i class="p-icon--error" aria-label="Error"></i>
+                  {% endif %}
+                {% else %}
+                  <i class="p-icon--information" aria-label="Info"></i>
+                {% endif %}
+                {{ event.message }}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>No events available for this job.</p>
+    {% endif %}
+  </div>
+</div>

--- a/server/src/testflinger/templates/job_detail.html
+++ b/server/src/testflinger/templates/job_detail.html
@@ -175,4 +175,5 @@
       {% endfor %}
     </div>
   {% endif %}
+  {% include "_job_activity.html" %}
 {% endblock content %}

--- a/server/src/testflinger/views.py
+++ b/server/src/testflinger/views.py
@@ -260,6 +260,7 @@ def job_detail(job_id):
 
     job_data["agent_name"] = job_data.get("result_data", {}).get("agent_id")
     job_yaml = build_job_yaml(job_data.get("job_data", {}))
+    job_data["events"] = database.get_job_events(job_id)
     return render_template("job_detail.html", job=job_data, job_yaml=job_yaml)
 
 

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -325,6 +325,7 @@ def test_job_detail_shows_activity_events(testapp):
                     ),
                     "message": "Job started.",
                     "detail": "",
+                    "status": 0,
                 },
                 {
                     "event_name": "job_submitted",
@@ -346,6 +347,8 @@ def test_job_detail_shows_activity_events(testapp):
     assert "Job started." in html
     assert "Job submitted." in html
     assert "2026-01-01 12:00:00" in html
+    assert '<i class="p-icon--success" aria-label="Success"></i>' in html
+    assert '<i class="p-icon--information" aria-label="Info"></i>' in html
 
 
 def test_job_detail_no_events_shows_placeholder(testapp):

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -302,6 +302,72 @@ def test_job_results_mongo_logs(testapp):
     assert "Exit Status:</span> 1" in html
 
 
+def test_job_detail_shows_activity_events(testapp):
+    """Test that job_detail renders stored events in the Activity section."""
+    mongo = mongomock.MongoClient()
+    job_id = str(uuid.uuid4())
+    mongo.db.jobs.insert_one(
+        {
+            "job_id": job_id,
+            "created_at": datetime.now(timezone.utc),
+            "job_data": {"job_queue": "queue1"},
+            "result_data": {"job_state": "complete"},
+        }
+    )
+    mongo.db.jobs_events.insert_one(
+        {
+            "job_id": job_id,
+            "events": [
+                {
+                    "event_name": "job_started",
+                    "timestamp": datetime(
+                        2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc
+                    ),
+                    "message": "Job started.",
+                    "detail": "",
+                },
+                {
+                    "event_name": "job_submitted",
+                    "timestamp": datetime(
+                        2026, 1, 1, 11, 0, 0, tzinfo=timezone.utc
+                    ),
+                    "message": "Job submitted.",
+                    "detail": "",
+                },
+            ],
+        }
+    )
+    with patch("testflinger.database.mongo", mongo):
+        with testapp.test_request_context():
+            response = job_detail(job_id)
+
+    html = str(response)
+    assert "Activity" in html
+    assert "Job started." in html
+    assert "Job submitted." in html
+    assert "2026-01-01 12:00:00" in html
+
+
+def test_job_detail_no_events_shows_placeholder(testapp):
+    """Test that the Activity section shows a placeholder with no events."""
+    mongo = mongomock.MongoClient()
+    job_id = str(uuid.uuid4())
+    mongo.db.jobs.insert_one(
+        {
+            "job_id": job_id,
+            "created_at": datetime.now(timezone.utc),
+            "job_data": {"job_queue": "queue1"},
+            "result_data": {"job_state": "complete"},
+        }
+    )
+    with patch("testflinger.database.mongo", mongo):
+        with testapp.test_request_context():
+            response = job_detail(job_id)
+
+    html = str(response)
+    assert "No events available for this job." in html
+
+
 def test_build_job_yaml():
     """build_job_yaml produces a submittable, ordered job definition."""
     job_data = {

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -319,21 +319,46 @@ def test_job_detail_shows_activity_events(testapp):
             "job_id": job_id,
             "events": [
                 {
-                    "event_name": "job_started",
-                    "timestamp": datetime(
-                        2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc
-                    ),
-                    "message": "Job started.",
-                    "detail": "",
-                    "status": 0,
-                },
-                {
                     "event_name": "job_submitted",
                     "timestamp": datetime(
                         2026, 1, 1, 11, 0, 0, tzinfo=timezone.utc
                     ),
-                    "message": "Job submitted.",
+                    "message": "Job submitted by user bob into queue queue1.",
                     "detail": "",
+                },
+                {
+                    "event_name": "job_phase_started",
+                    "timestamp": datetime(
+                        2026, 1, 1, 11, 15, 0, tzinfo=timezone.utc
+                    ),
+                    "message": "Phase setup started.",
+                    "detail": "",
+                },
+                {
+                    "event_name": "job_phase_completed",
+                    "timestamp": datetime(
+                        2026, 1, 1, 11, 30, 0, tzinfo=timezone.utc
+                    ),
+                    "message": "Phase setup completed with exit code 0",
+                    "detail": "",
+                    "status": 0,
+                },
+                {
+                    "event_name": "job_phase_started",
+                    "timestamp": datetime(
+                        2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc
+                    ),
+                    "message": "Phase provision started.",
+                    "detail": "",
+                },
+                {
+                    "event_name": "job_phase_completed",
+                    "timestamp": datetime(
+                        2026, 1, 1, 12, 30, 0, tzinfo=timezone.utc
+                    ),
+                    "message": "Phase provision completed with exit code 1",
+                    "detail": "",
+                    "status": 1,
                 },
             ],
         }
@@ -344,10 +369,13 @@ def test_job_detail_shows_activity_events(testapp):
 
     html = str(response)
     assert "Activity" in html
-    assert "Job started." in html
-    assert "Job submitted." in html
+    assert "Phase setup started." in html
+    assert "Phase setup completed with exit code 0" in html
+    assert "Phase provision started." in html
+    assert "Phase provision completed with exit code 1" in html
     assert "2026-01-01 12:00:00" in html
     assert '<i class="p-icon--success" aria-label="Success"></i>' in html
+    assert '<i class="p-icon--error" aria-label="Error"></i>' in html
     assert '<i class="p-icon--information" aria-label="Info"></i>' in html
 
 


### PR DESCRIPTION
## Description
This PR adds the job events into the job_detail view.

This:
1. Get all available events or a generic message in case none available
2. Adds all available events by the time of page load
3. Also add icons in case the `status` is available for an event, otherwise, use an information icon

I added the section as an "Activity" as I wanted to keep it generic and have this same section for the agent detail page which can contain events + agent logs in future PRs
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Merging the full stack resolves [CERTTF-1448](https://warthogs.atlassian.net/browse/CERTTF-1448)
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
N/A
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Added unit tests for view pages. Additionally, tested locally:
<img width="1752" height="738" alt="Screenshot from 2026-09-01 15-32-03" src="https://github.com/user-attachments/assets/b9988c68-7077-4838-87ed-b016bcc9a47e" />


<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[CERTTF-1448]: https://warthogs.atlassian.net/browse/CERTTF-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ