### PR TITLE
refactor(ci): use GH self-repository syntax

### DIFF
--- a/.github/actions/queue-status/action.yaml
+++ b/.github/actions/queue-status/action.yaml
@@ -39,26 +39,10 @@ outputs:
 runs:
   using: composite
   steps:
-    # Use testflinger-setup by copying action from adjacent directory.
-    # This is required so we can use the same reference as the one
-    # checked out by external workflow or action.
-    - name: Stage testflinger-setup from adjacent action directory
-      shell: bash
-      env:
-        ACTION_PATH: ${{ github.action_path }}
-      run: |
-        mkdir -p _tmp_testflinger-actions/.github/actions
-        cp -r "$ACTION_PATH/../testflinger-setup" \
-              _tmp_testflinger-actions/.github/actions/testflinger-setup
-
     - name: Setup Testflinger
-      uses: ./_tmp_testflinger-actions/.github/actions/testflinger-setup
+      uses: $/.github/actions/testflinger-setup
       with:
         server: ${{ inputs.server }}
-
-    - name: Cleanup temporary checkout
-      shell: bash
-      run: rm -rf ./_tmp_testflinger-actions
 
     - name: Query testflinger-cli queue-status ${{ inputs.queue }}
       id: queue-status

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -38,27 +38,10 @@ outputs:
 runs:
   using: composite
   steps:
-
-    # Use testflinger-setup by copying action from adjacent directory.
-    # This is required so we can use the same reference as the one
-    # checked out by external workflow or action.
-    - name: Stage testflinger-setup from adjacent action directory
-      shell: bash
-      env:
-        ACTION_PATH: ${{ github.action_path }}
-      run: |
-        mkdir -p _tmp_testflinger-actions/.github/actions
-        cp -r "$ACTION_PATH/../testflinger-setup" \
-              _tmp_testflinger-actions/.github/actions/testflinger-setup
-
     - name: Setup Testflinger
-      uses: ./_tmp_testflinger-actions/.github/actions/testflinger-setup
+      uses: $/.github/actions/testflinger-setup
       with:
         server: ${{ inputs.server }}
-
-    - name: Cleanup temporary checkout
-      shell: bash
-      run: rm -rf ./_tmp_testflinger-actions
 
     - name: Create job file, if required
       id: create-job-file


### PR DESCRIPTION
## Description
This removes the need for a workaround where a tmp directory was created to preserve the testflinger-setup available in caller SHA . 
This now uses GH [self-repository syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) which is the recommended mechanism by Zizmor. This requires GH runner `v2.336.0` which is the latest available for Canonical self-hosted runners. GH-hosted runners are using a later version (`v2.337.0`) so this change is compatible with all the runners we support. 

With this change, the tesflinger-setup will automatically use the same SHA as the composite action were its used e.g. submit and queue-status
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
N/A - QOL
<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Public documentation is in the repository in the docs/ folder.
  - If there impacts on Canonical processes the relevant documentation should be update outside the repository, confirm that this has happened.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Web service API changes
N/A
<!--
- Are there new endpoints introduced? Please detail for each of them...
  - The rationale for introducing it
  - The interface
    - the HTTP verb
    - the URL structure
    - Versioning
      - Is it expected to be long time stable? It should be versioned (e.g. `.../v2/...`)
      - ... or it expected to evolve, perhaps expected to be a system internal need or something we are expecting to iterate on still? It should be marked unstable (e.g. `.../unstable/...`)
    - the possible request body
    - the response bodies and status code(s) for success and possible failure case(s)
  - Authorization
    - What credentials are required to access the resource?
    - What automated test scenarios are included for authorization failures?
- Are there changed database queries? (... which could cause performance regressions)
- Are there required configuration changes?
- Are there DB migrations included?
- ... or other things you'd like to be aware of at deploy time?
-->

## Tests
Tested on this run: https://github.com/canonical/tf-submit-action-test/actions/runs/34252599955/job/102155528193

This run is targeting this repo branch `fix/use-gh-syntax` which can be clearly identified from the logs as the one used by both the `testflinger-setup` and submit actions. 

Submit action [log](https://github.com/canonical/tf-submit-action-test/actions/runs/34252599955/job/102155528193#step:4:1):
```
Run canonical/testflinger/.github/actions/submit@fix/use-gh-syntax <- Testflinger branch
  with:
    job-path: .github/test_staging.yaml
    poll: true
    server: testflinger.staging.canonical.com
    client-id: ***
    secret-key: ***
    dry-run: false
```

testflinger-setup action [log](https://github.com/canonical/tf-submit-action-test/actions/runs/34252599955/job/102155528193#step:4:10):
```
Run canonical/testflinger/.github/actions/testflinger-setup@fix/use-gh-syntax <- same Testflinger branch
    with:
      server: testflinger.staging.canonical.com
```


<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
-->
