### PR TITLE
feat(testflinger_agent): add recovery mechanism

### DIFF
--- a/agent/src/testflinger_agent/job.py
+++ b/agent/src/testflinger_agent/job.py
@@ -146,6 +146,10 @@ class TestflingerJob:
             output_timeout_checker = OutputTimeoutChecker(
                 self.get_output_timeout()
             )
+            runner.output_timeout_checker = output_timeout_checker
+            runner.output_timeout = self.get_output_timeout()
+            runner.recovery_enabled = self.get_recovery_enabled()
+            runner.recovery_timeout = self.get_recovery_timeout()
             runner.register_stop_condition_checker(output_timeout_checker)
             runner.subscribe_event(
                 RunnerEvents.OUTPUT_RECEIVED, output_timeout_checker.update
@@ -296,6 +300,26 @@ class TestflingerJob:
         return min(
             self.job_data.get("output_timeout", default_timeout),
             self.client.config.get("output_timeout", default_timeout),
+        )
+
+    def get_recovery_enabled(self):
+        """Get if the recovery mode on output timeout is enabled."""
+        return self.job_data.get(
+            "recovery_enabled",
+            self.client.config.get("recovery_enabled", ""),
+        )
+
+    def get_recovery_timeout(self):
+        """Get the recovery timeout for the recovery command in seconds."""
+        default_timeout = 5 * 60
+
+        # Don't exceed the maximum grace period configured for the device!
+        return min(
+            self.job_data.get(
+                "recovery_timeout",
+                default_timeout,
+            ),
+            self.client.config.get("recovery_timeout", default_timeout),
         )
 
     def banner(self, line):

--- a/agent/src/testflinger_agent/runner.py
+++ b/agent/src/testflinger_agent/runner.py
@@ -56,6 +56,11 @@ class CommandRunner:
         self.cwd = cwd
         self.env = os.environ.copy()
         self.events = defaultdict(list)
+        self.output_timeout = None
+        self.recovery_enabled = False
+        self.recovery_timeout = 5 * 60
+        self.recovery_command = self.env.get("REBOOT_SCRIPT", "")
+        self.under_recovery_period = False
         if env:
             self.env.update(
                 {k: str(v) for k, v in env.items() if isinstance(v, str)}
@@ -91,10 +96,16 @@ class CommandRunner:
                 return event, detail
         return None, ""
 
+    def reset_recover(self):
+        if self.under_recovery_period:
+            self.under_recovery_period = False
+            self.output_timeout_checker.reset(self.output_timeout)
+
     def check_and_post_output(self):
         raw_output = self.process.stdout.read()
         if not raw_output:
             return
+        self.reset_recover()
         self.post_event(RunnerEvents.OUTPUT_RECEIVED)
 
         output = raw_output.decode(sys.stdout.encoding, errors="replace")
@@ -119,6 +130,28 @@ class CommandRunner:
         if self.process is not None:
             self.process.kill()
 
+    def try_recover(self, stop_event: TestEvent):
+        if stop_event != TestEvent.OUTPUT_TIMEOUT:
+            return False
+        if not self.recovery_enabled or not self.recovery_command:
+            return False
+        if self.under_recovery_period:
+            return False
+
+        self.post_output(
+            f"\nRunning recovery command: {self.recovery_command}\n"
+        )
+        subprocess.run(
+            self.recovery_command,
+            cwd=self.cwd,
+            env=self.env,
+            shell=True,
+            check=False,
+        )
+        self.under_recovery_period = True
+        self.output_timeout_checker.reset(self.recovery_timeout)
+        return True
+
     def run(self, cmd: str) -> Tuple[int, Optional[TestEvent], str]:
         # Ensure that the process is None before starting
         self.process = None
@@ -142,6 +175,8 @@ class CommandRunner:
             stop_event, stop_reason = self.check_stop_conditions()
             if stop_event is not None:
                 self.post_output(f"\n{stop_reason}\n")
+                if self.try_recover(stop_event):
+                    continue
                 self.cleanup()
                 break
 

--- a/agent/src/testflinger_agent/schema.py
+++ b/agent/src/testflinger_agent/schema.py
@@ -43,6 +43,8 @@ SCHEMA_V1 = {
     voluptuous.Optional("provision_type"): str,
     voluptuous.Optional("global_timeout"): int,
     voluptuous.Optional("output_timeout"): int,
+    voluptuous.Optional("recovery_enabled", default=False): bool,
+    voluptuous.Optional("recovery_timeout", default=5 * 60): int,
     voluptuous.Optional("advertised_queues"): dict,
     voluptuous.Optional("advertised_images"): dict,
     # only the last `output_bytes` of the log will be included

--- a/agent/src/testflinger_agent/stop_condition_checkers.py
+++ b/agent/src/testflinger_agent/stop_condition_checkers.py
@@ -64,3 +64,9 @@ class OutputTimeoutChecker:
     def update(self):
         """Update the last output time to the current time."""
         self.last_output_time = time.time()
+
+    def reset(self, timeout: Optional[int] = None):
+        """Reset the timeout window, optionally changing the timeout."""
+        if timeout is not None:
+            self.timeout = timeout
+        self.last_output_time = time.time()

--- a/server/src/testflinger/api/schemas.py
+++ b/server/src/testflinger/api/schemas.py
@@ -402,6 +402,8 @@ class Job(Schema):
     job_queue = fields.String(required=True, validate=Length(min=1))
     global_timeout = fields.Integer(required=False)
     output_timeout = fields.Integer(required=False)
+    recovery_enabled = fields.Boolean(required=False)
+    recovery_timeout = fields.Integer(required=False)
     allocation_timeout = fields.Integer(required=False)
     provision_data = fields.Nested(
         ProvisionData, required=False, allow_none=True


### PR DESCRIPTION
## Description

Add a configuration option (`recovery_enabled`) that makes it runs the `$REBOOT_SCRIPT` command on output timeout. When that command is run, it enters recovery mode for `recovery_timeout` (default: 5 min). If a new output is detected before the timeout, returns to normal execution, otherwise it exits.

This should allow to recover and mark as crashed a checkbox test that crashes/stucks a DUT.

## Resolved issues

<!--
- Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
- Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

I will do the documentation if this mechanism has a chance to be merged.

## Tests

I did not test it yet as I'm not sure how to be able to test it.
